### PR TITLE
Add a helper to determine make path on Tiger

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -96,6 +96,19 @@ module FileUtils
     system RUBY_BIN/"rake", *args
   end
 
+  # Run `make` 3.81 or newer.
+  # Uses the system make on Leopard and newer, and the
+  # path to the actually-installed make on Tiger or older.
+  def make(*args)
+    if Utils.popen_read("/usr/bin/make", "--version").match(/Make (\d\.\d+)/)[1] > "3.80"
+      system "/usr/bin/make", *args
+    else
+      make = Formula["make"].opt_bin/"make"
+      make_path = make.exist? ? make.to_s : (Formula["make"].opt_bin/"gmake").to_s
+      system make_path, *args
+    end
+  end
+
   if method_defined?(:ruby)
     # @private
     alias_method :old_ruby, :ruby


### PR DESCRIPTION
This is what Homebrew/brew uses; I'll migrate things from `make_path` in a future PR.