### PR TITLE
ffmpeg: Always install SDL as a dependency because ffmpeg bottles link against it. Fixes issues #410 and #721.

### DIFF
--- a/Library/Formula/ffmpeg.rb
+++ b/Library/Formula/ffmpeg.rb
@@ -43,6 +43,9 @@ class Ffmpeg < Formula
   depends_on "texi2html" => :build
   depends_on "yasm" => :build
 
+  # Always install SDL as a dependency because ffmpeg bottles link against it.
+  depends_on "sdl"
+
   depends_on "x264" => :recommended
   depends_on "lame" => :recommended
   depends_on "libvo-aacenc" => :recommended
@@ -58,7 +61,6 @@ class Ffmpeg < Formula
   depends_on "opencore-amr" => :optional
   depends_on "libass" => :optional
   depends_on "openjpeg" => :optional
-  depends_on "sdl" if build.with? "ffplay"
   depends_on "speex" => :optional
   depends_on "schroedinger" => :optional
   depends_on "fdk-aac" => :optional


### PR DESCRIPTION
Not much to say about this one, it's just a simple dependency fix for issues #410 and #721.

---

**※ Note:** `brew audit` _does_ report "Use build instead of ARGV to check options" when run against `ffmpeg`, though that is not a result of my changes.

Specifically, it is referring to this line:
```ruby
    args << "--disable-altivec" if !Hardware::CPU.altivec? || (build.bottle? && ARGV.bottle_arch == :g3)
```