### PR TITLE
Update formulae which depend on libjpeg

### DIFF
--- a/Library/Formula/analog.rb
+++ b/Library/Formula/analog.rb
@@ -5,7 +5,7 @@ class Analog < Formula
   # homepage "http://analog.cx"
   url "https://mirrors.kernel.org/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
   sha256 "31c0e2bedd0968f9d4657db233b20427d8c497be98194daf19d6f859d7f6fcca"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/argyll-cms.rb
+++ b/Library/Formula/argyll-cms.rb
@@ -4,6 +4,7 @@ class ArgyllCms < Formula
   url "http://www.argyllcms.com/Argyll_V1.8.2_src.zip"
   version "1.8.2"
   sha256 "59bdfaeace35d2007c90fc53234ba33bf8a64cffc08f7b27a297fc5f85455377"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/center-im.rb
+++ b/Library/Formula/center-im.rb
@@ -3,7 +3,7 @@ class CenterIm < Formula
   homepage "http://www.centerim.org/index.php/Main_Page"
   url "http://www.centerim.org/download/releases/centerim-4.22.10.tar.gz"
   sha256 "93ce15eb9c834a4939b5aa0846d5c6023ec2953214daf8dc26c85ceaa4413f6e"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/dcraw.rb
+++ b/Library/Formula/dcraw.rb
@@ -3,6 +3,7 @@ class Dcraw < Formula
   homepage "https://www.cybercom.net/~dcoffin/dcraw/"
   url "https://mirror.pnl.gov/macports/distfiles/dcraw/dcraw-9.26.0.tar.gz"
   sha256 "85791d529e037ad5ca09770900ae975e2e4cc1587ca1da4192ca072cbbfafba3"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/devil.rb
+++ b/Library/Formula/devil.rb
@@ -3,7 +3,7 @@ class Devil < Formula
   homepage "http://sourceforge.net/projects/openil/"
   url "https://downloads.sourceforge.net/project/openil/DevIL/1.7.8/DevIL-1.7.8.tar.gz"
   sha256 "682ffa3fc894686156337b8ce473c954bf3f4fb0f3ecac159c73db632d28a8fd"
-  revision 1
+  revision 2
 
   depends_on "libpng"
   depends_on "jpeg"

--- a/Library/Formula/djvulibre.rb
+++ b/Library/Formula/djvulibre.rb
@@ -4,6 +4,7 @@ class Djvulibre < Formula
   url "https://downloads.sourceforge.net/project/djvu/DjVuLibre/3.5.27/djvulibre-3.5.27.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/d/djvulibre/djvulibre_3.5.27.orig.tar.gz"
   sha256 "e69668252565603875fb88500cde02bf93d12d48a3884e472696c896e81f505f"
+  revision 1
 
   head do
     url "git://git.code.sf.net/p/djvu/djvulibre-git"

--- a/Library/Formula/eet.rb
+++ b/Library/Formula/eet.rb
@@ -3,6 +3,7 @@ class Eet < Formula
   homepage "https://docs.enlightenment.org/auto/eet/eet_main.html"
   url "https://download.enlightenment.org/releases/eet-1.7.10.tar.gz"
   sha256 "c424821eb8ba09884d3011207b1ecec826bc45a36969cd4978b78f298daae1ee"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/efl.rb
+++ b/Library/Formula/efl.rb
@@ -3,6 +3,7 @@ class Efl < Formula
   homepage "https://www.enlightenment.org"
   url "https://download.enlightenment.org/rel/libs/efl/efl-1.14.2.tar.gz"
   sha256 "e5699d8183c1540fe45dddaf692254632f9131335e97a09cc313e866a150b42c"
+  revision 1
 
   bottle do
     sha256 "783d8e344e04e4f36e624d403a312194c1e2868ffbea4dfab97fbbe167f58e48" => :yosemite

--- a/Library/Formula/epeg.rb
+++ b/Library/Formula/epeg.rb
@@ -3,6 +3,7 @@ class Epeg < Formula
   homepage "https://github.com/mattes/epeg"
   url "https://github.com/mattes/epeg/archive/v0.9.1.042.tar.gz"
   sha256 "644362f87605e92f1e1cc0c421867252e4402939aeb4b36ad7cb385cc57a137c"
+  revision 1
 
   head "https://github.com/mattes/epeg.git"
 

--- a/Library/Formula/fbida.rb
+++ b/Library/Formula/fbida.rb
@@ -3,6 +3,7 @@ class Fbida < Formula
   homepage "http://linux.bytesex.org/fbida/"
   url "http://dl.bytesex.org/releases/fbida/fbida-2.10.tar.gz"
   sha256 "7a5a3aac61b40a6a2bbf716d270a46e2f8e8d5c97e314e927d41398a4d0b6cb6"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/ffmpegthumbnailer.rb
+++ b/Library/Formula/ffmpegthumbnailer.rb
@@ -3,6 +3,7 @@ class Ffmpegthumbnailer < Formula
   homepage "https://github.com/dirkvdb/ffmpegthumbnailer"
   url "https://github.com/dirkvdb/ffmpegthumbnailer/archive/2.0.10.tar.gz"
   sha256 "68125d98d72347a676ab2f9bc93ddd3537ff39d6a81145e2a58a6de5d3958e4e"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/flactag.rb
