### PR TITLE
Add dependency on `make` package.

### DIFF
--- a/Library/Formula/chicken.rb
+++ b/Library/Formula/chicken.rb
@@ -15,6 +15,8 @@ class Chicken < Formula
     sha1 "e2a9863f311099590265704fe410f39de802c600" => :lion
   end
 
+  depends_on 'homebrew/dupes/make' => :build
+
   def install
     ENV.deparallelize
 


### PR DESCRIPTION
This is needed in Tigerbrew because Chicken no longer builds with the system make 3.81.

What I would *really* like is to be able to dep on `make`, then use the Cellar'd make binaries without requiring `brew link`. This would allow the brew to work handsfree and not require an otherwise unnecessary change to environment. But I don't know if that's possible.