### PR TITLE
git: always use the Homebrew curl

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -24,7 +24,6 @@ class Git < Formula
   option "with-blk-sha1", "Compile with the block-optimized SHA1 implementation"
   option "without-completions", "Disable bash/zsh completions from 'contrib' directory"
   option "with-brewed-openssl", "Build with Homebrew OpenSSL instead of the system version" if MacOS.version > :snow_leopard
-  option "with-brewed-curl", "Use Homebrew's version of cURL library" if MacOS.version > :snow_leopard
   option "with-brewed-svn", "Use Homebrew's version of SVN"
   option "with-persistent-https", "Build git-remote-persistent-https from 'contrib' directory"
 
@@ -40,7 +39,7 @@ class Git < Formula
   depends_on "pcre" => :optional
   depends_on "gettext" => :optional
   depends_on "openssl" if MacOS.version < :snow_leopard || build.with?("brewed-openssl")
-  depends_on "curl" if MacOS.version < :snow_leopard || build.with?("brewed-curl")
+  depends_on "curl"
   depends_on "go" => :build if build.with? "persistent-https"
   # Trigger an install of swig before subversion, as the "swig" doesn't get pulled in otherwise
   # See https://github.com/Homebrew/homebrew/issues/34554


### PR DESCRIPTION
This is increasingly necessary on older OSs!

cc @sgirard - thanks for flagging this.

Fixes #637.