+++ b/Library/Formula/flactag.rb
@@ -3,6 +3,7 @@ class Flactag < Formula
   homepage "http://flactag.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/flactag/v2.0.4/flactag-2.0.4.tar.gz"
   sha256 "c96718ac3ed3a0af494a1970ff64a606bfa54ac78854c5d1c7c19586177335b2"
+  revision 1
 
   depends_on "pkg-config" => :build
   depends_on "asciidoc" => :build

--- a/Library/Formula/fltk.rb
+++ b/Library/Formula/fltk.rb
@@ -3,6 +3,7 @@ class Fltk < Formula
   homepage "http://www.fltk.org/"
   url "https://fossies.org/linux/misc/fltk-1.3.3-source.tar.gz"
   sha256 "f8398d98d7221d40e77bc7b19e761adaf2f1ef8bb0c30eceb7beb4f2273d0d97"
+  revision 1
 
   bottle do
     sha1 "33c75cce41deadbfe54bdcc22ae91d17d3ecc782" => :mavericks

--- a/Library/Formula/fontforge.rb
+++ b/Library/Formula/fontforge.rb
@@ -4,6 +4,7 @@ class Fontforge < Formula
   url "https://github.com/fontforge/fontforge/archive/20150824.tar.gz"
   sha256 "28ab2471cb010c1fa75b8ab8191a1dded81fe1e9490aa5ff6ab4706a4c78ff27"
   head "https://github.com/fontforge/fontforge.git"
+  revision 1
 
   bottle do
     revision 1

--- a/Library/Formula/freeswitch.rb
+++ b/Library/Formula/freeswitch.rb
@@ -6,6 +6,7 @@ class Freeswitch < Formula
       :revision => "87a059bafcc094bdb4899b6a20bcd215e249109e"
 
   head "https://freeswitch.org/stash/scm/fs/freeswitch.git"
+  revision 1
 
   bottle do
     sha256 "bafd8d3ec7bd43bf961ad3c747f1dcff7cc21f0e8aec934a950e2ee15273181b" => :el_capitan

--- a/Library/Formula/gd.rb
+++ b/Library/Formula/gd.rb
@@ -3,6 +3,7 @@ class Gd < Formula
   homepage "https://libgd.bitbucket.org/"
   url "https://bitbucket.org/libgd/gd-libgd/downloads/libgd-2.1.1.tar.xz"
   sha256 "9ada1ed45594abc998ebc942cef12b032fbad672e73efc22bc9ff54f5df2b285"
+  revision 1
 
   head do
     url "https://bitbucket.org/libgd/gd-libgd.git"

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -3,7 +3,7 @@ class Gdal < Formula
   homepage "http://www.gdal.org/"
   url "http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz"
   sha256 "66bc8192d24e314a66ed69285186d46e6999beb44fc97eeb9c76d82a117c0845"
-  revision 3
+  revision 4
 
   bottle do
     revision 1

--- a/Library/Formula/gdk-pixbuf.rb
+++ b/Library/Formula/gdk-pixbuf.rb
@@ -3,6 +3,7 @@ class GdkPixbuf < Formula
   homepage "http://gtk.org"
   url "https://download.gnome.org/sources/gdk-pixbuf/2.32/gdk-pixbuf-2.32.1.tar.xz"
   sha256 "4432b74f25538c7d6bcb3ca51adabdd666168955f25812a2568dc9637697f3bc"
+  revision 1
 
   bottle do
     sha256 "62f6a4d7d312267fdfda5d1497de9af7fe4d8e731f888bb761a516c8f0e9cfa3" => :el_capitan

--- a/Library/Formula/gegl.rb
+++ b/Library/Formula/gegl.rb
@@ -4,6 +4,7 @@ class Gegl < Formula
   url "http://download.gimp.org/pub/gegl/0.3/gegl-0.3.0.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/g/gegl/gegl_0.3.0.orig.tar.bz2"
   sha256 "f0fec8f2e7b8835979d3cf4e38b05d41bb79f68dc80cf899a846484da693bbf7"
+  revision 1
 
   bottle do
     sha256 "6082fe8ebabb6dcd94a8efd95dd32072e7f99cc26b36838368fd5c5937259424" => :yosemite

--- a/Library/Formula/gnuplot.rb
+++ b/Library/Formula/gnuplot.rb
@@ -3,7 +3,7 @@ class Gnuplot < Formula
   homepage "http://www.gnuplot.info"
   url "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.0.1/gnuplot-5.0.1.tar.gz"
   sha256 "7cbc557e71df581ea520123fb439dea5f073adcc9010a2885dc80d4ed28b3c47"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/gource.rb
+++ b/Library/Formula/gource.rb
@@ -3,7 +3,7 @@ class Gource < Formula
   homepage "https://github.com/acaudwell/Gource"
   url "https://github.com/acaudwell/Gource/releases/download/gource-0.43/gource-0.43.tar.gz"
   sha256 "85a40ac8e4f5c277764216465c248d6b76589ceac012541c4cc03883a24abde4"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "42545a4bef92eb71b83204f59357d28e74e9d80d5f10673ac5c7317bd32c7e2f" => :el_capitan

