### PR TITLE
libtorrent: fix building with gcc-7.3.0

### DIFF
--- a/Library/Formula/libtorrent.rb
+++ b/Library/Formula/libtorrent.rb
@@ -46,7 +46,8 @@ class Libtorrent < Formula
                           "--disable-debug",
                           "--disable-dependency-tracking",
                           "--with-kqueue",
-                          "--enable-ipv6"
+                          "--enable-ipv6",
+                          "--disable-instrumentation"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Instrumentation generates the following missing symbols on g4:
undefined reference to __sync_add_and_fetch_8

See also https://github.com/rakshasa/rtorrent/issues/156.