### PR TITLE
ruby: Fix build of 2.4.1 on Tiger i386

### DIFF
--- a/Library/Formula/ruby.rb
+++ b/Library/Formula/ruby.rb
@@ -27,6 +27,24 @@ class Ruby < Formula
   depends_on "openssl"
   depends_on :x11 if build.with? "tcltk"
 
+  if MacOS.version <= :leopard
+    # fix for https://bugs.ruby-lang.org/issues/11054
+    patch do
+      url "https://github.com/ruby/ruby/commit/1c80c388d5bd48018c419a2ea3ed9f7b7514dfa3.patch"
+      sha256 "b53661f3077f10af2446f6faf5870d476471290859b7058cd2661e6e6ca24e8e"
+    end
+
+    # fix for https://bugs.ruby-lang.org/issues/13247
+    patch do
+      url "https://github.com/ruby/ruby/commit/9e1a9858c84142e32b1bc51b23fa06a025f98b46.patch"
+      sha256 "6bae61c482b59771613c281def4826cd32fa5d9fbe8d0f4935b50896b65fe5fe"
+    end
+
+    # fix for ext/fiddle/libffi-3.2.1/src/x86/win32.S
+    # based on https://github.com/macports/macports-ports/blob/8964c98f0e33e4aaabc851d8b684f4c709edceef/devel/libffi/files/PR-44170.patch
+    patch :DATA
+  end
+
   fails_with :llvm do
     build 2326
   end
@@ -194,3 +212,85 @@ class Ruby < Formula
     assert_equal 0, $?.exitstatus
   end
 end
+__END__
+--- a/ext/fiddle/libffi-3.2.1/src/x86/win32.S	2017-04-04 11:14:27.000000000 +0200
++++ b/ext/fiddle/libffi-3.2.1/src/x86/win32.S	2017-04-04 11:16:20.000000000 +0200
+@@ -528,7 +528,7 @@
+         .text
+  
+         # This assumes we are using gas.
+-        .balign 16
++        .p2align 4
+ FFI_HIDDEN(ffi_call_win32)
+         .globl	USCORE_SYMBOL(ffi_call_win32)
+ #if defined(X86_WIN32) && !defined(__OS2__)
+@@ -711,7 +711,7 @@
+         popl %ebp
+         ret
+ .ffi_call_win32_end:
+-        .balign 16
++        .p2align 4
+ FFI_HIDDEN(ffi_closure_THISCALL)
+         .globl	USCORE_SYMBOL(ffi_closure_THISCALL)
+ #if defined(X86_WIN32) && !defined(__OS2__)
+@@ -724,7 +724,7 @@
+         push	%ecx
+         jmp	.ffi_closure_STDCALL_internal
+ 
+-        .balign 16
++        .p2align 4
+ FFI_HIDDEN(ffi_closure_FASTCALL)
+         .globl	USCORE_SYMBOL(ffi_closure_FASTCALL)
+ #if defined(X86_WIN32) && !defined(__OS2__)
+@@ -753,7 +753,7 @@
+ 
+ .LFE1:
+         # This assumes we are using gas.
+-        .balign 16
++        .p2align 4
+ FFI_HIDDEN(ffi_closure_SYSV)
+ #if defined(X86_WIN32)
+         .globl	USCORE_SYMBOL(ffi_closure_SYSV)
+@@ -897,7 +897,7 @@
+ #define RAW_CLOSURE_USER_DATA_OFFSET (RAW_CLOSURE_FUN_OFFSET + 4)
+ 
+ #ifdef X86_WIN32
+-        .balign 16
++        .p2align 4
+ FFI_HIDDEN(ffi_closure_raw_THISCALL)
+         .globl	USCORE_SYMBOL(ffi_closure_raw_THISCALL)
+ #if defined(X86_WIN32) && !defined(__OS2__)
+@@ -916,7 +916,7 @@
+ #endif /* X86_WIN32 */
+ 
+         # This assumes we are using gas.
+-        .balign 16
++        .p2align 4
+ #if defined(X86_WIN32)
+         .globl	USCORE_SYMBOL(ffi_closure_raw_SYSV)
+ #if defined(X86_WIN32) && !defined(__OS2__)
+@@ -1039,7 +1039,7 @@
+ #endif /* !FFI_NO_RAW_API */
+ 
+         # This assumes we are using gas.
+-        .balign	16
++        .p2align 4
+ FFI_HIDDEN(ffi_closure_STDCALL)
+         .globl	USCORE_SYMBOL(ffi_closure_STDCALL)
+ #if defined(X86_WIN32) && !defined(__OS2__)
+@@ -1184,7 +1184,6 @@
+ 
+ #if defined(X86_WIN32) && !defined(__OS2__)
+         .section	.eh_frame,"w"
+-#endif
+ .Lframe1:
+ .LSCIE1:
+         .long	.LECIE1-.LASCIE1  /* Length of Common Information Entry */
+@@ -1343,6 +1342,7 @@
+         /* End of DW_CFA_xxx CFI instructions.  */
+         .align 4
+ .LEFDE5:
++#endif
+ 
+ #endif /* !_MSC_VER */
+ 


### PR DESCRIPTION
Even though I did not test it, I think that the first two patches are needed on Leopard as well, because:
 - `fgetattrlist` was introduced in 10.6
 - `mach_task_basic_info_data_t` is not available even on 10.6

I am not sure about `win32.S` (maybe not needed on Leopard? likely not needed on ppc).