--- a/Library/Formula/gpac.rb
+++ b/Library/Formula/gpac.rb
@@ -10,6 +10,7 @@ class Gpac < Formula
   desc "Multimedia framework for research and academic purposes"
   homepage "https://gpac.wp.mines-telecom.fr/"
   head "https://github.com/gpac/gpac.git"
+  revision 1
 
   stable do
     url "https://github.com/gpac/gpac/archive/v0.5.2.tar.gz"

--- a/Library/Formula/gphoto2.rb
+++ b/Library/Formula/gphoto2.rb
@@ -3,7 +3,7 @@ class Gphoto2 < Formula
   homepage "http://gphoto.org/"
   url "http://downloads.sourceforge.net/project/gphoto/gphoto/2.5.1/gphoto2-2.5.1.tar.bz2"
   sha1 "c363adfb5d0f21c03bc5dc27daf19e9e409832ec"
-  revision 1
+  revision 2
 
   depends_on "pkg-config" => :build
   depends_on "jpeg"

--- a/Library/Formula/graphicsmagick.rb
+++ b/Library/Formula/graphicsmagick.rb
@@ -4,11 +4,9 @@ class Graphicsmagick < Formula
   url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick/1.3.21/GraphicsMagick-1.3.21.tar.bz2"
   sha256 "a0ce08f2710c158e39faa083463441f6eeeecce07dbd59510498ffa4e0b053d1"
   head "http://hg.code.sf.net/p/graphicsmagick/code", :using => :hg
+  revision 1
 
   bottle do
-    sha256 "6ea3436f715b3739485a35dd9ee55b6f4e9019d41d7ec12e095b009ec1e" => :tiger_altivec
-    sha256 "ce05ba743efd2dba316ca904f97793732afaf6787eab8bd1049691353ee5bd39" => :leopard_g3
-    sha256 "70bcb01a84da376d30dd8f730cbaad83271a21e9b9973e98b58204d969506626" => :leopard_altivec
   end
 
   option "with-quantum-depth-8", "Compile with a quantum depth of 8 bit"

--- a/Library/Formula/gst-plugins-good.rb
+++ b/Library/Formula/gst-plugins-good.rb
@@ -1,6 +1,7 @@
 class GstPluginsGood < Formula
   desc "GStreamer plugins (well-supported, under the LGPL)"
   homepage "http://gstreamer.freedesktop.org/"
+  revision 1
 
   stable do
     url "https://download.gnome.org/sources/gst-plugins-good/1.6/gst-plugins-good-1.6.0.tar.xz"

--- a/Library/Formula/gst-plugins-ugly.rb
+++ b/Library/Formula/gst-plugins-ugly.rb
@@ -3,6 +3,7 @@ class GstPluginsUgly < Formula
   homepage "http://gstreamer.freedesktop.org/"
   url "http://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.6.0.tar.xz"
   sha256 "91178dc0d687a83c083190a905681d3a66901374b1004fc52cd300b7802e5f06"
+  revision 1
 
   bottle do
     sha256 "ffcf9543143cd22f5f5ed1b10c1f871f8776d76422e647d28bb0031cbd3e26b3" => :el_capitan

--- a/Library/Formula/htmldoc.rb
+++ b/Library/Formula/htmldoc.rb
@@ -3,7 +3,7 @@ class Htmldoc < Formula
   homepage "http://www.msweet.org/projects.php?Z1"
   url "http://www.msweet.org/files/project1/htmldoc-1.8.28-source.tar.bz2"
   sha256 "2a688bd820ad6f7bdebb274716102dafbf4d5fcfa20a5b8d87a56b030d184732"
-  revision 1
+  revision 2
 
   depends_on "libpng"
   depends_on "jpeg"

--- a/Library/Formula/imagemagick.rb
+++ b/Library/Formula/imagemagick.rb
@@ -8,6 +8,7 @@ class Imagemagick < Formula
   mirror "https://www.imagemagick.org/download/ImageMagick-6.9.6-2.tar.xz"
   sha256 "39244823fe736626fb4ea22c4b6cb4cae30c6a27a38a02ecd774f0ce3c4d308d"
   head "http://git.imagemagick.org/repos/ImageMagick.git"
+  revision 1
 
   bottle do
     sha256 "2f8807e39abcf51a2ce1e7f0986d67091155f977731662d3d5e197f09cc0364d" => :sierra

--- a/Library/Formula/imageworsener.rb
+++ b/Library/Formula/imageworsener.rb
@@ -3,6 +3,7 @@ class Imageworsener < Formula
   homepage "http://entropymine.com/imageworsener/"
   url "http://entropymine.com/imageworsener/imageworsener-1.2.0.tar.gz"
   sha256 "97fdb1aafac7bc2339b2ce813071f0900de0b093b96ab1a99a43f9647afdfe35"
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/imlib2.rb
+++ b/Library/Formula/imlib2.rb
@@ -3,6 +3,7 @@ class Imlib2 < Formula
   homepage "http://sourceforge.net/projects/enlightenment/files/"
   url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.4.7/imlib2-1.4.7.tar.bz2"
   sha256 "35d733ce23ad7d338cff009095d37e656cb8a7a53717d53793a38320f9924701"
