### PR TITLE
zlib: Require building with GCC 4.2 or higher. Fixes #594.

### DIFF
--- a/Library/Formula/zlib.rb
+++ b/Library/Formula/zlib.rb
@@ -12,6 +12,10 @@ class Zlib < Formula
     sha256 "1c3d8a42f15b8f8f5427e5038c76538178b2b57759c57101fb07cbbe92d0ba21" => :yosemite
   end
 
+  fails_with :gcc_4_0 do
+    cause "Building zlib with GCC 4.0 results in a static library instead of a shared library, which can cause formulae that depend on zlib to fail to build. Please use a newer version of GCC instead, such as GCC 4.2 (brew install apple-gcc42)."
+  end
+
   keg_only :provided_by_osx
 
   # http://zlib.net/zlib_how.html


### PR DESCRIPTION
Building zlib with GCC 4.0 results in a static library instead of a shared library, which can cause formulae that depend on zlib (such as glib in issue #594) to fail to build.

---

Output on a 10.4.11 system without any newer GCC Tigerbrew packages installed:
```console
karen002ppc-osx104:~ karen$ brew list | grep gcc
karen002ppc-osx104:~ karen$ brew install zlib
Error: zlib cannot be built with any available compilers.
To install this formula, you may need to either:
  brew install apple-gcc42
or:
  brew install gcc
```

Output on a 10.4.11 system with applicable GCC Tigerbrew packages installed:
```console
karen002ppc-osx104:~ karen$ brew install zlib
==> Downloading http://zlib.net/zlib-1.2.11.tar.gz
Already downloaded: /Users/karen/Library/Caches/Homebrew/zlib-1.2.11.tar.gz
==> ./configure --prefix=/usr/local/Cellar/zlib/1.2.11
==> make install
^C
```

---

`brew install zlib` → **PASS** (OS X 10.4.11, PowerPC — this issue does not occur on 10.5)
`brew audit zlib` → **PASS**