### PR TITLE
gobject-introspection: Upgrade formula to v1.60.2

### DIFF
--- a/Library/Formula/gobject-introspection.rb
+++ b/Library/Formula/gobject-introspection.rb
@@ -1,16 +1,8 @@
 class GobjectIntrospection < Formula
   desc "Generate interface introspection data for GObject libraries"
   homepage "https://live.gnome.org/GObjectIntrospection"
-  url "https://download.gnome.org/sources/gobject-introspection/1.44/gobject-introspection-1.44.0.tar.xz"
-  sha256 "6f0c2c28aeaa37b5037acbf21558098c4f95029b666db755d3a12c2f1e1627ad"
-
-  bottle do
-    revision 2
-    sha256 "2b70ddf6f20e91dbded15f54fbf770879e815a677f8eb9eec0f587b31aa1c17c" => :el_capitan
-    sha256 "e29497a4aa084f25f7d53988beab1999c4b3145896f0ef6a993b0d7736269cbd" => :yosemite
-    sha256 "1e0e84d4d114f39d89549bc5a6bfae59a84655a1aefce926d8dd6e53495390ae" => :mavericks
-    sha256 "3dcfedfe989ec4d9c6558def0190ef3bd3214bafa4d2f53fd28aa1abbc1403f2" => :mountain_lion
-  end
+  url "https://download.gnome.org/sources/gobject-introspection/1.60/gobject-introspection-1.60.2.tar.xz"
+  sha256 "ffdfe2368fb2e34a547898b01aac0520d52d8627fdeb1c306559bcb503ab5e9c"
 
   option :universal
 
@@ -18,7 +10,7 @@ class GobjectIntrospection < Formula
   depends_on "pkg-config" => :run
   depends_on "glib"
   depends_on "libffi"
-  depends_on :python if MacOS.version < :snow_leopard
+  depends_on "python3"
 
   resource "tutorial" do
     url "https://gist.github.com/7a0023656ccfe309337a.git",


### PR DESCRIPTION
v1.60.2 is the last version to support autoconf.
More recent versions require meson.