### PR TITLE
vendor-install: add message that Tigerbrew is installing tools

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -44,6 +44,10 @@ fetch() {
   local sha
   local temporary_path
 
+  echo "==> Please wait... tigers are now brewing"
+  echo "Downloading Tigerbrew's ${VENDOR_NAME}; this may take some time"
+  echo ""
+
   curl_args=(
     --fail \
     --remote-time \


### PR DESCRIPTION
cc @ticky, who pointed this out awhile ago - users might think something is wrong if it takes this long for Tigerbrew to respond when installing these for the first time.