### PR TITLE
cmake: Fix build on 10.4

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -118,6 +118,9 @@ class Cmake < Formula
       args << "--sphinx-man" << "--sphinx-build=#{buildpath}/sphinx/bin/sphinx-build"
     end
 
+    # gcc-4.2 does not find stdarg.h if the sysroot is set to an SDK
+    args << "--" << "-DCMAKE_OSX_SYSROOT=/"
+
     system "./bootstrap", *args
     system "make"
     system "make", "install"


### PR DESCRIPTION
After bootstrapping, `cmake` passes `-isysroot /path/to/SDK` as
argument to the compiler unless overridden. This causes apple-gcc42 to
be unable to find the `stdarg.h` header.

Fixes #479.