### PR TITLE
libxml2: Upgrade formula to v2.11.4

### DIFF
--- a/Library/Formula/libxml2.rb
+++ b/Library/Formula/libxml2.rb
@@ -1,18 +1,8 @@
 class Libxml2 < Formula
   desc "GNOME XML library"
   homepage "http://xmlsoft.org"
-  url "http://xmlsoft.org/sources/libxml2-2.9.2.tar.gz"
-  mirror "ftp://xmlsoft.org/libxml2/libxml2-2.9.2.tar.gz"
-  sha256 "5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc"
-
-  bottle do
-    cellar :any
-    revision 1
-    sha256 "337cf2bdc5b23f29b7a8ec22c2039e7c3ee98031f49bd4d0b255c53b00ccf4ff" => :el_capitan
-    sha256 "bab1d6e940abc06c087651dbf49e050e27e0fe88a8069eaca49d3137616329f3" => :yosemite
-    sha256 "e61e5048ee1f7c762274896cd469b68f2d0827543cb47de3536505c735224a2e" => :mavericks
-    sha256 "4ad5ab851a5611d2cecdead0264357d93359f19e7b5af2a30807a8a33c68e721" => :mountain_lion
-  end
+  url "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.4.tar.xz"
+  sha256 "737e1d7f8ab3f139729ca13a2494fd17bf30ddb4b7a427cf336252cab57f57f7"
 
   head do
     url "https://git.gnome.org/browse/libxml2", :using => :git
@@ -28,12 +18,7 @@ class Libxml2 < Formula
 
   option :universal
 
-  depends_on :ld64
-
-  fails_with :llvm do
-    build 2326
-    cause "Undefined symbols when linking"
-  end
+  depends_on "xz" => :build
 
   def install
     ENV.universal_binary if build.universal?
@@ -45,7 +30,8 @@ class Libxml2 < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--without-python",
-                          "--without-lzma"
+                          "--with-lzma=#{Formula["xz"].opt_prefix}",
+                          "--with-zlib=#{Formula["zlib"].opt_prefix}"
     system "make"
     ENV.deparallelize
     system "make", "install"


### PR DESCRIPTION
With zlib formula built as a shared library there is no linking issue
Resolves undefined symbol issue part reported in #746 

Requires PR #809 so that a shared library is available to link against.