### PR TITLE
Trim searchable taps

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -79,9 +79,7 @@ module Homebrew
     raise SEARCH_ERROR_QUEUE.pop unless SEARCH_ERROR_QUEUE.empty?
   end
 
-  SEARCHABLE_TAPS = OFFICIAL_TAPS.map { |tap| ["Homebrew", tap] } + [
-    %w[Caskroom cask]
-  ]
+  SEARCHABLE_TAPS = OFFICIAL_TAPS.map { |tap| ["Homebrew", tap] }
 
   def query_regexp(query)
     case query

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -1,18 +1,4 @@
 OFFICIAL_TAPS = %w[
-  apache
-  binary
-  completions
-  devel-only
-  dupes
   emacs
-  fuse
-  games
-  head-only
   nginx
-  php
-  python
-  science
-  tex
-  versions
-  x11
 ]


### PR DESCRIPTION
This limits official taps to the ones that still exist and removes cask from the default search.

Fixes #705.