+  revision 2
 
   bottle do
     sha256 "475449cfe212bc0b7d567cab499993f2d04dc47c7c70939a49bc6310414ca744" => :el_capitan

--- a/Library/Formula/intltool.rb
+++ b/Library/Formula/intltool.rb
@@ -4,6 +4,8 @@ class Intltool < Formula
   url "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz"
   sha256 "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
 
+  depends_on "XML::Parser" => :perl
+
   bottle do
     cellar :any_skip_relocation
     sha256 "14bb0680842b8b392cb1a5f5baf142e99a54a538d1a587f6d1158785b276ffc6" => :el_capitan

--- a/Library/Formula/io.rb
+++ b/Library/Formula/io.rb
@@ -3,6 +3,7 @@ class Io < Formula
   homepage "http://iolanguage.com/"
   url "https://github.com/stevedekorte/io/archive/2013.12.04.tar.gz"
   sha256 "e31e8aded25069d945b55732960b3553ba69851a61bd8698b68dfca27b6724cd"
+  revision 1
 
   head "https://github.com/stevedekorte/io.git"
 

--- a/Library/Formula/jasper.rb
+++ b/Library/Formula/jasper.rb
@@ -4,6 +4,7 @@ class Jasper < Formula
   url "http://download.osgeo.org/gdal/jasper-1.900.1.uuid.tar.gz"
   sha256 "0021684d909de1eb2f7f5a4d608af69000ce37773d51d1fb898e03b8d488087d"
   version "1.900.1"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/jp2a.rb
+++ b/Library/Formula/jp2a.rb
@@ -3,6 +3,7 @@ class Jp2a < Formula
   homepage "http://csl.sublevel3.org/jp2a/"
   url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
   sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/jpeginfo.rb
+++ b/Library/Formula/jpeginfo.rb
@@ -3,6 +3,7 @@ class Jpeginfo < Formula
   homepage "http://www.kokkonen.net/tjko/projects.html"
   url "http://www.kokkonen.net/tjko/src/jpeginfo-1.6.1.tar.gz"
   sha256 "629e31cf1da0fa1efe4a7cc54c67123a68f5024f3d8e864a30457aeaed1d7653"
+  revision 1
 
   depends_on "jpeg"
 

--- a/Library/Formula/jpegoptim.rb
+++ b/Library/Formula/jpegoptim.rb
@@ -5,6 +5,7 @@ class Jpegoptim < Formula
   mirror "https://mirrors.kernel.org/debian/pool/main/j/jpegoptim/jpegoptim_1.4.3.orig.tar.gz"
   sha256 "f892f5917c8dd8259d319df204e4bc13806b90389041ca7a4a24d8a5c25c7013"
   head "https://github.com/tjko/jpegoptim.git"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/jpegrescan.rb
+++ b/Library/Formula/jpegrescan.rb
@@ -3,6 +3,7 @@ class Jpegrescan < Formula
   homepage "https://github.com/kud/jpegrescan"
   url "https://github.com/kud/jpegrescan/archive/1.0.0.tar.gz"
   sha256 "faa0f6009b16a67e6a847b40e7e736e9a5a716cefb64a7c470e266219db90d02"
+  revision 1
 
   head "https://github.com/kud/jpegrescan.git"
 

--- a/Library/Formula/leptonica.rb
+++ b/Library/Formula/leptonica.rb
@@ -3,6 +3,7 @@ class Leptonica < Formula
   homepage "http://www.leptonica.org/"
   url "http://www.leptonica.org/source/leptonica-1.72.tar.gz"
   sha256 "79d5eadd32658c9fea38700c975d60aa3d088eaa3e307659f004d40834de1f56"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/libagar.rb
+++ b/Library/Formula/libagar.rb
@@ -4,6 +4,7 @@ class Libagar < Formula
   url "http://stable.hypertriton.com/agar/agar-1.4.1.tar.gz"
   sha256 "b0e62b754f134c3c0dd070a4fa62fa552654356eebab3d55e32d5d9b151a275e"
   head "http://dev.csoft.net/agar/trunk", :using => :svn
+  revision 1
 
   bottle do
     sha256 "c237ad40ea2a61e9ec2daa9a0d1ee93beada00028fbc80011032a9a09b412870" => :el_capitan

--- a/Library/Formula/libbpg.rb
+++ b/Library/Formula/libbpg.rb
@@ -3,6 +3,7 @@ class Libbpg < Formula
   homepage "http://bellard.org/bpg/"
   url "http://bellard.org/bpg/libbpg-0.9.5.tar.gz"
   sha256 "30de1d0099920e24b7c9aae4d4e6b62f446823f0a1d52eb195dfc25c662ee203"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/libgaiagraphics.rb
+++ b/Library/Formula/libgaiagraphics.rb
@@ -3,7 +3,7 @@ class Libgaiagraphics < Formula
   homepage "https://www.gaia-gis.it/fossil/libgaiagraphics/index"
   url "http://www.gaia-gis.it/gaia-sins/gaiagraphics-sources/libgaiagraphics-0.5.tar.gz"
   sha256 "ccab293319eef1e77d18c41ba75bc0b6328d0fc3c045bb1d1c4f9d403676ca1c"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/libgeotiff.rb
