### PR TITLE
Fix sqlite build error

### DIFF
--- a/Library/Formula/sqlite.rb
+++ b/Library/Formula/sqlite.rb
@@ -34,6 +34,11 @@ class Sqlite < Formula
     ENV.append 'CPPFLAGS', "-DSQLITE_ENABLE_COLUMN_METADATA"
     ENV.append 'CPPFLAGS', "-DSQLITE_ENABLE_STAT3"
 
+    # prevent 'undefined symbol _OSAtomicCompareAndSwapPtrBarrier' error
+    if MacOS.version == :tiger
+      ENV.append 'CPPFLAGS', "-DSQLITE_WITHOUT_ZONEMALLOC"
+    end
+
     ENV.universal_binary if build.universal?
 
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking", "--enable-dynamic-extensions"


### PR DESCRIPTION
My build for sqlite was failing at the linking stage, with PPC Tiger.

```
$ brew install python
==> Installing python dependency: sqlite
==> Downloading http://sqlite.org/sqlite-autoconf-3071500.tar.gz
Already downloaded: /Library/Caches/Homebrew/sqlite-3.7.15.tar.gz
==> ./configure --prefix=/usr/local/Cellar/sqlite/3.7.15 --enable-dynamic-extens
==> make install
/usr/bin/gcc-4.2 -dynamiclib  -o .libs/libsqlite3.0.8.6.dylib  .libs/sqlite3.o  -L/usr/local/opt/readline/lib -L/usr/local/lib -L/usr/X11R6/lib  -mcpu=7450 -mtune=7450 -mmacosx-version-min=10.4 -install_name  /usr/local/Cellar/sqlite/3.7.15/lib/libsqlite3.0.dylib -compatibility_version 9 -current_version 9.6
/usr/bin/ld: Undefined symbols:
_OSAtomicCompareAndSwapPtrBarrier
collect2: ld returned 1 exit status
make: *** [libsqlite3.la] Error 1

READ THIS: https://github.com/mistydemeo/tigerbrew/wiki/troubleshooting

```

I found that MacPorts had this same problem, and fixed it with a patch and a configuration option. The patch has since been merged upstream, so I just added the configuration option to the formula, and now it builds.

MacPorts ticket: https://trac.macports.org/ticket/32930
Patch: https://trac.macports.org/changeset/89249
Discussion: http://comments.gmane.org/gmane.comp.db.sqlite.general/71258
Success:

```
==> Installing python dependency: sqlite
==> Downloading http://sqlite.org/sqlite-autoconf-3071500.tar.gz
Already downloaded: /Library/Caches/Homebrew/sqlite-3.7.15.tar.gz
==> ./configure --prefix=/usr/local/Cellar/sqlite/3.7.15 --enable-dynamic-extens
==> make install
/usr/local/Cellar/sqlite/3.7.15: 9 files, 2.0M, built in 14.2 minutes
```
