### PR TITLE
Fix vendored Ruby script on G3 (again)

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -97,7 +97,12 @@ fetch() {
     trap - SIGINT
   fi
 
-  cpu_family="$(sysctl -n hw.cpufamily)"
+  if [[ "$(sysctl -n hw.cputype)" = "18" ]]; then
+    cpu_family="$(sysctl -n hw.cpusubtype)"
+  else
+    cpu_family="$(sysctl -n hw.cpufamily)"
+  fi
+
   if [[ -x "$(which shasum)" ]]
   then
     sha="$(shasum -a 256 "$CACHED_LOCATION" | cut -d' ' -f1)"

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -115,7 +115,7 @@ fetch() {
     sha="$(ruby -e "require 'digest/sha2'; digest = Digest::SHA256.new; File.open('$CACHED_LOCATION', 'rb') { |f| digest.update(f.read) }; puts digest.hexdigest")"
   # Pure Perl SHA256 implementation
   else
-    sha="$(VENDOR_DIR/sha256 "$CACHED_LOCATION")"
+    sha="$($VENDOR_DIR/sha256 "$CACHED_LOCATION")"
   fi
 
   if [[ "$sha" != "$VENDOR_SHA" ]]


### PR DESCRIPTION
Fixes #593.

I was checking the CPU model incorrectly for PPC, which broke my attempt at guarding G3 and G4 from using Ruby 1.8.2's sha2. This fixes that check, and also fixes another bug that was hidden by this other bug. It's bugs all the way down!

cc @valtteri 