### PR TITLE
Import homebrew's formula@version

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -66,7 +66,7 @@ module Homebrew
         end
       end
     end
-    metacharacters = %w[\\ | ( ) [ ] { } ^ $ * + ? .]
+    metacharacters = %w[\\ | ( ) [ ] { } ^ $ * + ?]
     bad_regex = metacharacters.any? do |char|
       ARGV.any? do |arg|
         arg.include?(char) && !arg.start_with?("/")

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -51,6 +51,7 @@ class Formulary
     class_name = name.capitalize
     class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }
     class_name.tr!("+", "x")
+    class_name.gsub!(/\b@\b/, "AT")
     class_name
   end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -51,7 +51,7 @@ class Formulary
     class_name = name.capitalize
     class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }
     class_name.tr!("+", "x")
-    class_name.gsub!(/\b@\b/, "AT")
+    class_name.sub!(/(.)@(\d)/, "\\1AT\\2")
     class_name
   end
 

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -7,6 +7,7 @@ class FormularyTest < Homebrew::TestCase
     assert_equal "SLang", Formulary.class_s("s-lang")
     assert_equal "PkgConfig", Formulary.class_s("pkg-config")
     assert_equal "FooBar", Formulary.class_s("foo_bar")
+    assert_equal "OpensslAT11", Formulary.class_s("openssl@1.1")
   end
 end
 


### PR DESCRIPTION
Adapted from https://github.com/Homebrew/brew/pull/812.

I'm going to be getting Tigerbrew onto upstream Homebrew/brew at some point in the future, but this is a prerequisite for building the Ruby binary packages that are necessary to do so.