### PR TITLE
imagemagick: Update to latest 9.6.9 revision

### DIFF
--- a/Library/Formula/imagemagick.rb
+++ b/Library/Formula/imagemagick.rb
@@ -1,20 +1,10 @@
 class Imagemagick < Formula
   desc "Tools and libraries to manipulate images in many formats"
   homepage "https://www.imagemagick.org/"
-  # Please always keep the Homebrew mirror as the primary URL as the
-  # ImageMagick site removes tarballs regularly which means we get issues
-  # unnecessarily and older versions of the formula are broken.
-  url "https://dl.bintray.com/homebrew/mirror/imagemagick-6.9.6-2.tar.xz"
-  mirror "https://www.imagemagick.org/download/ImageMagick-6.9.6-2.tar.xz"
-  sha256 "39244823fe736626fb4ea22c4b6cb4cae30c6a27a38a02ecd774f0ce3c4d308d"
+  url "https://www.imagemagick.org/download/releases/ImageMagick-6.9.6-8.tar.xz"
+  mirror "https://sourceforge.net/projects/imagemagick/files/old-sources/6.x/6.9/ImageMagick-6.9.6-8.tar.xz"
+  sha256 "39bb2b18183454bd5e0ec6b975e648d08064e44f3ac1b945c9005706e9af3f5d"
   head "http://git.imagemagick.org/repos/ImageMagick.git"
-  revision 1
-
-  bottle do
-    sha256 "2f8807e39abcf51a2ce1e7f0986d67091155f977731662d3d5e197f09cc0364d" => :sierra
-    sha256 "1a6eff5a1d0039026c1c705e0f6e509b7dde593a20f24ae741a7c95b50824faf" => :el_capitan
-    sha256 "eb35a6b40371b5ee8970648f81c6956d6bbbc72872efe640d33a931a7ed297ee" => :yosemite
-  end
 
   option "with-fftw", "Compile with FFTW support"
   option "with-hdri", "Compile with HDRI support"


### PR DESCRIPTION
which is the last still hosted

The prior version's downloads are no longer available anywhere, and the Bintray mirror is, sadly, no longer with us.