### PR TITLE
Whois 5.3.2

### DIFF
--- a/Library/Formula/libidn2.rb
+++ b/Library/Formula/libidn2.rb
@@ -1,0 +1,52 @@
+class Libidn2 < Formula
+  desc "International domain name library (IDNA2008, Punycode and TR46)"
+  homepage "https://www.gnu.org/software/libidn/#libidn2"
+  url "https://ftp.gnu.org/gnu/libidn/libidn2-2.0.5.tar.gz"
+  mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.0.5.tar.gz"
+  sha256 "53f69170886f1fa6fa5b332439c7a77a7d22626a82ef17e2c1224858bb4ca2b8"
+
+  bottle do
+    sha256 "bed41502a268a78e11ee1ae8fd055703445970304dc918c0ef91acdf88128fc2" => :mojave
+    sha256 "5a772d41138cf7d83e338011ae9e6c943206a6feef0f7ce6f4eb31527c96e991" => :high_sierra
+    sha256 "ac2891ed72664c65c95398d51b8350e76f41236899e3d6d346ffa0fad4ff00c1" => :sierra
+    sha256 "3a5558ab5f48f68b8d3f855343146a879b1b1a02811e6a6d5792e7da96bcd56b" => :el_capitan
+  end
+
+  head do
+    url "https://gitlab.com/libidn/libidn2.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gengetopt" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "libunistring"
+
+  def install
+    if build.head?
+      ENV["GEM_HOME"] = buildpath/"gem_home"
+      system "gem", "install", "ronn"
+      ENV.prepend_path "PATH", buildpath/"gem_home/bin"
+      system "./bootstrap"
+    end
+
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}",
+                          "--with-packager=Homebrew"
+    system "make", "install"
+  end
+
+  test do
+    ENV.delete("LC_CTYPE")
+    ENV["CHARSET"] = "UTF-8"
+    output = shell_output("#{bin}/idn2 räksmörgås.se")
+    assert_equal "xn--rksmrgs-5wao1o.se", output.chomp
+    output = shell_output("#{bin}/idn2 blåbærgrød.no")
+    assert_equal "xn--blbrgrd-fxak7p.no", output.chomp
+  end
+end

--- a/Library/Formula/whois.rb
+++ b/Library/Formula/whois.rb
@@ -1,0 +1,40 @@
+class Whois < Formula
+  desc "Lookup tool for domain names and other internet resources"
+  homepage "https://packages.debian.org/sid/whois"
+  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/w/whois/whois_5.3.2.tar.xz"
+  mirror "https://mirrorservice.org/sites/ftp.debian.org/debian/pool/main/w/whois/whois_5.3.2.tar.xz"
+  sha256 "79714ba89172bca08a2443f59885daa4af0c5f8d6a49bc9e7f2a83559a286354"
+  head "https://github.com/rfc1036/whois.git"
+
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "feea8f6fc296db981e7eb39bedbf9d6647184d79fb5b926a5f86cdbaa8974da2" => :mojave
+    sha256 "a44e35933c977f5510daea2b8486e7843edf26551b077b718508471902653b06" => :high_sierra
+    sha256 "e6ca1417a99c060555de387381139d1ba3f0181bf92f19ae30d3a23558f6616c" => :sierra
+    sha256 "d40af5a93e8a0b7daa1ebb5de3a25a00cd834283c18f26957e33aec3329ef8b3" => :el_capitan
+  end
+
+  option "with-libidn2", "Compile with IDN support"
+
+  depends_on "pkg-config" => :build if build.with? "libidn2"
+  depends_on "libidn2" => :optional
+
+  def install
+    ENV.append "LDFLAGS", "-L/usr/lib -liconv"
+
+    system "make", "whois", "HAVE_ICONV=1"
+    bin.install "whois"
+    man1.install "whois.1"
+    man5.install "whois.conf.5"
+  end
+
+  def caveats; <<~EOS
+    Debian whois has been installed as `whois` and may shadow the
+    system binary of the same name.
+  EOS
+  end
+
+  test do
+    system "#{bin}/whois", "brew.sh"
+  end
+end

--- a/Library/Formula/whois.rb
+++ b/Library/Formula/whois.rb
@@ -20,6 +20,9 @@ class Whois < Formula
   depends_on "libidn2" => :optional
 
   def install
+    # autodie was not shipped with the system perl 5.8
+    inreplace "make_version_h.pl", "use autodie;", "" if MacOS.version < :snow_leopard
+
     ENV.append "LDFLAGS", "-L/usr/lib -liconv"
 
     system "make", "whois", "HAVE_ICONV=1"


### PR DESCRIPTION
Whois 5.3.2 and libidn2. Note that libidn2 does not currently build successfully due to test failures in libunistring (test-localename and test-fgetc). Which is particularly annoying after a long build.