### PR TITLE
Update URL for libmikmod.rb

### DIFF
--- a/Library/Formula/libmikmod.rb
+++ b/Library/Formula/libmikmod.rb
@@ -1,7 +1,7 @@
 class Libmikmod < Formula
   desc "Portable sound library"
   homepage "http://mikmod.shlomifish.org"
-  url "https://downloads.sourceforge.net/project/mikmod/libmikmod/3.3.7/libmikmod-3.3.7.tar.gz"
+  url "https://downloads.sourceforge.net/project/mikmod/outdated-versions/libmikmod/3.3.7/libmikmod-3.3.7.tar.gz"
   sha256 "4cf41040a9af99cb960580210ba900c0a519f73ab97b503c780e82428b9bd9a2"
 
   bottle do


### PR DESCRIPTION
Updated file path for source repository for libmikmod, as it was moved under an outdated_versions folder in the path