### PR TITLE
Fix lua

### DIFF
--- a/Library/Formula/lua.rb
+++ b/Library/Formula/lua.rb
@@ -39,7 +39,7 @@ class Lua < Formula
   # sigaction provided by posix signalling power patch
   if build.with? "sigaction"
     patch do
-      url "http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/lua/lua-5.2.3-sig_catch.patch"
       sha256 "f2e77f73791c08169573658caa3c97ba8b574c870a0a165972ddfbddb948c164"
     end
   end


### PR DESCRIPTION
I just found out (Leopard 10.5.2) that lua doesn't get installed because the patch doesn't exist anymore in the [website](http://lua-users.org/files/wiki_insecure/power_patches/5.2/lua-5.2.3-sig_catch.patch).

This should fix it.  I don't know if lua-5.3 is also affected, probably is.