### PR TITLE
ecl: fix source URL

### DIFF
--- a/Library/Formula/ecl.rb
+++ b/Library/Formula/ecl.rb
@@ -1,7 +1,7 @@
 class Ecl < Formula
   desc "Embeddable Common Lisp"
   homepage "https://common-lisp.net/project/ecl/"
-  url "https://common-lisp.net/project/ecl/files/ecl-16.0.0.tgz"
+  url "https://common-lisp.net/project/ecl/static/files/release/ecl-16.0.0.tgz"
   sha256 "343ed4c3e4906562757a6039b85ce16d33dd5e8001d74004936795983e3af033"
 
   head "https://gitlab.com/embeddable-common-lisp/ecl.git"


### PR DESCRIPTION
Thanks again for making tigerbrew!

This PR fixes a broken source URL for ecl 16.

```
$ brew install --build-bottle ecl
==> Downloading https://common-lisp.net/project/ecl/files/ecl-16.0.0.tgz
/usr/local/Library/Homebrew/vendor/portable-curl/current/bin/curl -fLA Homebrew/0.9.5 (Macintosh; powerpc Mac OS X 10.4.11) curl/7.58.0 https://common-lisp.net/project/ecl/files/ecl-16.0.0.tgz -C 0 -o /Users/cell/Library/Caches/Homebrew/ecl-16.0.0.tgz.incomplete
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "ecl"
Download failed: https://common-lisp.net/project/ecl/files/ecl-16.0.0.tgz
```

