### PR TITLE
Import gcc formulae from homebrew/versions

### DIFF
--- a/Library/Formula/gcc44.rb
+++ b/Library/Formula/gcc44.rb
@@ -1,0 +1,193 @@
+class Gcc44 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "GNU compiler collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.4.7/gcc-4.4.7.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.4.7/gcc-4.4.7.tar.bz2"
+  sha256 "5ff75116b8f763fa0fb5621af80fc6fb3ea0f1b1a57520874982f03f26cd607f"
+
+  bottle do
+    sha256 "361c84608ef1ddaca2f9a3996aeface6bb08f4525388c563a09b8f20fcd40386" => :mavericks
+    sha256 "c5a7a27d0bfc30a3e6ecce048c786cefa7e3bb4038ad6ea3fdeeb3c6e6454bd1" => :mountain_lion
+  end
+
+  option "with-fortran", "Build the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+
+  depends_on "gmp4"
+  depends_on "mpfr2"
+  depends_on "ppl011"
+  depends_on "cloog-ppl015"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+  depends_on MaximumMacOSRequirement => :mavericks
+
+  # Fix libffi for ppc, from MacPorts
+  patch :p0 do
+    url "https://trac.macports.org/export/110576/trunk/dports/lang/gcc44/files/ppc_fde_encoding.diff"
+    sha256 "9c5f6fd30d089e97e0364af322272bb06f3d107f357d2b621503ebfbbb4a5af7"
+  end
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--mandir=#{man}",
+      "--infodir=#{info}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
+      "--with-ppl=#{Formula["ppl011"].opt_prefix}",
+      "--disable-ppl-version-check",
+      "--with-cloog=#{Formula["cloog-ppl015"].opt_prefix}",
+      "--with-system-zlib",
+      # This ensures lib, libexec, include are sandboxed so that they
+      # don't wander around telling little children there is no Santa
+      # Claus.
+      "--enable-version-specific-runtime-libs",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      # Multilib building is broken in GCC 4.4 on Darwin
+      "--disable-multilib",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      # Flags for Clang compatibility
+      make_flags = 'BOOT_CFLAGS="$BOOT_CFLAGS -D_FORTIFY_SOURCE=0" STAGE1_CFLAGS="$STAGE1_CFLAGS -std=gnu89 -D_FORTIFY_SOURCE=0 -fkeep-inline-functions"'
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", make_flags, "profiledbootstrap"
+      else
+        system "make", make_flags, "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu formula must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Remove libffi stuff, which is not needed after GCC is built.
+    Dir.glob(prefix/"**/libffi.*") { |file| File.delete file }
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. Fix this.
+    info.rmtree
+
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.4", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Library/Formula/gcc45.rb
+++ b/Library/Formula/gcc45.rb
@@ -1,0 +1,222 @@
+class Gcc45 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "GNU compiler collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.5.4/gcc-4.5.4.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.5.4/gcc-4.5.4.tar.bz2"
+  sha256 "eef3f0456db8c3d992cbb51d5d32558190bc14f3bc19383dd93acc27acc6befc"
+
+  bottle do
+    sha256 "16c2a3e56e2da8ec6b38b36c54112d7c56bc05f71168fb867f586cb190c5fef7" => :yosemite
+    sha256 "51b73412c9628a593e765105a098ed1500b04574145391f3f93972e54d5b1b05" => :mavericks
+    sha256 "06806e0a4aa703b0cacb4a3e10b4c8738d3d97535c6dd52796ec5a85eee0638d" => :mountain_lion
+  end
+
+  option "with-fortran", "Build the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  # with system ld on Tiger, build fails with countless messages of:
+  # "relocation overflow for relocation entry"
+  depends_on :ld64
+  depends_on "gmp4"
+  depends_on "libmpc08"
+  depends_on "mpfr2"
+  depends_on "ppl011"
+  depends_on "cloog-ppl015"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # If someone wants to try and fix this, feel free to file a PR. Thanks!
+  # https://github.com/Homebrew/homebrew-versions/issues/1093
+  depends_on MaximumMacOSRequirement => :yosemite
+
+  # Fix libffi for ppc, from MacPorts
+  patch :p0 do
+    url "https://trac.macports.org/export/110576/trunk/dports/lang/gcc45/files/ppc_fde_encoding.diff"
+    sha256 "9c5f6fd30d089e97e0364af322272bb06f3d107f357d2b621503ebfbbb4a5af7"
+  end
+
+  # Handle OS X deployment targets correctly (GCC PR target/63810 <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63810>).
+  patch :p0 do
+    url "https://trac.macports.org/export/129382/trunk/dports/lang/gcc45/files/macosx-version-min.patch"
+    sha256 "9083143d2c60fbd89d33354710381590da770973746dd6849e18835f449510bc"
+  end
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc08"].opt_prefix}",
+      "--with-ppl=#{Formula["ppl011"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog-ppl015"].opt_prefix}",
+      "--with-system-zlib",
+      # This ensures lib, libexec, include are sandboxed so that they
+      # don't wander around telling little children there is no Santa
+      # Claus.
+      "--enable-version-specific-runtime-libs",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      # GCC 4.5 does not properly support LTO on Darwin.
+      "--disable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu formula must be installed in order to do this.
+      system "make", "install"
+
+      # `make install` neglects to transfer an essential plugin header file.
+      Pathname.new(Dir[prefix.join "**", "plugin", "include", "config"].first).install "../gcc/config/darwin-sections.def" if MacOS.version > :tiger
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Remove libffi stuff, which is not needed after GCC is built.
+    Dir.glob(prefix/"**/libffi.*") { |file| File.delete file }
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. Fix this.
+    info.rmtree
+
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.5", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Library/Formula/gcc46.rb
+++ b/Library/Formula/gcc46.rb
@@ -1,0 +1,215 @@
+class Gcc46 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "GNU compiler collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.6.4/gcc-4.6.4.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.6.4/gcc-4.6.4.tar.bz2"
+  sha256 "35af16afa0b67af9b8eb15cafb76d2bc5f568540552522f5dc2c88dd45d977e8"
+
+  bottle do
+    sha256 "23cb970d350f9096b17ad0a04c875d0c54ee71a0f22709e72bcf34e100412dfc" => :yosemite
+    sha256 "51a8a0efb2868c517258d2a504c45217fed8a10631ba724da437adb39064a632" => :mavericks
+    sha256 "8033c9313bf08a7bc825aca65c884027a877052b77418d9fcf1006dd27ac2287" => :mountain_lion
+  end
+
+  if MacOS.version >= :el_capitan
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+  end
+
+  option "with-fortran", "Build the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp4"
+  depends_on "libmpc08"
+  depends_on "mpfr2"
+  depends_on "ppl011"
+  depends_on "cloog-ppl015"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix 10.10 issues: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=215251
+  patch :p0 do
+    url "https://trac.macports.org/export/126996/trunk/dports/lang/gcc48/files/patch-10.10.diff"
+    sha256 "61e5d0f18db59220cbd99717e9b644c1d0f3502b09ada746b60850cacda07328"
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc08"].opt_prefix}",
+      "--with-ppl=#{Formula["ppl011"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog-ppl015"].opt_prefix}",
+      "--with-system-zlib",
+      # This ensures lib, libexec, include are sandboxed so that they
+      # don't wander around telling little children there is no Santa
+      # Claus.
+      "--enable-version-specific-runtime-libs",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Remove libffi stuff, which is not needed after GCC is built.
+    Dir.glob(prefix/"**/libffi.*") { |file| File.delete file }
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. Fix this.
+    info.rmtree
+
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.6", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Library/Formula/gcc47.rb
+++ b/Library/Formula/gcc47.rb
@@ -1,0 +1,213 @@
+class Gcc47 < Formula
+  desc "GNU compiler collection"
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.7.4/gcc-4.7.4.tar.bz2"
+  sha256 "92e61c6dc3a0a449e62d72a38185fda550168a86702dea07125ebd3ec3996282"
+
+  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_7-branch"
+
+  bottle do
+    sha256 "de527788a6fedea2173e340fee47324478e8956ef31868d376c7ac561a8f2952" => :yosemite
+    sha256 "b418cec1d503d859e99cb13928a2df8434a9037524f898fe095ea35f615d87f2" => :mavericks
+    sha256 "fe211028f9a219f48d127bc946d5f7046b7b6e7f792fd4cd63c1deb393484db3" => :mountain_lion
+  end
+
+  if MacOS.version >= :el_capitan
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+  end
+
+  option "with-fortran", "Build the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-fortran" => "with-fortran"
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp4"
+  depends_on "libmpc08"
+  depends_on "mpfr2"
+  depends_on "ppl011"
+  depends_on "cloog-ppl015"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix 10.10 issues: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=215251
+  patch :p0 do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/7293b7d3/gcc47/patch-10.10.diff"
+    sha256 "61e5d0f18db59220cbd99717e9b644c1d0f3502b09ada746b60850cacda07328"
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc08"].opt_prefix}",
+      "--with-ppl=#{Formula["ppl011"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog-ppl015"].opt_prefix}",
+      "--with-system-zlib",
+      # This ensures lib, libexec, include are sandboxed so that they
+      # don't wander around telling little children there is no Santa
+      # Claus.
+      "--enable-version-specific-runtime-libs",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Remove libffi stuff, which is not needed after GCC is built.
+    Dir.glob(prefix/"**/libffi.*") { |file| File.delete file }
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. Fix this.
+    info.rmtree
+
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.7", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Library/Formula/gcc48.rb
+++ b/Library/Formula/gcc48.rb
@@ -1,0 +1,232 @@
+class Gcc48 < Formula
+  desc "GNU compiler collection"
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+  sha256 "22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23"
+
+  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_8-branch"
+
+  bottle do
+    rebuild 1
+    sha256 "8cf53c3b1f03049538b9f78ea1ffe7ebf21fcc99a3b4147e4ede8defefc4cef4" => :el_capitan
+    sha256 "ae30faa242deae02d46bc92a318e0f0b8f6f0754521fec2225c2fb0403022e31" => :yosemite
+    sha256 "0bc974cb0c23ed4ca3536eb2b5e7f11e692a5e6246d99b82ad74880685f42736" => :mavericks
+  end
+
+  if MacOS.version >= :yosemite
+    # Fixes build on El Capitan
+    # https://trac.macports.org/ticket/48471
+    patch :p0 do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/dcfc5a2e6/gcc48/define_non_standard_clang_macros.patch"
+      sha256 "e727383c9186fdc36f804c69ad550f5cfd2b996e37083be94c0c9aa8fde226ee"
+    end
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+  end
+
+  option "without-fortran", "Build without the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp4"
+  depends_on "libmpc08"
+  depends_on "mpfr2"
+  depends_on "cloog018"
+  depends_on "isl011"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The as that comes with Tiger isn't capable of dealing with the
+  # PPC asm that comes in libitm
+  depends_on "cctools" => :build if MacOS.version < :leopard
+
+  fails_with :gcc_4_0
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc08"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog018"].opt_prefix}",
+      "--with-isl=#{Formula["isl011"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # Use 'bootstrap-debug' build configuration to force stripping of object
+    # files prior to comparison during bootstrap (broken by Xcode 6.3).
+    # This causes bottle errors for gcc48 on Mountain Lion, so scope it to 10.10.
+    args << "--with-build-config=bootstrap-debug" if MacOS.version >= :yosemite
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-header"s will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae
+    # Since GCC 4.8 libffi stuff are no longer shipped.
+    # Rename libiberty.a.
+    Dir.glob(prefix/"**/libiberty.*") { |file| add_suffix file, version_suffix }
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. Fix this.
+    info.rmtree
+
+    # Rename java properties
+    if build.with?("java") || build.with?("all-languages")
+      config_files = [
+        "#{lib}/logging.properties",
+        "#{lib}/security/classpath.security",
+        "#{lib}/i386/logging.properties",
+        "#{lib}/i386/security/classpath.security",
+      ]
+
+      config_files.each do |file|
+        add_suffix file, version_suffix if File.exist? file
+      end
+    end
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.8", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -1,0 +1,205 @@
+class Gcc49 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "The GNU Compiler Collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
+  sha256 "2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e"
+
+  head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
+
+  bottle do
+    rebuild 3
+    sha256 "0acf2b010e3c2210fcb5fdc03de9dc14f0556cf5295347d8f72f2d8d1cfab4ff" => :el_capitan
+    sha256 "5b635a24e9f7464fb94d2933b00a8d1b1cfc0efb1de140fe568e313d24965140" => :yosemite
+    sha256 "dc24f86a9652fbb0ec0bc9dd0103d23bb68c315bd490ee5d0b10a7144453ecc4" => :mavericks
+  end
+
+  if MacOS.version >= :yosemite
+    # Fixes build with Xcode 7.
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
+    patch do
+      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
+      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
+    end
+    # Fixes assembler generation with XCode 7
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66509
+    patch do
+      url "https://gist.githubusercontent.com/tdsmith/d248e025029add31e7aa/raw/444e292786df41346a3a1cc6267bba587408a007/gcc.diff"
+      sha256 "636b65a160ccb7417cc4ffc263fc815382f8bb895e32262205cd10d65ea7804a"
+    end
+  end
+
+  option "without-fortran", "Build without the gfortran compiler"
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  deprecated_option "enable-java" => "with-java"
+  deprecated_option "enable-all-languages" => "with-all-languages"
+  deprecated_option "enable-nls" => "with-nls"
+  deprecated_option "enable-profiled-build" => "with-profiled-build"
+  deprecated_option "disable-multilib" => "without-multilib"
+
+  depends_on "gmp4"
+  depends_on "libmpc08"
+  depends_on "mpfr2"
+  depends_on "cloog018"
+  depends_on "isl011"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+    end
+
+    version_suffix = version.to_s.slice(/\d\.\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp4"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc08"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog018"].opt_prefix}",
+      "--with-isl=#{Formula["isl011"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # Use 'bootstrap-debug' build configuration to force stripping of object
+      # files prior to comparison during bootstrap (broken by Xcode 6.3).
+      "--with-build-config=bootstrap-debug",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_prefix}/share/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+    # Since GCC 4.8 libffi stuff are no longer shipped.
+
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. Fix this.
+    info.rmtree
+    # Since GCC 4.9 java properties are properly sandboxed.
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-4.9", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end

