### PR TITLE
Update D-Bus Formula

### DIFF
--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -2,8 +2,9 @@ class DBus < Formula
   # releases: even (1.10.x) = stable, odd (1.11.x) = development
   desc "Message bus system, providing inter-application communication"
   homepage "https://wiki.freedesktop.org/www/Software/dbus"
-
-  stable do
+  head "git://anongit.freedesktop.org/dbus/dbus.git"
+ 
+ stable do
     url "http://dbus.freedesktop.org/releases/dbus/dbus-1.10.0.tar.gz"
     mirror "https://mirrors.kernel.org/debian/pool/main/d/dbus/dbus_1.10.0.orig.tar.gz"
     sha256 "1dfb9745fb992f1ccd43c920490de8caddf6726a6222e8b803be6098293f924b"
@@ -16,9 +17,16 @@ class DBus < Formula
     sha256 "8f571788a6bd6209e27b4e4cbdd4e1d2179b7f3bbdb35262c3159ff28336b76a" => :mountain_lion
   end
 
-  patch do
-    url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx-old.diff"
-    sha256 "da17af8e014d942d6e916a406ad7c901eebe6c3c7780318069db29e6c1e9ca67"
+  if MacOS.version >= :leopard
+    patch do
+      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx.diff"
+      sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
+    end
+  else
+    patch do
+      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx-old.diff"
+      sha256 "da17af8e014d942d6e916a406ad7c901eebe6c3c7780318069db29e6c1e9ca67"
+    end
   end
 
   def install
@@ -38,8 +46,6 @@ class DBus < Formula
     system "make"
     ENV.deparallelize
     system "make", "install"
-
-    (prefix+"org.freedesktop.dbus-session.plist").chmod 0644
   end
 
   def post_install

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -16,6 +16,11 @@ class DBus < Formula
     sha256 "8f571788a6bd6209e27b4e4cbdd4e1d2179b7f3bbdb35262c3159ff28336b76a" => :mountain_lion
   end
 
+  patch do
+    url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx-old.diff"
+    sha256 "da17af8e014d942d6e916a406ad7c901eebe6c3c7780318069db29e6c1e9ca67"
+  end
+
   def install
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"

--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -2,29 +2,25 @@ class DBus < Formula
   # releases: even (1.10.x) = stable, odd (1.11.x) = development
   desc "Message bus system, providing inter-application communication"
   homepage "https://wiki.freedesktop.org/www/Software/dbus"
-  head "git://anongit.freedesktop.org/dbus/dbus.git"
- 
- stable do
-    url "http://dbus.freedesktop.org/releases/dbus/dbus-1.10.0.tar.gz"
-    mirror "https://mirrors.kernel.org/debian/pool/main/d/dbus/dbus_1.10.0.orig.tar.gz"
-    sha256 "1dfb9745fb992f1ccd43c920490de8caddf6726a6222e8b803be6098293f924b"
-  end
+  url "https://dbus.freedesktop.org/releases/dbus/dbus-1.10.6.tar.gz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dbus/dbus_1.10.6.orig.tar.gz"
+  sha256 "b5fefa08a77edd76cd64d872db949eebc02cf6f3f8be82e4bbc641742af5d35f"
+  head "https://anongit.freedesktop.org/git/dbus/dbus.git"
 
   bottle do
-    sha256 "68500e3670555c2bf5eaeae7541111f9052e92c4a7b28410a0ded25fd7cac544" => :el_capitan
-    sha256 "5a49bcf55334b90e3cd6725b7cc6f0383bcf0160ca7a8d12611107ac7f6a022a" => :yosemite
-    sha256 "a2b9e6c8e84a6e199dcd22d748b3c617285a1eba4ec0b042fa16e9171e96bd91" => :mavericks
-    sha256 "8f571788a6bd6209e27b4e4cbdd4e1d2179b7f3bbdb35262c3159ff28336b76a" => :mountain_lion
-  end
+    sha256 "edf31f467954d3ead8d32fe9db3ef406211fa03eba81b2ab9cad842359a76829" => :el_capitan
+    sha256 "e1818ef166c0d49071bd687e83ec51367052bb8846888a482cac823a991aa092" => :yosemite
+    sha256 "08094b506bf81ce24aa9c38d9414b43726b35d19461440ecfc74d47d02298d50" => :mavericks
+  end 
 
   if MacOS.version >= :leopard
     patch do
-      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx.diff"
+      url "https://raw.githubusercontent.com/Homebrew/patches/0a8a55872e/d-bus/org.freedesktop.dbus-session.plist.osx.diff"
       sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
     end
   else
     patch do
-      url "https://raw.githubusercontent.com/zbentley/dbus-osx-examples/master/homebrew-patches/org.freedesktop.dbus-session.plist.osx-old.diff"
+      url "https://raw.githubusercontent.com/Homebrew/patches/0a8a55872e/d-bus/org.freedesktop.dbus-session.plist.osx-old.diff"
       sha256 "da17af8e014d942d6e916a406ad7c901eebe6c3c7780318069db29e6c1e9ca67"
     end
   end


### PR DESCRIPTION
The D-Bus formula can be updated:
- A new version can be pulled from homebrew/homebrew. It builds on OSX 10.5 (or it did for me, at least). 
- Bottle URLs can be updated for new OSXes on the new version.
- Patch URLs from my previous patch can be updated since they are now hosted on the main patch repo (see homebrew/patches#15). 
- The git master URL can be updated to use HTTPS (see discussion on homebrew/homebrew#50219)

This formula could theoretically be used everywhere, but the mainline maintainers wanted to avoid accumulating legacy-OSX support cruft, so pre-snow-leopard installs can remain supported here.
