### PR TITLE
appswitch: Decrement version to get PPC support.

### DIFF
--- a/Library/Formula/appswitch.rb
+++ b/Library/Formula/appswitch.rb
@@ -2,8 +2,11 @@ require 'formula'
 
 class Appswitch < Formula
   homepage 'http://web.sabi.net/nriley/software/'
-  url 'http://web.sabi.net/nriley/software/appswitch-1.1.1.tar.gz'
-  sha1 'df5535adadfcf219c60d28397b99627ae7be3148'
+  url 'http://web.sabi.net/nriley/software/appswitch-1.1.tar.gz'
+  sha1 'e62b142927386c905a70e00d3647cfcd1d06955b'
+
+  # This isn't the latest version of appswitch, but it is the latest
+  # version that will work on PPC with Tiger/Leopard.
 
   def install
     # Because the tarball always comes with a precompiled binary and because


### PR DESCRIPTION
The appswitch formula installs a binary that is Intel-only (and possibly >=10.6 only).  By going back a version, we can acquire PPC support for both Tiger and Leopard.

As far as I can see, there is no loss of functionality in doing so; Other than the dropping of PPC support (and Leopard support period at the same time), the only thing that's changed since v1.1 is a reworded man page.
