### PR TITLE
gcc{6,7}: build without plugins on Leopard, too

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -116,7 +116,7 @@ class Gcc < Formula
 
     # "Building GCC with plugin support requires a host that supports
     # -fPIC, -shared, -ldl and -rdynamic."
-    args << "--enable-plugin" if MacOS.version > :tiger
+    args << "--enable-plugin" if MacOS.version > :leopard
 
     # Otherwise make fails during comparison at stage 3
     # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248

--- a/Library/Formula/gcc6.rb
+++ b/Library/Formula/gcc6.rb
@@ -123,7 +123,7 @@ class Gcc6 < Formula
 
     # "Building GCC with plugin support requires a host that supports
     # -fPIC, -shared, -ldl and -rdynamic."
-    args << "--enable-plugin" if MacOS.version > :tiger
+    args << "--enable-plugin" if MacOS.version > :leopard
 
     # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
     # format to avoid failure during the stage 3 comparison of object files.


### PR DESCRIPTION
Fixes #518.
Fixes #551.