### PR TITLE
zsh: update version

### DIFF
--- a/Library/Formula/zsh.rb
+++ b/Library/Formula/zsh.rb
@@ -1,9 +1,10 @@
 class Zsh < Formula
   desc "UNIX shell (command interpreter)"
   homepage "http://www.zsh.org/"
-  url "https://downloads.sourceforge.net/project/zsh/zsh/5.1.1/zsh-5.1.1.tar.gz"
-  mirror "http://www.zsh.org/pub/zsh-5.1.1.tar.gz"
-  sha256 "94ed5b412023761bc8d2f03c173f13d625e06e5d6f0dff2c7a6e140c3fa55087"
+  url "https://downloads.sourceforge.net/project/zsh/zsh/5.2/zsh-5.2.tar.gz"
+  mirror "http://www.zsh.org/pub/zsh-5.2.tar.gz"
+  sha256 "fa924c534c6633c219dcffdcd7da9399dabfb63347f88ce6ddcd5bb441215937"
+
 
   bottle do
     sha256 "079cc9661532edf75b4602fffcf900d3d23a1f143f35ca3cce93a37c0fbc6ae8" => :el_capitan


### PR DESCRIPTION
I updated zsh's version from 5.1.1 to 5.2 mostly because the 5.1.1 version isn't available in those locations anymore (moved to the old versions folder) and because 5.2 is newer. I have tested this (including building + actually using zsh built).
