### PR TITLE
Update url for icu4c.rb

### DIFF
--- a/Library/Formula/icu4c.rb
+++ b/Library/Formula/icu4c.rb
@@ -2,8 +2,7 @@ class Icu4c < Formula
   desc "C/C++ and Java libraries for Unicode and globalization"
   homepage "http://site.icu-project.org/"
   head "https://ssl.icu-project.org/repos/icu/icu/trunk/", :using => :svn
-  url "https://ssl.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.tgz"
-  mirror "https://fossies.org/linux/misc/icu4c-55_1-src.tgz"
+  url "https://downloads.sourceforge.net/project/icu/ICU4C/55.1/icu4c-55_1-src.tgz"
   version "55.1"
   sha256 "e16b22cbefdd354bec114541f7849a12f8fc2015320ca5282ee4fd787571457b"
 


### PR DESCRIPTION
Source download is now on SourceForge and mirror listed is no longer valid. Updated to current URL.