### PR TITLE
update cmake to 3.13.2

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -1,8 +1,8 @@
 class Cmake < Formula
   desc "Cross-platform make"
   homepage "http://www.cmake.org/"
-  url "https://cmake.org/files/v3.6/cmake-3.6.3.tar.gz"
-  sha256 "7d73ee4fae572eb2d7cd3feb48971aea903bb30a20ea5ae8b4da826d8ccad5fe"
+  url "https://cmake.org/files/v3.13/cmake-3.13.2.tar.gz"
+  sha256 "c925e7d2c5ba511a69f43543ed7b4182a7d446c274c7480d0e42cd933076ae25"
 
   head "https://cmake.org/cmake.git"
 
@@ -13,15 +13,18 @@ class Cmake < Formula
     sha256 "16f91ff94d784b2120e248650a7a99c5974d325900f94ead54392b2fdaabeb8e" => :yosemite
   end
 
-  devel do
-    url "https://cmake.org/files/v3.7/cmake-3.7.0-rc3.tar.gz"
-    sha256 "654a5f0400c88fb07cf7e882e6254d17f248663b51a85ff07d79f7ee7b4795bd"
-  end
+#  devel do
+#    url "https://cmake.org/files/v3.7/cmake-3.7.0-rc3.tar.gz"
+#    sha256 "654a5f0400c88fb07cf7e882e6254d17f248663b51a85ff07d79f7ee7b4795bd"
+#  end
 
   option "without-docs", "Don't build man pages"
   option "with-completion", "Install Bash completion (Has potential problems with system bash)"
 
   depends_on :python => :build if MacOS.version <= :snow_leopard && build.with?("docs")
+
+  needs :cxx11
+  patch :DATA
 
   # The `with-qt` GUI option was removed due to circular dependencies if
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
@@ -139,3 +142,109 @@ class Cmake < Formula
     system "#{bin}/cmake", "."
   end
 end