+++ b/Library/Formula/libgeotiff.rb
@@ -3,7 +3,7 @@ class Libgeotiff < Formula
   homepage "http://geotiff.osgeo.org/"
   url "http://download.osgeo.org/geotiff/libgeotiff/libgeotiff-1.4.1.tar.gz"
   sha256 "acfc76ee19b3d41bb9c7e8b780ca55d413893a96c09f3b27bdb9b2573b41fd23"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "2d90f23486794745cbf3880b8327f6c9b8d1ee5b3952b599d372e139e3fa386a" => :el_capitan

--- a/Library/Formula/libgxps.rb
+++ b/Library/Formula/libgxps.rb
@@ -3,6 +3,7 @@ class Libgxps < Formula
   homepage "https://live.gnome.org/libgxps"
   url "https://download.gnome.org/sources/libgxps/0.2/libgxps-0.2.3.2.tar.xz"
   sha256 "6ea5f0ed85665a4e6702e31e38b5f1b2e5ae4f3d316a55d7f1fb1799224b4127"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/libpano.rb
+++ b/Library/Formula/libpano.rb
@@ -11,7 +11,7 @@ class Libpano < Formula
     sha1 "0ea739e0ad708cc3d48d48eb542cb726e705ea2a" => :mountain_lion
   end
 
-  revision 1
+  revision 2
 
   depends_on "libpng"
   depends_on "jpeg"

--- a/Library/Formula/libquicktime.rb
+++ b/Library/Formula/libquicktime.rb
@@ -3,7 +3,7 @@ class Libquicktime < Formula
   homepage "http://libquicktime.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/libquicktime/libquicktime/1.2.4/libquicktime-1.2.4.tar.gz"
   sha256 "1c53359c33b31347b4d7b00d3611463fe5e942cae3ec0fefe0d2fd413fd47368"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/libsvg.rb
+++ b/Library/Formula/libsvg.rb
@@ -3,7 +3,7 @@ class Libsvg < Formula
   homepage "http://cairographics.org/"
   url "http://cairographics.org/snapshots/libsvg-0.1.4.tar.gz"
   sha256 "4c3bf9292e676a72b12338691be64d0f38cd7f2ea5e8b67fbbf45f1ed404bc8f"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/libtiff.rb
+++ b/Library/Formula/libtiff.rb
@@ -4,12 +4,10 @@ class Libtiff < Formula
   url "http://download.osgeo.org/libtiff/tiff-4.0.6.tar.gz"
   mirror "ftp://ftp.remotesensing.org/pub/libtiff/tiff-4.0.6.tar.gz"
   sha256 "4d57a50907b510e3049a4bba0d7888930fdfc16ce49f1bf693e5b6247370d68c"
+  revision 1
 
   bottle do
     cellar :any
-    sha256 "7ee1f796f6355e84b039d8deb626677a512c25fb40685a511d9d9333ebcb23ad" => :tiger_altivec
-    sha256 "ac6deffd0e96ad67b5ecc976daa6b944a1292d0306d8ff1f411e06b817d94c2c" => :leopard_g3
-    sha256 "98294201f9f6e549b752006cc86a2dd029696ecfdc3f54c1b77bc5e38d9bd0ad" => :leopard_altivec
   end
 
   option :universal

--- a/Library/Formula/libuvc.rb
+++ b/Library/Formula/libuvc.rb
@@ -3,6 +3,7 @@ class Libuvc < Formula
   homepage "https://github.com/ktossell/libuvc"
   url "https://github.com/ktossell/libuvc/archive/v0.0.5.tar.gz"
   sha256 "62652a4dd024e366f41042c281e5a3359a09f33760eb1af660f950ab9e70f1f7"
+  revision 1
 
   head "https://github.com/ktossell/libuvc.git"
 

--- a/Library/Formula/libwmf.rb
+++ b/Library/Formula/libwmf.rb
@@ -3,7 +3,7 @@ class Libwmf < Formula
   homepage "http://wvware.sourceforge.net/libwmf.html"
   url "https://downloads.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz"
   sha256 "5b345c69220545d003ad52bfd035d5d6f4f075e65204114a9e875e84895a7cf8"
-  revision 1
+  revision 2
 
   bottle do
     revision 1

--- a/Library/Formula/links.rb
+++ b/Library/Formula/links.rb
@@ -4,6 +4,7 @@ class Links < Formula
   url "http://links.twibright.com/download/links-2.11.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/l/links2/links2_2.11.orig.tar.bz2"
   sha256 "87f7f927d6394f1dc45886dd5ff89234c4e0fb321132ceaa009db5bcc26f123f"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/little-cms.rb
+++ b/Library/Formula/little-cms.rb
@@ -3,6 +3,7 @@ class LittleCms < Formula
   homepage "http://www.littlecms.com/"
   url "https://downloads.sourceforge.net/project/lcms/lcms/1.19/lcms-1.19.tar.gz"
   sha256 "80ae32cb9f568af4dc7ee4d3c05a4c31fc513fc3e31730fed0ce7378237273a9"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/little-cms2.rb
