### PR TITLE
graphviz: replace 404'ed source URL

### DIFF
--- a/Library/Formula/graphviz.rb
+++ b/Library/Formula/graphviz.rb
@@ -1,7 +1,7 @@
 class Graphviz < Formula
   desc "Graph visualization software from AT&T and Bell Labs"
   homepage "http://graphviz.org/"
-  url "http://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.38.0.tar.gz"
+  url "http://ftp.osuosl.org/pub/blfs/conglomeration/graphviz/graphviz-2.38.0.tar.gz"
   sha256 "81aa238d9d4a010afa73a9d2a704fc3221c731e1e06577c2ab3496bdef67859e"
 
   head do


### PR DESCRIPTION
This PR fixes a broken URL for graphviz sources.

The official graphviz sources have been moved to a new location, and no longer go back as far as 2.38.

This PR switches to using the Open Source Lab mirror, which goes back to 2.38 and also supports plain HTTP.