### PR TITLE
(WIP) Fix qemu on 10.4

### DIFF
--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -52,10 +52,16 @@ class Qemu < Formula
       --prefix=#{prefix}
       --cc=#{ENV.cc}
       --host-cc=#{ENV.cc}
-      --enable-cocoa
       --disable-bsd-user
       --disable-guest-agent
     ]
+
+    # Cocoa UI uses features that require 10.5 or newer
+    if MacOS.version > :tiger
+      args << "--enable-cocoa"
+    else
+      args << "--disable-cocoa"
+    end
 
     # qemu will try to build 64-bit on 64-bit hardware, but we might not want that
     args << "--cpu=#{Hardware::CPU.arch_32_bit}" unless MacOS.prefer_64_bit?

--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -45,8 +45,13 @@ class Qemu < Formula
   def install
     ENV["LIBTOOL"] = "glibtool"
 
-    # Needed for certain stdint macros on 10.4
-    ENV.append_to_cflags "-D__STDC_CONSTANT_MACROS" if MacOS.version < :leopard
+    if MacOS.version < :leopard
+      # Needed for certain stdint macros on 10.4
+      ENV.append_to_cflags "-D__STDC_CONSTANT_MACROS"
+
+      # Rez is provided in a normal path in later Xcodes
+      ENV.prepend_path "PATH", "/Developer/Tools"
+    end
 
     args = %W[
       --prefix=#{prefix}

--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -26,6 +26,7 @@ class Qemu < Formula
   depends_on "jpeg"
   depends_on "gnutls"
   depends_on "glib"
+  depends_on "libutil" if MacOS.version < :leopard
   depends_on "pixman"
   depends_on "vde" => :optional
   depends_on "sdl" => :optional

--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -45,6 +45,9 @@ class Qemu < Formula
   def install
     ENV["LIBTOOL"] = "glibtool"
 
+    # Needed for certain stdint macros on 10.4
+    ENV.append_to_cflags "-D__STDC_CONSTANT_MACROS" if MacOS.version < :leopard
+
     args = %W[
       --prefix=#{prefix}
       --cc=#{ENV.cc}

--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -21,6 +21,7 @@ class Qemu < Formula
     sha256 "043f1c5b577fdfbaac516bc1ca909dee089cd591fd018b68c1298ab859170ef9" => :mavericks
   end
 
+  depends_on "make" => :build if MacOS.version < :leopard
   depends_on "pkg-config" => :build
   depends_on "libtool" => :build
   depends_on "jpeg"
@@ -51,6 +52,10 @@ class Qemu < Formula
 
       # Rez is provided in a normal path in later Xcodes
       ENV.prepend_path "PATH", "/Developer/Tools"
+
+      # Make 3.80 does not support the `or` operator and has trouble evaluating `unnest-vars`
+      # See https://github.com/mistydemeo/tigerbrew/pull/496
+      ENV["MAKE"] = make_path
     end
 
     args = %W[
@@ -76,7 +81,7 @@ class Qemu < Formula
     args << (build.with?("libssh2") ? "--enable-libssh2" : "--disable-libssh2")
 
     system "./configure", *args
-    system "make", "V=1", "install"
+    make "V=1", "install"
   end
 
   test do


### PR DESCRIPTION
Fixes #494.

This currently doesn't completely build due to a strange error, looks like the pixman CFLAGS are being passed incorrectly: https://gist.github.com/d590fb19ba97fea798970cec796bbdf9 Truncation, maybe?

```
I/usr/local/Cellar/pixman/0.32.6/include/pixman-1 -I/private/tmp/qemu20170424-27348-k1x6mt/qemu-2.4.0.1/dtc/libfdt -m32 -DOS_OBJECT_USE_OBJC=0 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -Wstrict-prototypes -Wredundant-decls -Wall -Wundef -Wwrite-strings -Wmissing-prototypes -fno-strict-aliasing -fno-common  -Wendif-labels -Wmissing-include-dirs -Wempty-body -Wnested-externs -Wformat-security -Wformat-y2k -Winit-self -Wignored-qualifiers -Wold-style-declaration -Wold-style-definition -Wtype-limits -fstack-protector-strong -I/usr/local/Cellar/gnutls/3.3.18/include -I/usr/local/Cellar/nettle/2.7.1/include -I/usr/local/Cellar/libtasn1/4.7/include -I/usr/local/Cellar/nettle/2.7.1/include -I/usr/local/Cellar/gnutls/3.3.18/include -I/usr/local/Cellar/nettle/2.7.1/include -I/usr/local/Cellar/libtasn1/4.7/include   -I.. -I/private/tmp/qemu20170424-27348-k1x6mt/qemu-2.4.0.1/target-i386 -DNEED_CPU_H -I/private/tmp/qemu20170424-27348-k1x6mt/qemu-2.4.0.1/include -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -D_REENTRANT -I/usr/local/Cellar/glib/2.50.1/include/glib-2.0 -I/usr/local/Cellar/glib/2.50.1/lib/glib-2.0/include -I/usr/local/opt/gettext/include -I/usr/local/Cellar/pcre/8.39/include -g -Os -w -pipe -march=prescott -mmacosx-version-min=10.4 -D__STDC_CONSTANT_MACROS -m32 -framework CoreFoundation -framework IOKit -g -L/usr/local/opt/pixman/lib -L/usr/local/opt/zlib/lib -L/usr/local/opt/gettext/lib -L/usr/local/opt/libtool/lib -L/usr/local/lib -F/usr/local/Frameworks -Wl,-headerpad_max_install_names  -o qemu-system-i386 exec.o translate-all.o cpu-exec.o tcg/tcg.o tcg/tcg-op.o tcg/optimize.o fpu/softfloat.o disas.o kvm-stub.o arch_init.o cpus.o monitor.o gdbstub.o balloon.o ioport.o numa.o qtest.o bootdevice.o memory.o cputlb.o memory_mapping.o dump.o migration/ram.o migration/savevm.o xen-common-stub.o xen-hvm-stub.o hw/block/virtio-blk.o hw/block/dataplane/virtio-blk.o hw/char/virtio-serial-bus.o hw/cpu/icc_bus.o hw/display/vga.o hw/display/virtio-gpu.o hw/display/virtio-gpu-pci.o hw/intc/apic.o hw/intc/apic_common.o hw/intc/ioapic.o hw/isa/lpc_ich9.o hw/misc/vmport.o hw/misc/pvpanic.o hw/misc/edu.o hw/net/virtio-net.o hw/net/vhost_net.o hw/scsi/virtio-scsi.o hw/scsi/virtio-scsi-dataplane.o hw/timer/mc146818rtc.o hw/virtio/virtio.o hw/virtio/virtio-balloon.o hw/virtio/dataplane/vring.o hw/i386/multiboot.o hw/i386/smbios.o hw/i386/pc.o hw/i386/pc_piix.o hw/i386/pc_q35.o hw/i386/pc_sysfw.o hw/i386/intel_iommu.o hw/i386/kvmvapic.o hw/i386/acpi-build.o target-i386/translate.o target-i386/helper.o target-i386/cpu.o target-i386/excp_helper.o target-i386/fpu_helper.o target-i386/cc_helper.o target-i386/int_helper.o target-i386/svm_helper.o target-i386/smm_helper.o target-i386/misc_helper.o target-i386/mem_helper.o target-i386/seg_helper.o target-i386/gdbstub.o target-i386/machine.o target-i386/arch_memory_mapping.o target-i386/arch_dump.o target-i386/kvm-stub.o ../blockdev.o ../blockdev-nbd.o ../iothread.o ../qdev-monitor.o ../device-hotplug.o ../os-posix.o ../qemu-char.o ../page_cache.o ../qjson.o ../accel.o ../bt-host.o ../bt-vhci.o ../dma-helpers.o ../vl.o ../tpm.o ../device_tree.o ../qmp-marshal.o ../qmp.o ../hmp.o ../qemu-log.o ../tcg-runtime.o ../audio/audio.o ../audio/noaudio.o ../audio/wavaudio.o ../audio/mixeng.o ../audio/coreaudio.o ../audio/wavcapture.o ../backends/rng.o ../backends/rng-egd.o ../backends/rng-random.o ../backends/msmouse.o ../backends/testdev.o ../backends/tpm.o ../backends/hostmem.o ../backends/hostmem-ram.o ../block/stream.o ../block/commit.o ../block/backup.o ../disas/i386.o ../hw/acpi/core.o ../hw/acpi/piix4.o ../hw/acpi/pcihp.o ../hw/acpi/ich9.o ../hw/acpi/tco.o ../hw/acpi/cpu_hotplug.o ../hw/acpi/memory_hotplug.o ../hw/acpi/acpi_interface.o ../hw/acpi/bios-linker-loader.o ../hw/acpi/aml-build.o ../hw/audio/sb16.o ../hw/audio/es1370.o ../hw/audio/ac97.o ../hw/audio/fmopl.o ../hw/audio/adlib.o ../hw/audio/gus.o ../hw/audio/gusemu_hal.o ../hw/audio/gusemu_mixer.o ../hw/audio/cs4231a.o ../hw/audio/intel-hda.o ../hw/audio/hda-codec.o ../hw/audio/pcspk.o ../hw/block/block.o ../hw/block/cdrom.o ../hw/block/hd-geometry.o ../hw/block/fdc.o ../hw/block/pflash_cfi01.o ../hw/block/nvme.o ../hw/bt/core.o ../hw/bt/l2cap.o ../hw/bt/sdp.o ../hw/bt/hci.o ../hw/bt/hid.o ../hw/bt/hci-csr.o ../hw/char/ipoctal232.o ../hw/char/parallel.o ../hw/char/serial.o ../hw/char/serial-isa.o ../hw/char/serial-pci.o ../hw/char/virtio-console.o ../hw/char/debugcon.o ../hw/core/qdev.o ../hw/core/qdev-properties.o ../hw/core/fw-path-provider.o ../hw/core/irq.o ../hw/core/hotplug.o ../hw/core/nmi.o ../hw/core/sysbus.o ../hw/core/machine.o ../hw/core/null-machine.o ../hw/core/loader.o ../hw/core/qdev-properties-system.o ../hw/display/cirrus_vga.o ../hw/display/vga-pci.o ../hw/display/vga-isa.o ../hw/display/vmware_vga.o ../hw/dma/i8257.o ../hw/i2c/core.o ../hw/i2c/smbus.o ../hw/i2c/smbus_eeprom.o ../hw/i2c/smbus_ich9.o ../hw/i2c/pm_smbus.o ../hw/ide/core.o ../hw/ide/atapi.o ../hw/ide/qdev.o ../hw/ide/pci.o ../hw/ide/isa.o ../hw/ide/piix.o ../hw/ide/ahci.o ../hw/ide/ich.o ../hw/input/hid.o ../hw/input/pckbd.o ../hw/input/ps2.o ../hw/input/vmmouse.o ../hw/intc/i8259_common.o ../hw/intc/i8259.o ../hw/intc/ioapic_common.o ../hw/ipack/ipack.o ../hw/ipack/tpci200.o ../hw/isa/isa-bus.o ../hw/isa/apm.o ../hw/mem/pc-dimm.o ../hw/misc/applesmc.o ../hw/misc/debugexit.o ../hw/misc/sga.o ../hw/misc/pc-testdev.o ../hw/misc/pci-testdev.o ../hw/net/ne2000.o ../hw/net/eepro100.o ../hw/net/pcnet-pci.o ../hw/net/pcnet.o ../hw/net/e1000.o ../hw/net/rtl8139.o ../hw/net/vmxnet_tx_pkt.o ../hw/net/vmxnet_rx_pkt.o ../hw/net/vmxnet3.o ../hw/net/ne2000-isa.o ../hw/net/rocker/rocker.o ../hw/net/rocker/rocker_fp.o ../hw/net/rocker/rocker_desc.o ../hw/net/rocker/rocker_world.o ../hw/net/rocker/rocker_of_dpa.o ../hw/nvram/eeprom93xx.o ../hw/nvram/fw_cfg.o ../hw/pci-bridge/pci_bridge_dev.o ../hw/pci-bridge/pci_expander_bridge.o ../hw/pci-bridge/xio3130_upstream.o ../hw/pci-bridge/xio3130_downstream.o ../hw/pci-bridge/ioh3420.o ../hw/pci-bridge/i82801b11.o ../hw/pci-host/pam.o ../hw/pci-host/piix.o ../hw/pci-host/q35.o ../hw/pci/pci.o ../hw/pci/pci_bridge.o ../hw/pci/msix.o ../hw/pci/msi.o ../hw/pci/shpc.o ../hw/pci/slotid_cap.o ../hw/pci/pci_host.o ../hw/pci/pcie_host.o ../hw/pci/pcie.o ../hw/pci/pcie_aer.o ../hw/pci/pcie_port.o ../hw/pcmcia/pcmcia.o ../hw/scsi/scsi-disk.o ../hw/scsi/scsi-generic.o ../hw/scsi/scsi-bus.o ../hw/scsi/lsi53c895a.o ../hw/scsi/megasas.o ../hw/scsi/vmw_pvscsi.o ../hw/scsi/esp.o ../hw/scsi/esp-pci.o ../hw/sd/sd.o ../hw/sd/sdhci.o ../hw/timer/hpet.o ../hw/timer/i8254_common.o ../hw/timer/i8254.o ../hw/tpm/tpm_tis.o ../hw/usb/core.o ../hw/usb/combined-packet.o ../hw/usb/bus.o ../hw/usb/libhw.o ../hw/usb/desc.o ../hw/usb/desc-msos.o ../hw/usb/hcd-uhci.o ../hw/usb/hcd-ohci.o ../hw/usb/hcd-ehci.o ../hw/usb/hcd-ehci-pci.o ../hw/usb/hcd-xhci.o ../hw/usb/dev-hub.o ../hw/usb/dev-hid.o ../hw/usb/dev-wacom.o ../hw/usb/dev-storage.o ../hw/usb/dev-uas.o ../hw/usb/dev-audio.o ../hw/usb/dev-serial.o ../hw/usb/dev-network.o ../hw/usb/dev-bluetooth.o ../hw/usb/dev-smartcard-reader.o ../hw/usb/ccid-card-passthru.o ../hw/usb/dev-mtp.o ../hw/usb/host-stub.o ../hw/virtio/virtio-rng.o ../hw/virtio/virtio-pci.o ../hw/virtio/virtio-bus.o ../hw/virtio/virtio-mmio.o ../hw/watchdog/watchdog.o ../hw/watchdog/wdt_i6300esb.o ../hw/watchdog/wdt_ib700.o ../migration/migration.o ../migration/tcp.o ../migration/vmstate.o ../migration/qemu-file.o ../migration/qemu-file-buf.o ../migration/qemu-file-unix.o ../migration/qemu-file-stdio.o ../migration/xbzrle.o ../migration/exec.o ../migration/unix.o ../migration/fd.o ../migration/block.o ../net/net.o ../net/queue.o ../net/checksum.o ../net/util.o ../net/hub.o ../net/socket.o ../net/dump.o ../net/eth.o ../net/tap.o ../net/vhost-user.o ../net/tap-bsd.o ../net/slirp.o ../qom/object.o ../qom/container.o ../qom/qom-qobject.o ../qom/cpu.o ../qom/object_interfaces.o ../slirp/cksum.o ../slirp/if.o ../slirp/ip_icmp.o ../slirp/ip_input.o ../slirp/ip_output.o ../slirp/dnssearch.o ../slirp/slirp.o ../slirp/mbuf.o ../slirp/misc.o ../slirp/sbuf.o ../slirp/socket.o ../slirp/tcp_input.o ../slirp/tcp_output.o ../slirp/tcp_subr.o ../slirp/tcp_timer.o ../slirp/udp.o ../slirp/bootp.o ../slirp/tftp.o ../slirp/arp_table.o ../ui/keymaps.o ../ui/console.o ../ui/cursor.o ../ui/qemu-pixman.o ../ui/input.o ../ui/input-keymap.o ../ui/input-legacy.o ../ui/curses.o ../ui/vnc.o ../ui/vnc-enc-zlib.o ../ui/vnc-enc-hextile.o ../ui/vnc-enc-tight.o ../ui/vnc-palette.o ../ui/vnc-enc-zrle.o ../ui/vnc-tls.o ../ui/vnc-auth-vencrypt.o ../ui/vnc-ws.o ../ui/vnc-jobs.o trace/generated-helpers.o ../async.o ../thread-pool.o ../nbd.o ../block.o ../blockjob.o ../main-loop.o ../iohandler.o ../qemu-timer.o ../aio-posix.o ../qemu-io-cmds.o ../qemu-coroutine.o ../qemu-coroutine-lock.o ../qemu-coroutine-io.o ../qemu-coroutine-sleep.o ../coroutine-sigaltstack.o ../block/raw_bsd.o ../block/qcow.o ../block/vdi.o ../block/vmdk.o ../block/cloop.o ../block/bochs.o ../block/vpc.o ../block/vvfat.o ../block/qcow2.o ../block/qcow2-refcount.o ../block/qcow2-cluster.o ../block/qcow2-snapshot.o ../block/qcow2-cache.o ../block/qed.o ../block/qed-gencb.o ../block/qed-l2-cache.o ../block/qed-table.o ../block/qed-cluster.o ../block/qed-check.o ../block/vhdx.o ../block/vhdx-endian.o ../block/vhdx-log.o ../block/quorum.o ../block/parallels.o ../block/blkdebug.o ../block/blkverify.o ../block/block-backend.o ../block/snapshot.o ../block/qapi.o ../block/raw-posix.o ../block/null.o ../block/mirror.o ../block/io.o ../block/throttle-groups.o ../block/nbd.o ../block/nbd-client.o ../block/sheepdog.o ../block/accounting.o ../block/write-threshold.o ../block/dmg.o  ../libqemuutil.a ../libqemustub.a   -lz -lbz2 -L/usr/local/Cellar/pixman/0.32.6/lib -lpixman-1 -lncurses -framework CoreAudio -ljpeg -L/usr/local/Cellar/gnutls/3.3.18/lib -lgnutls -L/usr/local/Cellar/nettle/2.7.1/lib -lnettle -L/usr/local/Cellar/gnutls/3.3.18/lib -lgnutls -F/System/Library/Frameworks -framework Cocoa -framework IOKit  -L/private/tmp/qemu20170424-27348-k1x6mt/qemu-2.4.0.1/dtc/libfdt -lfdt -L/usr/local/Cellar/glib/2.50.1/lib -L/usr/local/opt/gettext/lib -lgthread-2.0 -lglib-2.0 -lintl  -lz
```

cc @programmingkidx, @ranma42 