### PR TITLE
Added mirror for PCRE because the two existing links did not work for me 

### DIFF
--- a/Library/Formula/pcre.rb
+++ b/Library/Formula/pcre.rb
@@ -3,6 +3,8 @@ class Pcre < Formula
   homepage "http://www.pcre.org/"
   url "https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/downloads.sourceforge.net/p/pc/pcre/pcre/8.39/pcre-8.39.tar.bz2"
+  mirror "https://ftp.pcre.org/pub/pcre/pcre-8.39.tar.bz2"
+  
   sha256 "b858099f82483031ee02092711689e7245586ada49e534a06e678b8ea9549e8b"
 
   bottle do

--- a/Library/Formula/popt.rb
+++ b/Library/Formula/popt.rb
@@ -1,7 +1,7 @@
 class Popt < Formula
   desc "Library like getopt(3) with a number of enhancements"
   homepage "http://rpm5.org"
-  url "http://rpm5.org/files/popt/popt-1.16.tar.gz"
+  url "https://fossies.org/linux/misc/popt-1.16.tar.gz"
   sha256 "e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8"
 
   bottle do


### PR DESCRIPTION
Hi,

I created a new mirror for the PCRE to https://ftp.pcre.org/pub/pcre/pcre-8.39.tar.bz2 because the existing links seemed to be broken.