### PR TITLE
Removal of erroneous lines in ffmpeg Formula.

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -120,12 +120,9 @@ class Ffmpeg < Formula
     args << "--enable-libx265" if build.with? "x265"
     args << "--enable-libwebp" if build.with? "webp"
     args << "--enable-libzmq" if build.with? "zeromq"
-<<<<<<< HEAD
     args << "--disable-indev=qtkit" if build.without?("qtkit") || MacOS.version < :snow_leopard
-=======
     args << "--enable-libbs2b" if build.with? "libbs2b"
     args << "--disable-indev=qtkit" if build.without? "qtkit"
->>>>>>> Homebrew/master
 
     if build.with? "openjpeg"
       args << "--enable-libopenjpeg"


### PR DESCRIPTION
Lines 123, 125, and 128 in the original formula appear to be erroneously merged in. This patch removes those lines, as `brew outdated` will not function with them present.