### PR TITLE
cairo: Fix building Cairo w/ X11 on Tiger

### DIFF
--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -10,7 +10,7 @@ class Cairo < Formula
   option :universal
 
   depends_on "pkg-config" => :build
-  depends_on :x11 => :recommended if MacOS.version == :leopard
+  depends_on :x11 => :recommended if MacOS.version <= :leopard
   depends_on :x11 => :optional if MacOS.version > :leopard
   depends_on "freetype"
   depends_on "fontconfig"
@@ -40,7 +40,9 @@ class Cairo < Formula
     ]
 
     if build.with? "x11"
-      args << "--enable-xcb=yes" << "--enable-xlib=yes" << "--enable-xlib-xrender=yes"
+      # Tiger's X11 does not include XCB
+      args << "--enable-xcb=yes" if MacOS.version > :tiger
+      args << "--enable-xlib=yes" << "--enable-xlib-xrender=yes"
     else
       args << "--enable-xcb=no" << "--enable-xlib=no" << "--enable-xlib-xrender=no"
     end

--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -41,7 +41,7 @@ class Cairo < Formula
 
     if build.with? "x11"
       # Tiger's X11 does not include XCB
-      args << "--enable-xcb=yes" if MacOS.version > :tiger
+      args << "--enable-xcb=yes" if MacOS.version > :leopard
       args << "--enable-xlib=yes" << "--enable-xlib-xrender=yes"
     else
       args << "--enable-xcb=no" << "--enable-xlib=no" << "--enable-xlib-xrender=no"

--- a/Library/Formula/cairo.rb
+++ b/Library/Formula/cairo.rb
@@ -8,10 +8,9 @@ class Cairo < Formula
   keg_only :provided_pre_mountain_lion
 
   option :universal
-  # Tiger's X11 is simply way too old
-  option 'without-x', 'Build without X11 support' if MacOS.version > :tiger
 
   depends_on "pkg-config" => :build
+  depends_on :x11 => :recommended if MacOS.version == :leopard
   depends_on :x11 => :optional if MacOS.version > :leopard
   depends_on "freetype"
   depends_on "fontconfig"


### PR DESCRIPTION
Tiger ships with an old X11 that does not include the XCB (X protocol
C-language Binding), but the Xlib backend builds just fine.

The build failure at https://gist.github.com/anonymous/5695285 is
caused by a defect in the cairo build system that has been fixed
upstream.

Fixes #69.