### PR TITLE
add APR dependencies for subversion and serf

### DIFF
--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -1,0 +1,20 @@
+require 'formula'
+
+class AprUtil < Formula
+  homepage 'http://apr.apache.org/'
+  url 'http://archive.apache.org/dist/apr/apr-util-1.4.1.tar.bz2'
+  sha1 '229a1df48822e3048ae90e2467a5c078474e99a6'
+
+  depends_on 'apr'
+
+  def install
+    # Compilation will not complete without deparallelize
+    ENV.deparallelize
+
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}",
+                          "--with-apr=#{Formula.factory('apr').prefix}"
+    system "make install"
+  end
+
+end

--- a/Library/Formula/apr.rb
+++ b/Library/Formula/apr.rb
@@ -1,0 +1,17 @@
+require 'formula'
+
+class Apr < Formula
+  homepage 'http://apr.apache.org/'
+  url 'http://archive.apache.org/dist/apr/apr-1.4.6.tar.bz2'
+  sha1 '1a72fc9d89a378590ef243399396169426d1f6cf'
+
+  def install
+    # Compilation will not complete without deparallelize
+    ENV.deparallelize
+
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}"
+    system "make install"
+  end
+
+end

--- a/Library/Formula/serf.rb
+++ b/Library/Formula/serf.rb
@@ -8,17 +8,15 @@ class Serf < Formula
   option :universal
 
   depends_on :libtool
-
-  def apr_bin
-    superbin or "/usr/bin"
-  end
+  depends_on 'apr'
+  depends_on 'apr-util'
 
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-apr=#{apr_bin}"
+                          "--with-apr=#{HOMEBREW_PREFIX}"
     system "make install"
   end
 end

--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -111,10 +111,6 @@ class Subversion < Formula
     cause "core.c:1: error: bad value (native) for -march= switch"
   end if build_perl? or build_python? or build_ruby?
 
-  def apr_bin
-    superbin or "/usr/bin"
-  end
-
   def install
     # We had weird issues with "make" apparently hanging on first run: https://github.com/mxcl/homebrew/issues/13226
     ENV.deparallelize
@@ -138,7 +134,7 @@ class Subversion < Formula
     # Don't mess with Apache modules (since we're not sudo)
     args = ["--disable-debug",
             "--prefix=#{prefix}",
-            "--with-apr=#{apr_bin}",
+            "--with-apr=#{HOMEBREW_PREFIX}",
             "--with-ssl",
             "--with-zlib=/usr",
             "--with-sqlite=#{Formula.factory('sqlite').opt_prefix}",


### PR DESCRIPTION
Tiger doesn't appear to include apr, so subversion wouldn't build. This adds apr.rb and apr-util.rb from https://github.com/alanthing/homebrew-dupes (is there a way to pull from there then push here while maintaining history? I am a git noob) with keg-only removed, and fixes subversion and serf to build with them.
