### PR TITLE
lz4: Upgrade formula to r193

### DIFF
--- a/Library/Formula/lz4.rb
+++ b/Library/Formula/lz4.rb
@@ -1,10 +1,10 @@
 class Lz4 < Formula
   desc "Lossless compression algorithm"
-  homepage "http://www.lz4.info/"
-  url "https://github.com/Cyan4973/lz4/archive/r131.tar.gz"
-  version "r131"
-  sha256 "9d4d00614d6b9dec3114b33d1224b6262b99ace24434c53487a0c8fd0b18cfed"
-  head "https://github.com/Cyan4973/lz4.git"
+  homepage "https://lz4.github.io/lz4"
+  url "https://github.com/lz4/lz4/archive/refs/tags/v1.9.3.tar.gz"
+  version "r193"
+  sha256 "030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1"
+  head "https://github.com/lz4/lz4.git"
 
   bottle do
     cellar :any
@@ -14,7 +14,15 @@ class Lz4 < Formula
     sha256 "549d8bdae519e3315ecfab95ffd3a657d6991f72571c9720dc7d976d7445bd24" => :mountain_lion
   end
 
+  # -dynamiclib needs to be stated for a shared object to be generated.
+  # https://github.com/lz4/lz4/pull/1220/files
+  patch do
+    url "https://patch-diff.githubusercontent.com/raw/lz4/lz4/pull/1220.patch"
+    sha256 "bf3ebdfef8a0f1fd4e3e1f9892e3b04373f48d5510146dd4b6cd7b655bb4d968"
+  end
+
   def install
+    ENV.enable_warnings if ENV.compiler == :gcc_4_0
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
A newer version than what was previously offered in the formula is required for current version of subversion.