### PR TITLE
Update tig formula to 2.2

### DIFF
--- a/Library/Formula/tig.rb
+++ b/Library/Formula/tig.rb
@@ -1,20 +1,14 @@
 class Tig < Formula
   desc "Text interface for Git repositories"
   homepage "http://jonas.nitro.dk/tig/"
-  url "http://jonas.nitro.dk/tig/releases/tig-2.1.1.tar.gz"
-  sha256 "50c5179fd564b829b6b2cec087e66f10cf8799601de19350df0772ae77e4852f"
+  url "http://jonas.nitro.dk/tig/releases/tig-2.2.tar.gz"
+  sha256 "8f5213d3abb45ca9a79810b8d2a2a12d941112bc4682bcfa91f34db74942754c"
   head "https://github.com/jonas/tig.git"
   revision 1
 
   stable do
-    url "http://jonas.nitro.dk/tig/releases/tig-2.1.1.tar.gz"
-    sha256 "50c5179fd564b829b6b2cec087e66f10cf8799601de19350df0772ae77e4852f"
-
-    # Merged in HEAD; remove in next stable release
-    patch do
-      url "https://github.com/jonas/tig/commit/91912eb97da4f6907015dab41ef9bba315730854.diff"
-      sha256 "263e86b25f788eb158bdd667e112bc839debe9e3fe788cbc39cc9654b65b6c8a"
-    end
+    url "http://jonas.nitro.dk/tig/releases/tig-2.2.tar.gz"
+    sha256 "8f5213d3abb45ca9a79810b8d2a2a12d941112bc4682bcfa91f34db74942754c"
   end
 
   bottle do


### PR DESCRIPTION
I updated the `tig` formula to 2.2, and removed the patch, which was merged into the stable branch. The patch wasn't working anyways, as the SHA changed.

Tested on my iBook G4 running 10.4.11