### PR TITLE
qemu: Updated test image URL as the old one is no longer available. Improved test block by checking every built binary's `--version` output for either the expected version string or "QEMU emulator" to verify that the binaries have been built correctly.

### DIFF
--- a/Library/Formula/qemu.rb
+++ b/Library/Formula/qemu.rb
@@ -20,10 +20,10 @@ class Qemu < Formula
   depends_on "gtk+" => :optional
   depends_on "libssh2" => :optional
 
-  # 3.2MB working disc-image file hosted on upstream's servers for people to use to test qemu functionality.
-  resource "armtest" do
-    url "http://wiki.qemu.org/download/arm-test-0.2.tar.gz"
-    sha256 "4b4c2dce4c055f0a2adb93d571987a3d40c96c6cbfd9244d19b9708ce5aea454"
+  # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
+  resource "test-image" do
+    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
+    sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 
   def install
@@ -65,7 +65,36 @@ class Qemu < Formula
   end
 
   test do
-    resource("armtest").stage testpath
-    assert_match /file format: raw/, shell_output("#{bin}/qemu-img info arm_root.img")
+    expected = build.stable? ? version.to_s : "QEMU emulator"
+    assert_match expected, shell_output("#{bin}/qemu-system-aarch64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-alpha --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-arm --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-cris --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-i386 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-lm32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-m68k --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-microblaze --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-microblazeel --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mips64el --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-mipsel --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-moxie --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-or32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppc --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppc64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-ppcemb --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-s390x --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sh4 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sh4eb --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sparc --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-sparc64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-tricore --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-unicore32 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-x86_64 --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-xtensa --version")
+    assert_match expected, shell_output("#{bin}/qemu-system-xtensaeb --version")
+    resource("test-image").stage testpath
+    assert_match "file format: raw", shell_output("#{bin}/qemu-img info FLOPPY.img")
   end
 end


### PR DESCRIPTION
Here's what the new `brew test qemu` output is like:
```console
karen002ppc-osx104:~ karen$ brew test qemu
Testing qemu
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-aarch64 --version

(process:28027): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-alpha --version

(process:28029): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-arm --version

(process:28031): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-cris --version

(process:28033): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-i386 --version

(process:28035): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-lm32 --version

(process:28037): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-m68k --version

(process:28039): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-microblaze --version

(process:28041): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-microblazeel --version

(process:28043): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-mips --version

(process:28045): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-mips64 --version

(process:28047): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-mips64el --version

(process:28049): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-mipsel --version

(process:28051): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-moxie --version

(process:28053): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-or32 --version

(process:28055): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-ppc --version

(process:28057): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-ppc64 --version

(process:28059): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-ppcemb --version

(process:28061): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-s390x --version

(process:28063): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-sh4 --version

(process:28065): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-sh4eb --version

(process:28067): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-sparc --version

(process:28069): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-sparc64 --version

(process:28071): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-tricore --version

(process:28073): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-unicore32 --version

(process:28075): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-x86_64 --version

(process:28077): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-xtensa --version

(process:28079): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-system-xtensaeb --version

(process:28081): GLib-WARNING **: gmem.c:483: custom memory allocation vtable not supported
==> Downloading https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip
################################################################################################################################################################################################### 100.0%
==> /usr/local/Cellar/qemu/2.2.1_1/bin/qemu-img info FLOPPY.img
karen002ppc-osx104:~ karen$ brew audit qemu
karen002ppc-osx104:~ karen$ 
```

---

`brew install qemu` → **PASS** (OS X 10.5.8 [`--cc=gcc-7` is required for now, I'm working on a PR to address this] and OS X 10.4.11, both PowerPC)
`brew audit qemu` → **PASS**
`brew test qemu` → **PASS**