### PR TITLE
libgcrypt: Delete PPC-specific patch for 1.6.2

### DIFF
--- a/Library/Formula/libgcrypt.rb
+++ b/Library/Formula/libgcrypt.rb
@@ -23,10 +23,6 @@ class Libgcrypt < Formula
     sha1 "136f636673b5c9d040f8a55f59b430b0f1c97d7a"
   end if build.universal?
 
-  # Otherwise PPC darwin will attempt to build x86-only code and blow up
-  # Reported upstream: https://bugs.g10code.com/gnupg/issue1616
-  def patches; DATA; end
-
   def install
     ENV.universal_binary if build.universal?
 
@@ -46,22 +42,3 @@ class Libgcrypt < Formula
     system "make", "install"
   end
 end
-
-__END__
-diff --git a/mpi/config.links b/mpi/config.links
-index 0217d35..f5bfea3 100644
---- a/mpi/config.links
-+++ b/mpi/config.links
-@@ -44,7 +44,11 @@ echo '/* created by config.links - do not edit */' >./mpi/asm-syntax.h
- echo "/* Host: ${host} */" >>./mpi/asm-syntax.h
-
- case "${host}" in
--    powerpc-apple-darwin*          | \
-+    powerpc-apple-darwin*)
-+       echo '/* No working assembler modules available */' >>./mpi/asm-syntax.h
-+       path=""
-+       mpi_cpu_arch="ppc"
-+       ;;
-     i[34567]86*-*-openbsd[12]*     | \
-     i[34567]86*-*-openbsd3.[0123]*)
-        echo '/* No working assembler modules available */' >>./mpi/asm-syntax.h


### PR DESCRIPTION
Version 1.6.2 fixes the issue that required the patch.
