### PR TITLE
sdl2_mixer: patch native MIDI issue

### DIFF
--- a/Library/Formula/sdl2_mixer.rb
+++ b/Library/Formula/sdl2_mixer.rb
@@ -24,6 +24,10 @@ class Sdl2Mixer < Formula
   depends_on "libvorbis" => :optional
 
   def install
+    unless build.head?
+      inreplace "native_midi/native_midi_macosx.c", "MusicSequenceLoadSMFData(song->sequence", "MusicSequenceLoadSMFData(retval->sequence"
+    end
+
     ENV.universal_binary if build.universal?
     inreplace "SDL2_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
 

--- a/Library/Formula/sdl2_mixer.rb
+++ b/Library/Formula/sdl2_mixer.rb
@@ -25,6 +25,7 @@ class Sdl2Mixer < Formula
 
   def install
     unless build.head?
+      # work around a bug where an indentifier was misnamed in a OS X + PPC-only section of sdl2_mixer's source
       inreplace "native_midi/native_midi_macosx.c", "MusicSequenceLoadSMFData(song->sequence", "MusicSequenceLoadSMFData(retval->sequence"
     end
 


### PR DESCRIPTION
## Description

This PR fixes the build of `sdl2_mixer`

## Testing

Tested on a PowerBook G3 Pismo with Mac OS X 10.4.11. After this change, `sdl2_mixer` builds and installs no problem!

## Background

I was getting the following error when trying to build `sdl2_mixer` using `brew install -vd sdl2_mixer`:

```
libtool: compile:  /usr/local/bin/gcc-4.2 -Os -w -pipe -mcpu=750 -faltivec -mmacosx-version-min=10.4 -F/usr/local/Frameworks -D_GNU_SOURCE=1 -D_THREAD_SAFE -I/usr/local/include/SDL2 -DHAVE_SIGNAL_H -DHAVE_SETBUF -fvisibility=hidden -DHAVE_FORK -DCMD_MUSIC -DWAV_MUSIC -DMID_MUSIC -DUSE_TIMIDITY_MIDI -I./timidity -DUSE_NATIVE_MIDI -I./native_midi -c native_midi/native_midi_macosx.c  -fno-common -DPIC -o build/.libs/native_midi_macosx.o
native_midi/native_midi_macosx.c: In function ‘native_midi_loadsong_RW’:
native_midi/native_midi_macosx.c:204: error: ‘song’ undeclared (first use in this function)
native_midi/native_midi_macosx.c:204: error: (Each undeclared identifier is reported only once
native_midi/native_midi_macosx.c:204: error: for each function it appears in.)
make: *** [build/native_midi_macosx.lo] Error 1
```

Inspecting the source code, it seems there's [an ifdef that checks for PPC](https://github.com/libsdl-org/SDL_mixer/blob/dff4911212c3c3bcfd7a25cfc37cfa8d606dc7aa/native_midi/native_midi_macosx.c#L203-L209), and if so, uses a different function -- but it passes the wrong value and dereferences and undeclared identifier. Perhaps they forgot to replace that along the way when renaming identifiers, or it was a copy/paste error. In any case, this fixes it.

## Should this be an upstream patch?

Note that this is my first time contributing to Homebrew, and I may not have done this correctly. I read this in the [Homebrew docs](https://docs.brew.sh/Formula-Cookbook):

> [inreplace](https://rubydoc.brew.sh/Utils/Inreplace) should be used instead of patches when patching something that will never be accepted upstream, e.g. making the software’s build system respect Homebrew’s installation hierarchy. If it’s something that affects both Homebrew and MacPorts (i.e. macOS specific) it should be turned into an upstream submitted patch instead.

And honestly, I don't think this would be accepted as a patch to an old version of SDL specifically for old PPC Macs... I can look into it if that's the right thing to do. Note that this PPC-specific code [has been ripped out](https://github.com/libsdl-org/SDL_mixer/commit/25cb36e8994a7583c4374b76a545dc6eaa02853f), and the bug is still present in 2.0.4.