### PR TITLE
libevent: Upgrade formula to v2.1.12-stable

### DIFF
--- a/Library/Formula/libevent.rb
+++ b/Library/Formula/libevent.rb
@@ -1,8 +1,8 @@
 class Libevent < Formula
   desc "Asynchronous event library"
   homepage "http://libevent.org"
-  url "https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz"
-  sha256 "71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3"
+  url "https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz"
+  sha256 "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
 
   bottle do
     cellar :any


### PR DESCRIPTION
Needed to support OpenSSL version 1.1.0 and newer.

Required when PR https://github.com/mistydemeo/tigerbrew/pull/805 is merged