### PR TITLE
lynx: Update formula to v2.8.9r1

### DIFF
--- a/Library/Formula/lynx.rb
+++ b/Library/Formula/lynx.rb
@@ -1,9 +1,9 @@
 class Lynx < Formula
   desc "Text-based web browser"
   homepage "http://lynx.isc.org/release/"
-  url "http://invisible-mirror.net/archives/lynx/tarballs/lynx2.8.8rel.2.tar.bz2"
-  version "2.8.8rel.2"
-  sha256 "6980e75cf0d677fd52c116e2e0dfd3884e360970c88c8356a114338500d5bee7"
+  url "http://invisible-mirror.net/archives/lynx/tarballs/lynx2.8.9rel.1.tar.bz2"
+  version "2.8.9rel.1"
+  sha256 "387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
   revision 1
 
   bottle do


### PR DESCRIPTION
Needed to support OpenSSL version 1.1.0 and newer.

Required when PR https://github.com/mistydemeo/tigerbrew/pull/805 is merged