### PR TITLE
Fix python3 postinstall

### DIFF
--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -217,7 +217,8 @@ class Python3 < Formula
     # setuptools-0.9.8-py3.3.egg
     rm_rf Dir["#{site_packages}/setuptools*"]
     rm_rf Dir["#{site_packages}/distribute*"]
-    rm_rf Dir["#{site_packages}/pip[-_.][0-9]*", "#{site_packages}/pip"]
+    rm_rf Dir["#{site_packages}/pip[-_.][0-9]*"]
+    rm_rf Dir["#{site_packages}/pip"]
 
     %w[setuptools pip wheel].each do |pkg|
       (libexec/pkg).cd do


### PR DESCRIPTION
Postinstall was failing with these errors, which caused (perhaps among other problems?) easy_install and pip3 to not be linked & added to PATH properly.

Fixes #441.
 
`vivtop-g4:~/Desktop vivlim$ brew postinstall python3
Error: wrong number of arguments (2 for 1)
Please report this bug:
    https://github.com/mistydemeo/tigerbrew/wiki/troubleshooting
/usr/local/Library/Formula/python3.rb:220:in '[]'
/usr/local/Library/Formula/python3.rb:220:in 'post_install'
/usr/local/Library/Homebrew/formula.rb:765:in 'run_post_install'
/usr/local/Library/Homebrew/cmd/postinstall.rb:3:in 'postinstall'
/usr/local/Library/Homebrew/cmd/postinstall.rb:3:in 'each'
/usr/local/Library/Homebrew/cmd/postinstall.rb:3:in 'postinstall'
/usr/local/Library/brew.rb:143:in 'send'
/usr/local/Library/brew.rb:143
vivtop-g4:~/Desktop vivlim$`