### PR TITLE
Un-quieten vendor installs

### DIFF
--- a/Library/Homebrew/cmd/vendor-curl.sh
+++ b/Library/Homebrew/cmd/vendor-curl.sh
@@ -15,7 +15,7 @@ setup-curl-path() {
 
       if [[ $(readlink "$vendor_curl_current_version") != "$(<"$vendor_dir/portable-curl-version")" ]]
       then
-        if ! brew vendor-install curl --quiet
+        if ! brew vendor-install curl
         then
           onoe "Failed to upgrade vendor Curl."
         fi
@@ -30,7 +30,7 @@ setup-curl-path() {
 
       if [[ "$HOMEBREW_OSX_VERSION_NUMERIC" -lt "100900" || ! -x "$HOMEBREW_CURL" ]]
       then
-        brew vendor-install curl --quiet
+        brew vendor-install curl
         if [[ ! -x "$vendor_curl_path" ]]
         then
           odie "Failed to install vendor Curl."

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -21,7 +21,7 @@ setup-ruby-path() {
 
       if [[ $(readlink "$vendor_ruby_current_version") != "$(<"$vendor_dir/portable-ruby-version")" ]]
       then
-        if ! brew vendor-install ruby --quiet
+        if ! brew vendor-install ruby
         then
           onoe "Failed to upgrade vendor Ruby."
         fi
@@ -43,7 +43,7 @@ setup-ruby-path() {
 
       if [[ "$ruby_version_major" != "2" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
       then
-        brew vendor-install ruby --quiet
+        brew vendor-install ruby
         if [[ ! -x "$vendor_ruby_path" ]]
         then
           odie "Failed to install vendor Ruby."


### PR DESCRIPTION
The vendor installation and subsequent checksum verification of curl and ruby takes quite a long time on older machines; somewhere in the order of an hour on my PowerBook G4 Titanium’s 867 MHz CPU and ailing disk drive.

For that entire time, unless you’ve set Tigerbrew to verbose, you’re given _absolutely no_ output until the “real” Ruby infrastructure takes over, which is easy to mistake for nothing actually happening!

For that reason, and having talked to @mistydemeo about it in person, I’d propose removing the `--quiet` flags from these steps, so that `vendor-install` _at least_ goes and prints that it’s downloading stuff.

This way there’s some feedback almost immediately that it’s understandable could take some time, which IMO makes for a better first-launch experience on older machines. 👍🏼