### PR TITLE
Fix conditional in Object#instance_variable_defined?

### DIFF
--- a/Library/Homebrew/extend/tiger.rb
+++ b/Library/Homebrew/extend/tiger.rb
@@ -3,7 +3,7 @@
 
 class Object
   def instance_variable_defined?(ivar)
-    if !ivar.to_s =~ /^@/
+    if ivar.to_s !~ /^@/
       raise NameError, "`#{ivar}' is not allowed as an instance variable name"
     end
 


### PR DESCRIPTION
Also, this method is defined on Kernel (at least on 1.8.7+):

```
irb 1.8.7 > Object.instance_method(:instance_variable_defined?).owner
=> Kernel
```

Probably not an issue in practice though.
