### PR TITLE
jpeg: correct SHA256 checksum

### DIFF
--- a/Library/Formula/jpeg.rb
+++ b/Library/Formula/jpeg.rb
@@ -2,7 +2,7 @@ class Jpeg < Formula
   desc "JPEG image manipulation library"
   homepage "http://www.ijg.org"
   url "http://www.ijg.org/files/jpegsrc.v8d.tar.gz"
-  sha256 "00029b1473f0f0ea72fbca3230e8cb25797fbb27e58ae2e46bb8bf5a806fe0b3"
+  sha256 "d625ad6b3375a036bf30cd3b0b40e8dde08f0891bfd3a2960650654bdb50318c"
 
   bottle do
     cellar :any


### PR DESCRIPTION
For an unknown reason, the SHA256 checksum of [https://ijg.org/files/jpegsrc.v8d.tar.gz](jpegsrc.v8d.tar.gz) has changed, and as a result jpeg fails to install due to a checksum mismatch. This PR corrects that issue.