### PR TITLE
Update url in fortune.rb

### DIFF
--- a/Library/Formula/fortune.rb
+++ b/Library/Formula/fortune.rb
@@ -1,7 +1,7 @@
 class Fortune < Formula
   desc "Infamous electronic fortune-cookie generator"
   homepage "http://ftp.ibiblio.org/pub/linux/games/amusements/fortune/!INDEX.html"
-  url "http://ftp.ibiblio.org/pub/linux/games/amusements/fortune/fortune-mod-9708.tar.gz"
+  url "ftp://ftp.ibiblio.org/pub/linux/games/amusements/fortune/fortune-mod-9708.tar.gz"
   sha256 "1a98a6fd42ef23c8aec9e4a368afb40b6b0ddfb67b5b383ad82a7b78d8e0602a"
 
   bottle do


### PR DESCRIPTION
The source download requires having an FTP URL instead of an HTTP URL to fetch the file.