### PR TITLE
Fix youtube-dl-2014.12.17.2 which now requires Python 2.7 or above.

### DIFF
--- a/Library/Formula/youtube-dl.rb
+++ b/Library/Formula/youtube-dl.rb
@@ -20,6 +20,7 @@ class YoutubeDl < Formula
     depends_on "pandoc" => :build
   end
 
+  depends_on :python if MacOS.version <= :snow_leopard
   depends_on "rtmpdump" => :optional
 
   def install

--- a/Library/Formula/youtube-dl.rb
+++ b/Library/Formula/youtube-dl.rb
@@ -20,7 +20,7 @@ class YoutubeDl < Formula
     depends_on "pandoc" => :build
   end
 
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on :python if MacOS.version <= :leopard
   depends_on "rtmpdump" => :optional
 
   def install


### PR DESCRIPTION
This is only available on OS X > Snow Leopard.  This updates the formula to use the brew based python for systems <= snow_leopard.

Before this change, I would receive this error:

```bash
brew update && brew upgrade
Already up-to-date.
==> Upgrading 1 outdated package, with result:
youtube-dl 2014.12.17.2
==> Upgrading youtube-dl
==> Downloading https://yt-dl.org/downloads/2014.12.17.2/youtube-dl-2014.12.17.2.tar.gz
Already downloaded: /Library/Caches/Homebrew/youtube-dl-2014.12.17.2.tar.gz
==> make PREFIX=/usr/local/Cellar/youtube-dl/2014.12.17.2
  File "devscripts/make_contributing.py", line 17
    with io.open(infile, encoding='utf-8') as inf:
          ^
SyntaxError: invalid syntax
make: *** [CONTRIBUTING.md] Error 1

READ THIS: https://github.com/mistydemeo/tigerbrew/wiki/troubleshooting

Error: Failed to connect to: https://api.github.com/search/issues?q=youtube-dl+repo:mistydemeo/tigerbrew+in:title+state:open&per_page=100
SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed
```
but now it builds without a problem.  `with` was added in Python 2.7.