### PR TITLE
WIP qt: add Carbon support on Tiger

### DIFF
--- a/Library/Formula/qt.rb
+++ b/Library/Formula/qt.rb
@@ -33,7 +33,6 @@ class Qt < Formula
   option "with-docs", "Build documentation"
   option "with-developer", "Build and link with developer options"
 
-  depends_on :macos => :leopard
   depends_on "d-bus" => :optional
   depends_on "mysql" => :optional
   depends_on "postgresql" => :optional
@@ -49,7 +48,14 @@ class Qt < Formula
             "-qt-libtiff", "-qt-libpng", "-qt-libjpeg",
             "-confirm-license", "-opensource",
             "-nomake", "demos", "-nomake", "examples",
-            "-cocoa", "-fast", "-release"]
+            "-fast", "-release"]
+
+    # Cocoa build requires 10.5 or newer
+    if MacOS.version < :leopard
+      args << "-carbon"
+    else
+      args << "-cocoa"
+    end
 
     if ENV.compiler == :clang
       args << "-platform"


### PR DESCRIPTION
cc @nekonoir - this is currently broken, but I'm looking at it.

Here are the logs: https://gist.github.com/acb1f77094ade2e490bcb5c360b31f1b

The error is this:

```
/usr/local/bin/g++-4.2 -c -o msvc_vcproj.o -arch ppc -pipe -DQMAKE_OPENSOURCE_EDITION -fconstant-cfstrings -g -I. -Igenerators -Igenerators/unix -Igenerators/win32 -Igenerators/mac -Igenerators/symbian -Igenerators/integrity -I/private/tmp/qt20180410-379-jys4wh/qt-everywhere-opensource-src-4.8.7/include -I/private/tmp/qt20180410-379-jys4wh/qt-everywhere-opensource-src-4.8.7/include/QtCore -I/private/tmp/qt20180410-379-jys4wh/qt-everywhere-opensource-src-4.8.7/src/corelib/global -I/private/tmp/qt20180410-379-jys4wh/qt-everywhere-opensource-src-4.8.7/src/corelib/xml -I/private/tmp/qt20180410-379-jys4wh/qt-everywhere-opensource-src-4.8.7/tools/shared -DQT_NO_PCRE -DQT_BUILD_QMAKE -DQT_BOOTSTRAPPED -DQLIBRARYINFO_EPOCROOT -DQT_NO_TEXTCODEC -DQT_NO_UNICODETABLES -DQT_NO_COMPONENT -DQT_NO_STL -DQT_NO_COMPRESS -I/private/tmp/qt20180410-379-jys4wh/qt-everywhere-opensource-src-4.8.7/mkspecs/macx-g++ -DHAVE_QCONFIG_CPP -DQT_NO_THREAD -DQT_NO_QOBJECT -DQT_NO_GEOM_VARIANT -DQT_NO_DEPRECATED  generators/win32/msvc_vcproj.cpp
In file included from /System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/DriverServices.h:32,
                 from /System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:125,
                 from /System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:21,
                 from /System/Library/Frameworks/ApplicationServices.framework/Headers/ApplicationServices.h:20,
                 from generators/mac/pbuilder_pbx.cpp:56:
/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/MachineExceptions.h:115: error: expected ‘;’ before ‘unsigned’
```