--- a/Library/Formula/gcc5.rb
+++ b/Library/Formula/gcc5.rb
@@ -1,0 +1,210 @@
+class Gcc5 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "The GNU Compiler Collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2"
+  sha256 "608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a"
+
+  bottle do
+    sha256 "834b511f2f460db483e8126b446bb0a7fc7e2d7ee16bb53d6c4ec51910ce89be" => :el_capitan
+    sha256 "b44fcce2f25919f93d33fe9482c1f9cc1068e3332f6890340853c32007c0113b" => :yosemite
+    sha256 "7b4970b4c2c86558208476c3e281f242be4f6bfe7c1fa8391e52b9829ef4ba78" => :mavericks
+  end
+
+  # GCC's Go compiler is not currently supported on Mac OS X.
+  # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46986
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  option "with-jit", "Build the jit compiler"
+  option "without-fortran", "Build without the gfortran compiler"
+  # enabling multilib on a host that can"t run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "isl014"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  if MacOS.version < :leopard
+    # The as that comes with Tiger isn't capable of dealing with the
+    # PPC asm that comes in libitm
+    depends_on "cctools" => :build
+  end
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix for libgccjit.so linkage on Darwin.
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  patch :DATA
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++ jit]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+      languages << "jit" if build.with? "jit"
+    end
+
+    version_suffix = version.to_s.slice(/\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-isl=#{Formula["isl014"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    args << "--enable-host-shared" if build.with?("jit") || build.with?("all-languages")
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+
+    # Since GCC 4.8 libffi stuff are no longer shipped.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. fix this.
+    info.rmtree
+    # Since GCC 4.9 java properties are properly sandboxed.
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-5", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end
+
+__END__
+--- a/gcc/jit/Make-lang.in	2015-02-03 17:19:58.000000000 +0000
++++ b/gcc/jit/Make-lang.in	2015-04-08 22:08:24.000000000 +0100
+@@ -85,8 +85,7 @@
+	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)

