### PR TITLE
Add portable Ruby/curl to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 /Library/Homebrew/test/vendor
 /Library/Homebrew/test/coverage
 /Library/Homebrew/test/fs_leak_log
+/Library/Homebrew/vendor/portable-curl
+/Library/Homebrew/vendor/portable-ruby
 /Library/LinkedKegs
 /Library/PinnedKegs
 /Library/Taps


### PR DESCRIPTION
I somehow missed this even though they were added *years* ago. 🙈 

Fixes #716.