### PR TITLE
tap_constants: allow formulae to have @ in name.

### DIFF
--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -1,7 +1,7 @@
 # match expressions when taps are given as ARGS, e.g. someuser/sometap
 HOMEBREW_TAP_ARGS_REGEX = %r{^([\w-]+)/(homebrew-)?([\w-]+)$}
 # match taps' formulae, e.g. someuser/sometap/someformula
-HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.]+)$}
+HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}
 # match core's formulae, e.g. homebrew/homebrew/someformula
 HOMEBREW_CORE_FORMULA_REGEX = %r{^homebrew/homebrew/([\w+-.]+)$}i
 # match taps' directory paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap


### PR DESCRIPTION
Cherry-picked from https://github.com/homebrew/brew/commit/0c44ce2a38d. This fixes `brew search` and certain other commands that went through `Formulary.from_rack`.