### PR TITLE
Fix ruby 1.8.2 detection to skip ppc7450 cpu

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -109,7 +109,7 @@ fetch() {
   elif [[ -x "$(which sha256sum)" ]]
   then
     sha="$(sha256sum "$CACHED_LOCATION" | cut -d' ' -f1)"
-  # Ruby 1.8.2's vendored Ruby has broken SHA256 calculation pre-G4e
+  # Ruby 1.8.2's vendored Ruby has broken SHA256 calculation on several PowerPC CPUs
   elif [[ -x "$(which ruby)" && "$cpu_family" != 9 && "$cpu_family" != 10 && "$cpu_family" != 11 ]]
   then
     sha="$(ruby -e "require 'digest/sha2'; digest = Digest::SHA256.new; File.open('$CACHED_LOCATION', 'rb') { |f| digest.update(f.read) }; puts digest.hexdigest")"

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -110,7 +110,7 @@ fetch() {
   then
     sha="$(sha256sum "$CACHED_LOCATION" | cut -d' ' -f1)"
   # Ruby 1.8.2's vendored Ruby has broken SHA256 calculation pre-G4e
-  elif [[ -x "$(which ruby)" && "$cpu_family" != 9 && "$cpu_family" != 10 ]]
+  elif [[ -x "$(which ruby)" && "$cpu_family" != 9 && "$cpu_family" != 10 && "$cpu_family" != 11 ]]
   then
     sha="$(ruby -e "require 'digest/sha2'; digest = Digest::SHA256.new; File.open('$CACHED_LOCATION', 'rb') { |f| digest.update(f.read) }; puts digest.hexdigest")"
   # Pure Perl SHA256 implementation


### PR DESCRIPTION
This is added to skip Ruby 1.8.2 on OSX 10.4 running on PPC7450 (Mac mini G4)
on Mac mini G4, the cpu_type is 18 but cpu_family is 11, and will cause failure as Ruby buggy sha256 logic will be used.

