### PR TITLE
Update dcraw.rb

### DIFF
--- a/Library/Formula/dcraw.rb
+++ b/Library/Formula/dcraw.rb
@@ -1,7 +1,7 @@
 class Dcraw < Formula
   desc "Digital camera RAW photo decoding software"
   homepage "https://www.cybercom.net/~dcoffin/dcraw/"
-  url "https://www.cybercom.net/~dcoffin/dcraw/archive/dcraw-9.26.0.tar.gz"
+  url "https://mirror.pnl.gov/macports/distfiles/dcraw/dcraw-9.26.0.tar.gz"
   sha256 "85791d529e037ad5ca09770900ae975e2e4cc1587ca1da4192ca072cbbfafba3"
 
   bottle do


### PR DESCRIPTION
Fix Doesn't Install Issue.
Checking OS X 10.7.5(11G63) on iMac 5,1 and Mac Pro 2,1.