### PR TITLE
openssl: fix urls

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -1,9 +1,9 @@
 class Openssl < Formula
   desc "SSL/TLS cryptography library"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-1.0.2j.tar.gz"
-  mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2j.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2j.tar.gz"
+  url "https://www.openssl.org/source/old/1.0.2/openssl-1.0.2j.tar.gz"
+  mirror "http://artfiles.org/openssl.org/source/old/1.0.2/openssl-1.0.2j.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/old/1.0.2/openssl-1.0.2j.tar.gz"
   sha256 "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431"
 
   bottle do


### PR DESCRIPTION
the urls in the openssl formula are outdated and return 404