--- a/Library/Formula/gcc6.rb
+++ b/Library/Formula/gcc6.rb
@@ -1,0 +1,214 @@
+class Gcc6 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "The GNU Compiler Collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftpmirror.gnu.org/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-6.2.0/gcc-6.2.0.tar.bz2"
+  sha256 "9944589fc722d3e66308c0ce5257788ebd7872982a718aa2516123940671b7c5"
+
+  bottle do
+    sha256 "c30c0898b73794434af820725d3b69d4f26e58357c6d2867028527ce31273b58" => :sierra
+    sha256 "b3b138b29d6705f85bf3d558795bd901c53929ac7935879ff4b7778f7f7b84c7" => :el_capitan
+    sha256 "0ffe5b97c65df653ea664514880fd72c01cf516b1409655a8c03e48a42275050" => :yosemite
+  end
+
+  # GCC's Go compiler is not currently supported on Mac OS X.
+  # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=46986
+  option "with-java", "Build the gcj compiler"
+  option "with-all-languages", "Enable all compilers and languages, except Ada"
+  option "with-nls", "Build with native language support (localization)"
+  option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
+  option "with-jit", "Build the jit compiler"
+  option "without-fortran", "Build without the gfortran compiler"
+  # enabling multilib on a host that can"t run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "isl014"
+  depends_on "ecj" if build.with?("java") || build.with?("all-languages")
+
+  if MacOS.version < :leopard
+    # The as that comes with Tiger isn't capable of dealing with the
+    # PPC asm that comes in libitm
+    depends_on "cctools" => :build
+  end
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # Fix for libgccjit.so linkage on Darwin
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  patch :DATA
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    if build.with? "all-languages"
+      # Everything but Ada, which requires a pre-existing GCC Ada compiler
+      # (gnat) to bootstrap. GCC 4.6.0 add go as a language option, but it is
+      # currently only compilable on Linux.
+      languages = %w[c c++ fortran java objc obj-c++ jit]
+    else
+      # C, C++, ObjC compilers are always built
+      languages = %w[c c++ objc obj-c++]
+
+      languages << "fortran" if build.with? "fortran"
+      languages << "java" if build.with? "java"
+      languages << "jit" if build.with? "jit"
+    end
+
+    version_suffix = version.to_s.slice(/\d/)
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-isl=#{Formula["isl014"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-libstdcxx-time=yes",
+      "--enable-stage1-checking",
+      "--enable-checking=release",
+      "--enable-lto",
+      # Use 'bootstrap-debug' build configuration to force stripping of object
+      # files prior to comparison during bootstrap (broken by Xcode 6.3).
+      "--with-build-config=bootstrap-debug",
+      # A no-op unless --HEAD is built because in head warnings will
+      # raise errors. But still a good idea to include.
+      "--disable-werror",
+      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :tiger
+
+    # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
+    # format to avoid failure during the stage 3 comparison of object files.
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version <= :mountain_lion
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.with?("java") || build.with?("all-languages")
+      args << "--with-ecj-jar=#{Formula["ecj"].opt_share}/java/ecj.jar"
+    end
+
+    if !MacOS.prefer_64_bit? || build.without?("multilib")
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    args << "--enable-host-shared" if build.with?("jit") || build.with?("all-languages")
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      if build.with? "profiled-build"
+        # Takes longer to build, may bug out. Provided for those who want to
+        # optimise all the way to 11.
+        system "make", "profiledbootstrap"
+      else
+        system "make", "bootstrap"
+      end
+
+      # At this point `make check` could be invoked to run the testsuite. The
+      # deja-gnu and autogen formulae must be installed in order to do this.
+      system "make", "install"
+    end
+
+    # Handle conflicts between GCC formulae.
+
+    # Since GCC 4.8 libffi stuff are no longer shipped.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. fix this.
+    info.rmtree
+    # Since GCC 4.9 java properties are properly sandboxed.
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system bin/"gcc-6", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+  end
+end
+
+__END__
+--- a/gcc/jit/Make-lang.in	2015-02-03 17:19:58.000000000 +0000
++++ b/gcc/jit/Make-lang.in	2015-04-08 22:08:24.000000000 +0100
+@@ -85,8 +85,7 @@
+	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)


### PR DESCRIPTION
Eventually these will be replaced with versions using Homebrew's new naming format, but these will allow users who already had them to use them.

cc @dcwar 

Fixes #499.