### PR TITLE
pcre: Upgrade formula to v8.45

### DIFF
--- a/Library/Formula/pcre.rb
+++ b/Library/Formula/pcre.rb
@@ -1,24 +1,8 @@
 class Pcre < Formula
   desc "Perl compatible regular expressions library"
   homepage "http://www.pcre.org/"
-  url "https://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.tar.bz2"
-  mirror "https://downloads.sourceforge.net/project/pcre/pcre/8.39/pcre-8.39.tar.bz2"
-  sha256 "b858099f82483031ee02092711689e7245586ada49e534a06e678b8ea9549e8b"
-
-  bottle do
-    cellar :any
-    revision 1
-    sha256 "1fe865e7df8f4b783eff0482c0c474f51b1a4fe0e37202935bce1954843efa22" => :tiger_g4e
-    sha256 "256b60b3b81e91086442e5f546b6f3bc0f9030630eaeae1c5fc05b5a4e3443d3" => :leopard_g4e
-  end
-
-  head do
-    url "svn://vcs.exim.org/pcre/code/trunk"
-
-    depends_on "automake" => :build
-    depends_on "autoconf" => :build
-    depends_on "libtool" => :build
-  end
+  url "https://downloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.bz2"
+  sha256 "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
 
   option :universal
 
@@ -49,7 +33,6 @@ class Pcre < Formula
     # JIT fails tests very badly on PPC right now
     args << "--enable-jit" unless Hardware::CPU.type == :ppc
 
-    system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make"
     ENV.deparallelize


### PR DESCRIPTION
PCRE is now EoL (pcre2 is where development happens), so drop support from building from head of branch.