+++ b/Library/Formula/little-cms2.rb
@@ -3,6 +3,7 @@ class LittleCms2 < Formula
   homepage "http://www.littlecms.com/"
   url "https://downloads.sourceforge.net/project/lcms/lcms/2.7/lcms2-2.7.tar.gz"
   sha256 "4524234ae7de185e6b6da5d31d6875085b2198bc63b1211f7dde6e2d197d6a53"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/logstalgia.rb
+++ b/Library/Formula/logstalgia.rb
@@ -3,7 +3,7 @@ class Logstalgia < Formula
   homepage "https://code.google.com/p/logstalgia/"
   url "https://github.com/acaudwell/Logstalgia/releases/download/logstalgia-1.0.6/logstalgia-1.0.6.tar.gz"
   sha256 "a81b94742cce64b0b2d1b1683f2f7ac6d06456056f353896153b1b8181855f34"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "20b927dd78f1928df830897968d6da6a0daf066130a8ef1c557d24543831595d" => :yosemite

--- a/Library/Formula/mal4s.rb
+++ b/Library/Formula/mal4s.rb
@@ -3,7 +3,7 @@ class Mal4s < Formula
   homepage "https://github.com/secure411dotorg/mal4s/"
   url "https://service.dissectcyber.com/mal4s/mal4s-1.2.8.tar.gz"
   sha256 "1c40ca9d11d113278c4fbd5c7ec9ce0edc78d6c8bd1aa7d85fb6b9473e60f0f1"
-  revision 1
+  revision 2
 
   head "https://github.com/secure411dotorg/mal4s.git"
 

--- a/Library/Formula/mapnik.rb
+++ b/Library/Formula/mapnik.rb
@@ -4,6 +4,7 @@ class Mapnik < Formula
   head "https://github.com/mapnik/mapnik.git"
   url "https://s3.amazonaws.com/mapnik/dist/v3.0.5/mapnik-v3.0.5.tar.bz2"
   sha256 "d8f771d45b236d987aab44819a517f4c1ed6d7ff2c42c2e51160e37d28c89cc3"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/minidlna.rb
+++ b/Library/Formula/minidlna.rb
@@ -3,6 +3,7 @@ class Minidlna < Formula
   homepage "http://sourceforge.net/projects/minidlna/"
   url "https://downloads.sourceforge.net/project/minidlna/minidlna/1.1.5/minidlna-1.1.5.tar.gz"
   sha256 "8477ad0416bb2af5cd8da6dde6c07ffe1a413492b7fe40a362bc8587be15ab9b"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/mjpegtools.rb
+++ b/Library/Formula/mjpegtools.rb
@@ -3,6 +3,7 @@ class Mjpegtools < Formula
   homepage "http://mjpeg.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mjpeg/mjpegtools/2.1.0/mjpegtools-2.1.0.tar.gz"
   sha256 "864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
+  revision 1
 
   depends_on :x11 => :optional
 

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -3,6 +3,7 @@ class OpenSceneGraph < Formula
   homepage "http://www.openscenegraph.org/projects/osg"
   url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.4.0.zip"
   sha256 "5c727d84755da276adf8c4a4a3a8ba9c9570fc4b4969f06f1d2e9f89b1e3040e"
+  revision 1
 
   head "http://www.openscenegraph.org/svn/osg/OpenSceneGraph/trunk/"
 

--- a/Library/Formula/openslide.rb
+++ b/Library/Formula/openslide.rb
@@ -3,7 +3,7 @@ class Openslide < Formula
   homepage "http://openslide.org/"
   url "https://github.com/openslide/openslide/releases/download/v3.4.1/openslide-3.4.1.tar.xz"
   sha256 "9938034dba7f48fadc90a2cdf8cfe94c5613b04098d1348a5ff19da95b990564"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/pdf2htmlex.rb
+++ b/Library/Formula/pdf2htmlex.rb
@@ -3,7 +3,7 @@ class Pdf2htmlex < Formula
   homepage "https://coolwanglu.github.io/pdf2htmlEX/"
   url "https://github.com/coolwanglu/pdf2htmlEX/archive/v0.13.6.tar.gz"
   sha256 "fc133a5791bfd76a4425af16c6a6a2460f672501b490cbda558213cb2b03d5d7"
-  revision 3
+  revision 4
 
   head "https://github.com/coolwanglu/pdf2htmlEX.git"
 

--- a/Library/Formula/podofo.rb
+++ b/Library/Formula/podofo.rb
@@ -3,6 +3,7 @@ class Podofo < Formula
   homepage "http://podofo.sourceforge.net"
   url "https://downloads.sourceforge.net/podofo/podofo-0.9.3.tar.gz"
   sha256 "ec261e31e89dce45b1a31be61e9c6bb250532e631a02d68ec5bb849ef0a222d8"
+  revision 1
 
   depends_on "cmake" => :build
   depends_on "libpng"

