### PR TITLE
openssh: Add formula for v9.3p1

### DIFF
--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -13,11 +13,11 @@ class Openssh < Formula
   depends_on "pkg-config" => :build
   depends_on "ldns"
   depends_on "openssl"
+  depends_on "zlib"
 
   #uses_from_macos "lsof" => :test
   #uses_from_macos "krb5"
   #uses_from_macos "libedit"
-  #uses_from_macos "zlib"
 
     # Both these patches are applied by Apple.
     # https://github.com/apple-oss-distributions/OpenSSH/blob/main/openssh/sandbox-darwin.c#L66
@@ -46,6 +46,7 @@ class Openssh < Formula
       --with-kerberos5
       --with-pam
       --with-ssl-dir=#{Formula["openssl"].opt_prefix}
+      --with-zlib=#{Formula["zlib"].opt_prefix}
     ]
 
     if OS.mac?

--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -1,0 +1,81 @@
+class Openssh < Formula
+  desc "OpenBSD freely-licensed SSH connectivity tools"
+  homepage "https://www.openssh.com/"
+  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.3p1.tar.gz"
+  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.3p1.tar.gz"
+  version "9.3p1"
+  sha256 "e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8"
+  license "SSH-OpenSSH"
+
+  # Please don't resubmit the keychain patch option. It will never be accepted.
+  # https://archive.is/hSB6d#10%25
+
+  depends_on "pkg-config" => :build
+  depends_on "ldns"
+  depends_on "openssl"
+
+  #uses_from_macos "lsof" => :test
+  #uses_from_macos "krb5"
+  #uses_from_macos "libedit"
+  #uses_from_macos "zlib"
+
+    # Both these patches are applied by Apple.
+    # https://github.com/apple-oss-distributions/OpenSSH/blob/main/openssh/sandbox-darwin.c#L66
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/1860b0a745f1fe726900974845d1b0dd3c3398d6/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff"
+      sha256 "d886b98f99fd27e3157b02b5b57f3fb49f43fd33806195970d4567f12be66e71"
+    end
+
+    # https://github.com/apple-oss-distributions/OpenSSH/blob/main/openssh/sshd.c#L532
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2612fd251ac6de17bf0cc5174c3aab94c/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
+      sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
+    end
+
+  resource "com.openssh.sshd.sb" do
+    url "https://raw.githubusercontent.com/apple-oss-distributions/OpenSSH/OpenSSH-268.100.4/com.openssh.sshd.sb"
+    sha256 "a273f86360ea5da3910cfa4c118be931d10904267605cdd4b2055ced3a829774"
+  end
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}/ssh
+      --with-ldns
+      --with-libedit
+      --with-kerberos5
+      --with-pam
+      --with-ssl-dir=#{Formula["openssl"].opt_prefix}
+    ]
+
+    if OS.mac?
+      ENV.append "CPPFLAGS", "-D__APPLE_SANDBOX_NAMED_EXTERNAL__"
+
+      # Ensure sandbox profile prefix is correct.
+      # We introduce this issue with patching, it's not an upstream bug.
+      inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
+    end
+
+    system "./configure", *args
+    system "make"
+    ENV.deparallelize
+    system "make", "install"
+
+    # This was removed by upstream with very little announcement and has
+    # potential to break scripts, so recreate it for now.
+    # Debian have done the same thing.
+    bin.install_symlink bin/"ssh" => "slogin"
+
+    buildpath.install resource("com.openssh.sshd.sb")
+    (etc/"ssh").install "com.openssh.sshd.sb" => "org.openssh.sshd.sb"
+  end
+
+  test do
+    assert_match "OpenSSH_", shell_output("#{bin}/ssh -V 2>&1")
+
+    port = free_port
+    fork { exec sbin/"sshd", "-D", "-p", port.to_s }
+    sleep 2
+    assert_match "sshd", shell_output("lsof -i :#{port}")
+  end
+end


### PR DESCRIPTION
Obtained from
https://github.com/Homebrew/homebrew-core/blob/e83e6ef77caf25382a7e9e85c16231361a52eee2/Formula/openssh.rb and modified slightly to drop libfido requirement for now.

Uses updated zlib from tigerbrew so depends on PR https://github.com/mistydemeo/tigerbrew/pull/809

Ideally should be merged after PR https://github.com/mistydemeo/tigerbrew/pull/805