### PR TITLE
Fix building GCC on 10.4 Intel

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -71,6 +71,13 @@ class Gcc < Formula
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
   patch :DATA
 
+  # Fix build with make 3.80
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66947
+  patch do
+    url "https://gist.githubusercontent.com/mistydemeo/f5508247c1171edcbddcd95671137bdb/raw/249976f5b22ace26f2373f6fad12c0a1c0e22df4/libgcc-fix-make380.patch"
+    sha256 "fc5b45bb2771a6b35b0283412a50d7cb13ae982ed5607b27232a976a48078134"
+  end
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"

--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -78,6 +78,13 @@ class Gcc < Formula
     sha256 "fc5b45bb2771a6b35b0283412a50d7cb13ae982ed5607b27232a976a48078134"
   end
 
+  # Fix an Intel-only build failure on 10.4
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64184
+  patch do
+    url "https://gist.githubusercontent.com/anonymous/c0eff2ff4bfbf555505968e21311a38f/raw/39e96539676556e87c7461a382b73088c0b5ba28/-"
+    sha256 "c10779e463fe3c77c574225083a9f7a12638f6b0cb278e8c3d6c40bf9d9c2762"
+  end
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -338,7 +338,7 @@ module Stdenv
     append flags, map.fetch(effective_arch, default)
 
     # Works around a buggy system header on Tiger
-    append flags, "-faltivec" if MacOS.version == :tiger
+    append flags, "-faltivec" if MacOS.version == :tiger && Hardware::CPU.ppc?
 
     # not really a 'CPU' cflag, but is only used with clang
     remove flags, '-Qunused-arguments'


### PR DESCRIPTION
This is still a WIP; GCC still fails to build with these patches at this time.