### PR TITLE
Use newer make for projects with GObject introspection

### DIFF
--- a/Library/Formula/atk.rb
+++ b/Library/Formula/atk.rb
@@ -11,6 +11,7 @@ class Atk < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "make" => :build if MacOS.version < :leopard
   depends_on "glib"
   depends_on "gobject-introspection"
 
@@ -21,8 +22,8 @@ class Atk < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-introspection=yes"
-    system "make"
-    system "make", "install"
+    system make_path
+    system make_path, "install"
   end
 
   test do

--- a/Library/Formula/atk.rb
+++ b/Library/Formula/atk.rb
@@ -12,7 +12,7 @@ class Atk < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "gobject-introspection" => :build
+  depends_on "gobject-introspection"
 
   option :universal
 

--- a/Library/Formula/atk.rb
+++ b/Library/Formula/atk.rb
@@ -11,9 +11,8 @@ class Atk < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "make" => :build if MacOS.version < :leopard
   depends_on "glib"
-  depends_on "gobject-introspection"
+  depends_on "gobject-introspection" => :build
 
   option :universal
 
@@ -22,8 +21,8 @@ class Atk < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-introspection=yes"
-    system make_path
-    system make_path, "install"
+    make
+    make "install"
   end
 
   test do

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -14,12 +14,11 @@ class GdkPixbuf < Formula
   option "with-relocations", "Build with relocation support for bundles"
 
   depends_on "pkg-config" => :build
-  depends_on "make" => :build if MacOS.version < :leopard
   depends_on "glib"
   depends_on "jpeg"
   depends_on "libtiff"
   depends_on "libpng"
-  depends_on "gobject-introspection"
+  depends_on "gobject-introspection" => :build
 
   # 'loaders.cache' must be writable by other packages
   skip_clean "lib/gdk-pixbuf-2.0"
@@ -38,8 +37,8 @@ class GdkPixbuf < Formula
     args << "--enable-relocations" if build.with?("relocations")
 
     system "./configure", *args
-    system make_path
-    system make_path, "install"
+    make
+    make "install"
 
     # Other packages should use the top-level modules directory
     # rather than dumping their files into the gdk-pixbuf keg.

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -14,6 +14,7 @@ class GdkPixbuf < Formula
   option "with-relocations", "Build with relocation support for bundles"
 
   depends_on "pkg-config" => :build
+  depends_on "make" => :build if MacOS.version < :leopard
   depends_on "glib"
   depends_on "jpeg"
   depends_on "libtiff"
@@ -37,8 +38,8 @@ class GdkPixbuf < Formula
     args << "--enable-relocations" if build.with?("relocations")
 
     system "./configure", *args
-    system "make"
-    system "make", "install"
+    system make_path
+    system make_path, "install"
 
     # Other packages should use the top-level modules directory
     # rather than dumping their files into the gdk-pixbuf keg.

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -18,7 +18,7 @@ class GdkPixbuf < Formula
   depends_on "jpeg"
   depends_on "libtiff"
   depends_on "libpng"
-  depends_on "gobject-introspection" => :build
+  depends_on "gobject-introspection"
 
   # 'loaders.cache' must be writable by other packages
   skip_clean "lib/gdk-pixbuf-2.0"

--- a/Library/Formula/gsettings-desktop-schemas.rb
+++ b/Library/Formula/gsettings-desktop-schemas.rb
@@ -24,7 +24,7 @@ class GsettingsDesktopSchemas < Formula
                           "--prefix=#{prefix}",
                           "--disable-schemas-compile",
                           "--enable-introspection=yes"
-    system "make", "install"
+    make "install"
   end
 
   test do

--- a/Library/Formula/gtk+.rb
+++ b/Library/Formula/gtk+.rb
@@ -48,7 +48,7 @@ class Gtkx < Formula
     args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
     system "./configure", *args
-    system "make", "install"
+    make "install"
   end
 
   test do

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -44,7 +44,7 @@ class Gtkx3 < Formula
     # necessary to avoid gtk-update-icon-cache not being found during make install
     bin.mkpath
     ENV.prepend_path "PATH", "#{bin}"
-    system "make", "install"
+    make "install"
     # Prevent a conflict between this and Gtk+2
     mv bin/"gtk-update-icon-cache", bin/"gtk3-update-icon-cache"
   end

--- a/Library/Formula/harfbuzz.rb
+++ b/Library/Formula/harfbuzz.rb
@@ -28,7 +28,7 @@ class Harfbuzz < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "freetype"
-  depends_on "gobject-introspection" => :build
+  depends_on "gobject-introspection"
   depends_on "icu4c" => :recommended
   depends_on "cairo" => :optional
   depends_on "graphite2" => :optional

--- a/Library/Formula/harfbuzz.rb
+++ b/Library/Formula/harfbuzz.rb
@@ -25,13 +25,10 @@ class Harfbuzz < Formula
   # ld64 is needed to lookup @loader_path/libicudata.*.dylib
   depends_on :ld64
 
-  # the make binary shipped on Tiger cannot handle the gobject-introspection Makefiles
-  depends_on "make" => :build if MacOS.version < :leopard
-
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "freetype"
-  depends_on "gobject-introspection"
+  depends_on "gobject-introspection" => :build
   depends_on "icu4c" => :recommended
   depends_on "cairo" => :optional
   depends_on "graphite2" => :optional

--- a/Library/Formula/pango.rb
+++ b/Library/Formula/pango.rb
@@ -51,8 +51,8 @@ class Pango < Formula
 
     system "./autogen.sh" if build.head?
     system "./configure", *args
-    system "make"
-    system "make", "install"
+    make
+    make "install"
   end
 
   test do


### PR DESCRIPTION
On Tiger, building `atk` and `gdk-pixbuf` with the system-provided `make` results in errors such as:

```
  *** Need to define Atk_1_0_gir_LIBS or Atk_1_0_gir_PROGRAM.  Stop.
```

Using the brew-provided `make` fixes the issue.