+
+
+__END__
+diff -u -r cmake-3.13.2/Source/CMakeLists.txt cmake-3.13.2-patched/Source/CMakeLists.txt
+--- cmake-3.13.2/Source/CMakeLists.txt	2018-12-13 12:57:40.000000000 +0100
++++ cmake-3.13.2-patched/Source/CMakeLists.txt	2018-12-16 14:40:06.000000000 +0100
+@@ -793,7 +793,7 @@
+ 
+ # On Apple we need CoreFoundation
+ if(APPLE)
+-  target_link_libraries(CMakeLib "-framework CoreFoundation")
++  target_link_libraries(CMakeLib "-framework CoreFoundation -framework ApplicationServices")
+ endif()
+ 
+ if(WIN32 AND NOT UNIX)
+diff -u -r cmake-3.13.2/Utilities/cmlibuv/src/unix/core.c cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/core.c
+--- cmake-3.13.2/Utilities/cmlibuv/src/unix/core.c	2018-12-13 12:57:42.000000000 +0100
++++ cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/core.c	2018-12-16 14:41:49.000000000 +0100
+@@ -1293,8 +1293,7 @@
+   if (name == NULL)
+     return UV_EINVAL;
+ 
+-  if (unsetenv(name) != 0)
+-    return UV__ERR(errno);
++  unsetenv(name);
+ 
+   return 0;
+ }
+diff -u -r cmake-3.13.2/Utilities/cmlibuv/src/unix/darwin-proctitle.c cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/darwin-proctitle.c
+--- cmake-3.13.2/Utilities/cmlibuv/src/unix/darwin-proctitle.c	2018-12-13 12:57:42.000000000 +0100
++++ cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/darwin-proctitle.c	2018-12-16 16:01:36.000000000 +0100
+@@ -29,6 +29,9 @@
+ #include <TargetConditionals.h>
+ 
+ #if !TARGET_OS_IPHONE
++#undef TCP_NODELAY
++#undef TCP_MAXSEG
++#undef TCP_KEEPALIVE
+ # include <CoreFoundation/CoreFoundation.h>
+ # include <ApplicationServices/ApplicationServices.h>
+ #endif
+diff -u -r cmake-3.13.2/Utilities/cmlibuv/src/unix/fs.c cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/fs.c
+--- cmake-3.13.2/Utilities/cmlibuv/src/unix/fs.c	2018-12-13 12:57:42.000000000 +0100
++++ cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/fs.c	2018-12-16 14:40:06.000000000 +0100
+@@ -60,7 +60,7 @@
+ # include <sys/sendfile.h>
+ #endif
+ 
+-#if defined(__APPLE__)
++#if 0 && defined(__APPLE__)
+ # include <copyfile.h>
+ #elif defined(__linux__) && !defined(FICLONE)
+ # include <sys/ioctl.h>
+@@ -674,7 +674,7 @@
+ 
+     return -1;
+   }
+-#elif defined(__APPLE__)           || \
++#elif 0 && defined(__APPLE__)           || \
+       defined(__DragonFly__)       || \
+       defined(__FreeBSD__)         || \
+       defined(__FreeBSD_kernel__)
+@@ -825,7 +825,7 @@
+ }
+ 
+ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
+-#if defined(__APPLE__) && !TARGET_OS_IPHONE
++#if 0 && defined(__APPLE__) && !TARGET_OS_IPHONE
+   /* On macOS, use the native copyfile(3). */
+   copyfile_flags_t flags;
+ 
+@@ -991,8 +991,8 @@
+   dst->st_mtim.tv_nsec = src->st_mtimespec.tv_nsec;
+   dst->st_ctim.tv_sec = src->st_ctimespec.tv_sec;
+   dst->st_ctim.tv_nsec = src->st_ctimespec.tv_nsec;
+-  dst->st_birthtim.tv_sec = src->st_birthtimespec.tv_sec;
+-  dst->st_birthtim.tv_nsec = src->st_birthtimespec.tv_nsec;
++  dst->st_birthtim.tv_sec = src->st_ctimespec.tv_sec;
++  dst->st_birthtim.tv_nsec = src->st_ctimespec.tv_nsec;
+   dst->st_flags = src->st_flags;
+   dst->st_gen = src->st_gen;
+ #elif defined(__ANDROID__)
+diff -u -r cmake-3.13.2/Utilities/cmlibuv/src/unix/fsevents.c cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/fsevents.c
+--- cmake-3.13.2/Utilities/cmlibuv/src/unix/fsevents.c	2018-12-13 12:57:42.000000000 +0100
++++ cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/fsevents.c	2018-12-16 14:40:06.000000000 +0100
+@@ -21,7 +21,7 @@
+ #include "uv.h"
+ #include "internal.h"
+ 
+-#if TARGET_OS_IPHONE
++#if 1 || TARGET_OS_IPHONE
+ 
+ /* iOS (currently) doesn't provide the FSEvents-API (nor CoreServices) */
+ 
+diff -u -r cmake-3.13.2/Utilities/cmlibuv/src/unix/tty.c cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/tty.c
+--- cmake-3.13.2/Utilities/cmlibuv/src/unix/tty.c	2018-12-13 12:57:42.000000000 +0100
++++ cmake-3.13.2-patched/Utilities/cmlibuv/src/unix/tty.c	2018-12-16 14:40:06.000000000 +0100
+@@ -44,7 +44,7 @@
+   int dummy;
+ 
+   result = ioctl(fd, TIOCGPTN, &dummy) != 0;
+-#elif defined(__APPLE__)
++#elif 0 && defined(__APPLE__)
+   char dummy[256];
+ 
+   result = ioctl(fd, TIOCPTYGNAME, &dummy) != 0;


### PR DESCRIPTION
The previously provided cmake 3.6.3 is over two years old now, so here's an upgrade.

The good news:
* It seems to work.

The bad news:
* It now needs a C++11 compiler.
* It needed some patches, disabling the use of some features of more modern macOS incarnation, that the current cmake source code just assumes to be there.
