### PR TITLE
sdl2_gfx: Disable MMX on PPC

### DIFF
--- a/Library/Formula/sdl2_gfx.rb
+++ b/Library/Formula/sdl2_gfx.rb
@@ -10,9 +10,12 @@ class Sdl2Gfx < Formula
 
   def install
     ENV.universal_binary if build.universal?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--disable-sdltest"
+    args = %W[--disable-dependency-tracking
+              --prefix=#{prefix}
+              --disable-sdltest]
+    args << "--disable-mmx" unless Hardware::CPU.type == :intel
+
+    system "./configure", *args
     system "make", "install"
   end
 end


### PR DESCRIPTION
Thanks so much for making tigerbrew!

I ran into a build error with an eMac running Tiger:

```
$ brew install sdl2_gfx
...
config.status: executing libtool commands
config.status: executing depfiles commands

Options summary:
* --enable-mmx: yes
==> make install
/bin/sh ./libtool --tag=CC   --mode=compile /usr/bin/gcc-4.0 -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DPACKAGE=\"SDL2_gfx\" -DVERSION=\"1.0.0\" -DSIZEOF_LONG=4 -I.   -F/usr/local/Frameworks  -Os -w -pipe -mcpu=7450 -faltivec -mmacosx-version-min=10.4 -O -DUSE_MMX -mmmx -D_THREAD_SAFE -I/usr/local/include/SDL2 -c -o SDL2_framerate.lo SDL2_framerate.c
libtool: compile:  /usr/bin/gcc-4.0 -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DPACKAGE=\"SDL2_gfx\" -DVERSION=\"1.0.0\" -DSIZEOF_LONG=4 -I. -F/usr/local/Frameworks -Os -w -pipe -mcpu=7450 -faltivec -mmacosx-version-min=10.4 -O -DUSE_MMX -mmmx -D_THREAD_SAFE -I/usr/local/include/SDL2 -c SDL2_framerate.c  -fno-common -DPIC -o .libs/SDL2_framerate.o
cc1: error: invalid option ‘mmx’
```

I noticed that the `sdl_gfx` formula [already accounted for this](https://github.com/mistydemeo/tigerbrew/blob/e5789812d99596b9817ebb5d75672fd29034cfa9/Library/Formula/sdl_gfx.rb#L25), so I just copied what was done there.

Tested locally with `brew install --build-from-source ./sdl2_gfx.rb`.

Cheers!