### PR TITLE
Expat: Update URLs and HEAD

### DIFF
--- a/Library/Formula/expat.rb
+++ b/Library/Formula/expat.rb
@@ -1,12 +1,12 @@
 class Expat < Formula
   desc "XML 1.0 parser"
   homepage "http://www.libexpat.org"
-  url "https://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz"
-  mirror "https://fossies.org/linux/www/expat-2.1.0.tar.gz"
+  url "https://github.com/libexpat/libexpat/releases/download/R_2_1_0/expat-2.1.0.tar.gz"
+  mirror "https://ftp.osuosl.org/pub/blfs/conglomeration/expat/expat-2.1.0.tar.gz"
   sha256 "823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86"
   revision 1
 
-  head ":pserver:anonymous:@expat.cvs.sourceforge.net:/cvsroot/expat", :using => :cvs
+  head "https://github.com/libexpat/libexpat.git"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Expat 2.1.0 is deprecated and has been removed from a number of mirrors. Restore working links until support for a more recent version of expat is added.