### PR TITLE
Update OpenSSL and enable universal build on Tiger

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,10 +1,10 @@
 class Openssl < Formula
   desc "SSL/TLS cryptography library"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.0.2j.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2j.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2j.tar.gz"
-  sha256 "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431"
+  url "https://www.openssl.org/source/openssl-1.0.2k.tar.gz"
+  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2k.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2k.tar.gz"
+  sha256 "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0"
 
   bottle do
     sha256 "109fe24d2ee82d89e1ee60587d91c953cdd3384db5374e8e83635c456fa15ed0" => :sierra

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -15,6 +15,13 @@ class Openssl < Formula
   option :universal
   option "without-test", "Skip build-time tests (not recommended)"
 
+  if MacOS.version == :tiger
+    # Tiger's ld defaults to multi-module dylibs, which do not support common symbols
+    depends_on :ld64
+    # Tiger's as cannot parse .comm pseudo-ops when the optional alignment argument is specified
+    depends_on "cctools" => :build
+  end
+
   depends_on "makedepend" => :build
   depends_on "curl-ca-bundle" if MacOS.version < :snow_leopard
 
@@ -42,8 +49,6 @@ class Openssl < Formula
       enable-cms
     ]
     
-    args << "no-asm" if MacOS.version == :tiger
-
     args
   end
 

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -76,7 +76,7 @@ class Openssl < Formula
       system "perl", "./Configure", *(configure_args + arch_args[arch])
       system "make", "depend"
       system "make"
-      system "make", "test" if build.with?("test")
+      system "make", "test" if build.with?("test") && Hardware::CPU.can_run?(arch)
 
       if build.universal?
         cp "include/openssl/opensslconf.h", dir

--- a/Library/Homebrew/os/mac/hardware.rb
+++ b/Library/Homebrew/os/mac/hardware.rb
@@ -79,7 +79,11 @@ module MacCPUs
   end
 
   def bits
-    sysctl_bool("hw.cpu64bit_capable") ? 64 : 32
+    # hw.cpu64bit_capable is not available on Tiger, but it is
+    # possible to detect 64-bit CPUs by checking the ppc- and
+    # intel-specific flags, as shown in
+    # https://opensource.apple.com/source/xnu/xnu-1504.7.4/tools/tests/xnu_quick_test/misc.c?txt
+    sysctl_bool("hw.optional.64bitops") || sysctl_bool("hw.optional.x86_64") ? 64 : 32
   end
 
   def arch_32_bit

--- a/Library/Homebrew/os/mac/hardware.rb
+++ b/Library/Homebrew/os/mac/hardware.rb
@@ -97,12 +97,15 @@ module MacCPUs
   # Returns an array that's been extended with ArchitectureListExtension,
   # which provides helpers like #as_arch_flags and #as_cmake_arch_flags.
   def universal_archs
-    # Building 64-bit is a no-go on Tiger, and pretty hit or miss on Leopard.
-    # Don't even try unless Tigerbrew's experimental 64-bit Leopard support is enabled.
-    if MacOS.version <= :leopard && !MacOS.prefer_64_bit?
-      [arch_32_bit].extend ArchitectureListExtension
+    # Support for running on ppc was dropped after Leopard
+    if MacOS.version > :leopard
+      [:x86_64, :i386].extend ArchitectureListExtension
+    # Building 64-bit is pretty hit or miss on Tiger and Leopard.
+    # Don't even try unless Tigerbrew's experimental 64-bit support is enabled.
+    elsif ENV["HOMEBREW_PREFER_64_BIT"]
+      [:x86_64, :i386, :ppc64, :ppc].extend ArchitectureListExtension
     else
-      [arch_32_bit, arch_64_bit].extend ArchitectureListExtension
+      [:i386, :ppc].extend ArchitectureListExtension
     end
   end
 


### PR DESCRIPTION
The main aim of this PR is updating the OpenSSL formula and fixing it to build a universal library on Tiger (with assembly-optimized functions).

In order to do so, some additional changes are applied to `Library/Homebrew/os/mac/hardware.rb`.
Specifically, the detection of 64-bit CPUs now works on Tiger and the architectures returned by `universal_archs` now depend on the os, but not on the CPU.