### PR TITLE
Fix dpkg links

### DIFF
--- a/Library/Formula/dpkg.rb
+++ b/Library/Formula/dpkg.rb
@@ -1,8 +1,8 @@
 class Dpkg < Formula
   desc "Debian package management system"
   homepage "https://wiki.debian.org/Teams/Dpkg"
-  url "https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_1.18.2.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dpkg/dpkg_1.18.2.tar.xz"
+  url "https://mirrors.kernel.org/debian/pool/main/d/dpkg/dpkg_1.18.24.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dpkg/dpkg_1.18.24.tar.xz"
   sha256 "11484f2a73d027d696e720a60380db71978bb5c06cd88fe30c291e069ac457a4"
 
   bottle do


### PR DESCRIPTION
Currently, tigerbrew attempts to download a version of dpkg that doesn't exist. This fixes the links to reference a version that does.