--- a/Library/Formula/poppler.rb
+++ b/Library/Formula/poppler.rb
@@ -3,6 +3,7 @@ class Poppler < Formula
   homepage "http://poppler.freedesktop.org"
   url "http://poppler.freedesktop.org/poppler-0.36.0.tar.xz"
   sha256 "93cc067b23c4ef7421380d3e8bd7c940b2027668446750787d7c1cb42720248e"
+  revision 1
 
   bottle do
     sha256 "ee3a00acc6fc9ea30530e59a09b758cbde2fb64b762553a7de39268ec70aa174" => :el_capitan

--- a/Library/Formula/povray.rb
+++ b/Library/Formula/povray.rb
@@ -3,7 +3,7 @@ class Povray < Formula
   homepage "http://www.povray.org/"
   url "https://github.com/POV-Ray/povray/archive/v3.7.0.0.tar.gz"
   sha256 "bf68861d648e3acafbd1d83a25016a0c68547b257e4fa79fb36eb5f08d665f27"
-  revision 1
+  revision 2
 
   depends_on :macos => :lion
   depends_on "autoconf" => :build

--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -6,6 +6,7 @@ class Qemu < Formula
   url "http://wiki.qemu-project.org/download/qemu-2.2.1.tar.bz2"
   sha256 "4617154c6ef744b83e10b744e392ad111dd351d435d6563ce24d8da75b1335a0"
   head "git://git.qemu-project.org/qemu.git"
+  revision 1
 
   depends_on "make" => :build if MacOS.version < :leopard
   depends_on "pkg-config" => :build

--- a/Library/Formula/sane-backends.rb
+++ b/Library/Formula/sane-backends.rb
@@ -12,7 +12,7 @@ class SaneBackends < Formula
     sha1 "343224849f6824dba073499bcb0521abd76e9e23" => :mountain_lion
   end
 
-  revision 1
+  revision 2
 
   option :universal
 

--- a/Library/Formula/sdl2_image.rb
+++ b/Library/Formula/sdl2_image.rb
@@ -13,7 +13,7 @@ class Sdl2Image < Formula
     sha1 "39628bcec4c2a8a64ec255c6adabc55de7481678" => :mountain_lion
   end
 
-  revision 1
+  revision 2
 
   depends_on "pkg-config" => :build
   depends_on "sdl2"

--- a/Library/Formula/sdl_image.rb
+++ b/Library/Formula/sdl_image.rb
@@ -3,7 +3,7 @@ class SdlImage < Formula
   homepage "https://www.libsdl.org/projects/SDL_image"
   url "https://www.libsdl.org/projects/SDL_image/release/SDL_image-1.2.12.tar.gz"
   sha256 "0b90722984561004de84847744d566809dbb9daf732a9e503b91a1b5a84e5699"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any

--- a/Library/Formula/sfml.rb
+++ b/Library/Formula/sfml.rb
@@ -7,18 +7,17 @@ class Sfml < Formula
   if MacOS.version < :lion
     url "http://www.sfml-dev.org/download/sfml/2.1/SFML-2.1-sources.zip"
     sha256 "5f46d7748223be3f0c6a9fcf18c0016d227f7b1903cdbcd85f61ddbc82ef95bf"
+    revision 1
   else
     url "http://www.sfml-dev.org/files/SFML-2.3-sources.zip"
     sha256 "a1dc8b00958000628c5394bc8438ba1aa5971fbeeef91a2cf3fa3fff443de7c1"
-    revision 1
+    revision 2
   end
 
   head "https://github.com/SFML/SFML.git"
 
   bottle do
     cellar :any
-    sha256 "508425964941cd9d99a9ed0f6fec449676f7995e6f7d6eb6db1ac868b788a494" => :leopard_g3
-    sha256 "67e6b2996aa55bcd19e2c65a1a0c5d9523e922791773f7939d0a5a3a54366553" => :leopard_altivec
   end
 
   # SFML 2.x requires 10.5; it appears to be a substantial rewrite from 1.x,

--- a/Library/Formula/swftools.rb
+++ b/Library/Formula/swftools.rb
@@ -3,7 +3,7 @@ class Swftools < Formula
   homepage "http://www.swftools.org"
   url "http://www.swftools.org/swftools-0.9.2.tar.gz"
   sha256 "bf6891bfc6bf535a1a99a485478f7896ebacbe3bbf545ba551298080a26f01f1"
-  revision 1
+  revision 2
 
   bottle do
     sha256 "7343a6c406b0374b460f1d814e5542372f85df5d6ee500759648084713e33174" => :el_capitan

--- a/Library/Formula/tiff2png.rb
+++ b/Library/Formula/tiff2png.rb
@@ -3,6 +3,7 @@ class Tiff2png < Formula
   homepage "http://www.libpng.org/pub/png/apps/tiff2png.html"
   url "https://github.com/rillian/tiff2png/archive/v0.92.tar.gz"
   sha256 "64e746560b775c3bd90f53f1b9e482f793d80ea6e7f5d90ce92645fd1cd27e4a"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/ufraw.rb
+++ b/Library/Formula/ufraw.rb
@@ -3,6 +3,7 @@ class Ufraw < Formula
   homepage "http://ufraw.sourceforge.net"
   url "https://downloads.sourceforge.net/project/ufraw/ufraw/ufraw-0.22/ufraw-0.22.tar.gz"
   sha256 "f7abd28ce587db2a74b4c54149bd8a2523a7ddc09bedf4f923246ff0ae09a25e"
