### PR TITLE
gtk+3 fixes on 10.4

### DIFF
--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -24,6 +24,8 @@ class Gtkx3 < Formula
   depends_on "glib"
   depends_on "hicolor-icon-theme"
 
+  patch :DATA if MacOS.version < :leopard # No NSTextInputClient on Tiger
+
   def install
     ENV.universal_binary if build.universal?
 
@@ -116,3 +118,17 @@ class Gtkx3 < Formula
     system "./test"
   end
 end
+
+__END__
+diff -ur a/gdk/quartz/GdkQuartzView.h b/gdk/quartz/GdkQuartzView.h
+--- a/gdk/quartz/GdkQuartzView.h	2014-11-26 21:54:55.000000000 -0500
++++ b/gdk/quartz/GdkQuartzView.h	2021-06-09 13:24:00.000000000 -0400
+@@ -32,7 +32,7 @@
+ #define GIC_FILTER_PASSTHRU	0
+ #define GIC_FILTER_FILTERED	1
+
+-@interface GdkQuartzView : NSView <NSTextInputClient>
++@interface GdkQuartzView : NSView
+ {
+   GdkWindow *gdk_window;
+   NSTrackingRectTag trackingRect;

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -38,6 +38,7 @@ class Gtkx3 < Formula
       --disable-x11-backend
     ]
 
+    args << "--disable-cups" if MacOS.version < :leopard # Requires CUPS 1.2
     args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
     system "./configure", *args

--- a/Library/Formula/gtk+3.rb
+++ b/Library/Formula/gtk+3.rb
@@ -24,6 +24,8 @@ class Gtkx3 < Formula
   depends_on "glib"
   depends_on "hicolor-icon-theme"
 
+  depends_on :ld64
+
   patch :DATA if MacOS.version < :leopard # No NSTextInputClient on Tiger
 
   def install


### PR DESCRIPTION
Here are a few changes that I found necessary to compile the gtk+3 formula on 10.4.11. They are workarounds for the following facts:

* Tiger has CUPS 1.1 but not 1.2
* Tiger doesn't have the `NSTextInputClient` protocol. I am guessing this was an informal protocol prior to 10.5; it's possible that removing the protocol declaration will have a run-time effect, but in my experience Cocoa frameworks check for individual methods rather than protocol conformance. Anyway, compiling is better than not.
* Tiger's default linker doesn't find Carbon symbols (e.g. `GetCurrentButtonState`) without additional flags