### PR TITLE
qemu: Enable the SDL UI frontend by default on OS X < 10.5.

### DIFF
--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -16,7 +16,12 @@ class Qemu < Formula
   depends_on "glib"
   depends_on "pixman"
   depends_on "vde" => :optional
-  depends_on "sdl" => :optional
+  if MacOS.version < :leopard
+    # Enable the SDL UI by default on OS X versions older than 10.5 because the Cocoa UI (which is otherwise enabled by default) is unavailable on these OS X versions.
+    depends_on "sdl" => :recommended
+  else
+    depends_on "sdl" => :optional
+  end
   depends_on "gtk+" => :optional
   depends_on "libssh2" => :optional
 
@@ -46,7 +51,7 @@ class Qemu < Formula
       --disable-guest-agent
     ]
 
-    # Cocoa UI uses features that require 10.5 or newer
+    # The Cocoa UI uses features that require OS X 10.5 or newer, so we only enable it by default on those OS X versions.
     if MacOS.version > :tiger
       args << "--enable-cocoa"
     else


### PR DESCRIPTION
QEMU normally enables the Cocoa UI frontend by default when building for OS X, but this is unusable on < 10.5 due to missing features on these OS X versions.

This change allows users building QEMU for 10.4.x to have a UI by default (like what you would get building it for >= 10.5), instead of having to remember to specify the `--with-sdl` build flag.

Otherwise, OS X 10.4.x users who run `brew install qemu` without this commit will end up building headless/VNC-only binaries of QEMU, which they may not expect.

---

`brew install qemu` → **PASS** (OS X 10.5.8 [`--cc=gcc-7` is required, a future PR will address this] and OS X 10.4.11, both PowerPC)
`brew audit qemu` → **PASS**
`brew test qemu` → **PASS** (PR #769 required)