### PR TITLE
ninja: Fix dependency URL

### DIFF
--- a/Library/Formula/ninja.rb
+++ b/Library/Formula/ninja.rb
@@ -18,7 +18,7 @@ class Ninja < Formula
   option "without-tests", "Run build-time tests"
 
   resource "gtest" do
-    url "https://googletest.googlecode.com/files/gtest-1.7.0.zip"
+    url "https://web.archive.org/web/20160617081653if_/http://googletest.googlecode.com/files/gtest-1.7.0.zip"
     sha256 "247ca18dd83f53deb1328be17e4b1be31514cedfc1e3424f672bf11fd7e0d60d"
   end
 


### PR DESCRIPTION
`gtest` is no longer available at the old URL.

There are a couple of alternatives including Googles own GitHub page however the hash isn't matching.

```
https://github.com/google/googletest/archive/release-1.7.0.zip

https://web.archive.org/web/20160617081653if_/http://googletest.googlecode.com/files/gtest-1.7.0.zip
https://src.fedoraproject.org/lookaside/pkgs/gtest/gtest-1.7.0.zip/2d6ec8ccdf5c46b05ba54a9fd1d130d7/gtest-1.7.0.zip
```