### PR TITLE
Point links in contribution guide at Tigerbrew

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 ## Reporting Bugs
 First, please run `brew update` and `brew doctor`.
 
-Second, read the [Troubleshooting Checklist](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting).
+Second, read the [Troubleshooting Checklist](https://github.com/mistydemeo/tigerbrew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting).
 
 **If you don't read these it will take us far longer to help you with your problem.**
 
@@ -12,11 +12,11 @@ Please report security issues to security@brew.sh.
 ## Contributing
 Please read:
 
-* [Code of Conduct](https://github.com/Homebrew/homebrew/blob/master/CODEOFCONDUCT.md#code-of-conduct)
-* [Formula Cookbook](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md#formula-cookbook)
-* [Acceptable Formulae](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Acceptable-Formulae.md#acceptable-formulae)
+* [Code of Conduct](https://github.com/mistydemeo/tigerbrew/blob/master/CODEOFCONDUCT.md#code-of-conduct)
+* [Formula Cookbook](https://github.com/mistydemeo/tigerbrew/blob/master/share/doc/homebrew/Formula-Cookbook.md)
+* [Acceptable Formulae](https://github.com/mistydemeo/tigerbrew/blob/master/share/doc/homebrew/Acceptable-Formulae.md#acceptable-formulae)
 * [Ruby Style Guide](https://github.com/styleguide/ruby)
-* [How To Open a Homebrew Pull Request (and get it merged)](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md#how-to-open-a-homebrew-pull-request-and-get-it-merged)
+* [How To Open a Tigerbrew Pull Request (and get it merged)](https://github.com/mistydemeo/tigerbrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md#how-to-open-a-tigerbrew-pull-request-and-get-it-merged)
 
 Tigerbrew guidelines
 --------------------


### PR DESCRIPTION
These links went to the upstream Homebrew project, and some of them are no longer at that URL. This updates them to point at this project’s copy.