+  revision 1
 
   bottle do
     sha256 "5462d1df3236f497fbae4171b743e598107224abce9ba274ef8c783153c3e41d" => :el_capitan

--- a/Library/Formula/vice.rb
+++ b/Library/Formula/vice.rb
@@ -3,7 +3,7 @@ class Vice < Formula
   homepage "http://vice-emu.sourceforge.net/"
   url "http://www.zimmers.net/anonftp/pub/cbm/crossplatform/emulators/VICE/vice-2.4.tar.gz"
   sha256 "ff8b8d5f0f497d1f8e75b95bbc4204993a789284a08a8a59ba727ad81dcace10"
-  revision 2
+  revision 3
 
   bottle do
     cellar :any

--- a/Library/Formula/vncsnapshot.rb
+++ b/Library/Formula/vncsnapshot.rb
@@ -3,6 +3,7 @@ class Vncsnapshot < Formula
   homepage "http://sourceforge.net/projects/vncsnapshot/"
   url "https://downloads.sourceforge.net/project/vncsnapshot/vncsnapshot/1.2a/vncsnapshot-1.2a-src.tar.gz"
   sha256 "20f5bdf6939a0454bc3b41e87e41a5f247d7efd1445f4fac360e271ddbea14ee"
+  revision 1
 
   depends_on "jpeg"
 

--- a/Library/Formula/webp.rb
+++ b/Library/Formula/webp.rb
@@ -3,12 +3,10 @@ class Webp < Formula
   homepage "https://developers.google.com/speed/webp/"
   url "http://downloads.webmproject.org/releases/webp/libwebp-0.4.3.tar.gz"
   sha256 "efbe0d58fda936f2ed99d0b837ed7087d064d6838931f282c4618d2a3f7390c4"
+  revision 1
 
   bottle do
     cellar :any
-    sha256 "f40ebbbb4a92ed580fab324f26160b58f9456d17deaf4e138852e394a72f2084" => :tiger_altivec
-    sha256 "14cd48734271f4f7236a06a83de069b30848b7147b71924646fd09f79ee26261" => :leopard_g3
-    sha256 "0b7953dfbedccc64b3047677f885b3e7890a6b6df368ec52dec07bd40dc4d041" => :leopard_altivec
   end
 
   head do

--- a/Library/Formula/wine.rb
+++ b/Library/Formula/wine.rb
@@ -20,6 +20,7 @@ class Wine < Formula
       sha256 "3dfc23bbc29015e4e538dab8b83cb825d3248a0e5cf3b3318503ee7331115402"
     end
   end
+  revision 1
 
   bottle do
     sha256 "545e28e3c8442d8be08dbb5ec193bbc9fbf82d1c196030e07f4758161af42924" => :el_capitan

--- a/Library/Formula/wxmac.rb
+++ b/Library/Formula/wxmac.rb
@@ -3,6 +3,7 @@ class Wxmac < Formula
   homepage "https://www.wxwidgets.org"
   url "https://downloads.sourceforge.net/project/wxwindows/3.0.2/wxWidgets-3.0.2.tar.bz2"
   sha256 "346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/x11vnc.rb
+++ b/Library/Formula/x11vnc.rb
@@ -3,6 +3,7 @@ class X11vnc < Formula
   homepage "http://www.karlrunge.com/x11vnc/"
   url "https://downloads.sourceforge.net/project/libvncserver/x11vnc/0.9.13/x11vnc-0.9.13.tar.gz"
   sha256 "f6829f2e629667a5284de62b080b13126a0736499fe47cdb447aedb07a59f13b"
+  revision 1
 
   bottle do
     cellar :any

--- a/Library/Formula/xplanet.rb
+++ b/Library/Formula/xplanet.rb
@@ -3,7 +3,7 @@ class Xplanet < Formula
   homepage "http://xplanet.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/xplanet/xplanet/1.3.0/xplanet-1.3.0.tar.gz"
   sha256 "44fb742bb93e5661ea8b11ccabcc12896693e051f3dd5083c9227224c416b442"
-  revision 2
+  revision 3
 
   bottle do
     sha256 "401b46887f90818530d5996e11ef2977481c51c85716e8da22e2dbaa454c01ab" => :yosemite

--- a/Library/Formula/zbar.rb
+++ b/Library/Formula/zbar.rb
@@ -3,7 +3,7 @@ class Zbar < Formula
   homepage "http://zbar.sourceforge.net"
   url "https://downloads.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
   sha256 "234efb39dbbe5cef4189cc76f37afbe3cfcfb45ae52493bfe8e191318bdbadc6"
-  revision 1
+  revision 2
 
   depends_on :x11 => :optional
   depends_on "pkg-config" => :build


### PR DESCRIPTION
After the libjpeg update in #743, dependent bottles will no longer find it, requiring a rebuild from source.

This change thus invalidates existing Tiger or Leopard bottles in the following formulae:

- graphicsmagick
- libtiff
- sfml
- webp