### PR TITLE
miniupnpc: bump to version 2.0.20170509. Fixes CVE-2017-8798

### DIFF
--- a/Library/Formula/miniupnpc.rb
+++ b/Library/Formula/miniupnpc.rb
@@ -1,15 +1,11 @@
 class Miniupnpc < Formula
   desc "UpnP IGD client library and daemon"
-  homepage "http://miniupnp.tuxfamily.org"
-  url "http://miniupnp.tuxfamily.org/files/download.php?file=miniupnpc-1.9.20150609.tar.gz"
-  sha256 "86e6ccec5b660ba6889893d1f3fca21db087c6466b1a90f495a1f87ab1cd1c36"
+  homepage "https://miniupnp.tuxfamily.org"
+  url "http://miniupnp.tuxfamily.org/files/download.php?file=miniupnpc-2.0.20170509.tar.gz"
+  sha256 "d3c368627f5cdfb66d3ebd64ca39ba54d6ff14a61966dbecb8dd296b7039f16a"
 
   bottle do
     cellar :any
-    sha256 "aecb5c84e988af64b0d3d4c3f090d033a6daaad5fe145cbec599537bcba65646" => :el_capitan
-    sha256 "b31e62a6331c82219bdf674c9d5b366f1288f203b947f446bbade154ab54025d" => :yosemite
-    sha256 "ffc0d9665983408ee86c4e5aae53c66abb22f56d700c8ceea6bd01f2a3875c75" => :mavericks
-    sha256 "ba1333c0e47f68fb0b11e945ada0aff81b69517aea4356f936fed0eaf357475e" => :mountain_lion
   end
 
   def install


### PR DESCRIPTION
also update homepage for https