### PR TITLE
json-glib: Upgrade formula to v1.2.8

### DIFF
--- a/Library/Formula/json-glib.rb
+++ b/Library/Formula/json-glib.rb
@@ -1,17 +1,11 @@
 class JsonGlib < Formula
   desc "Library for JSON, based on GLib"
   homepage "https://live.gnome.org/JsonGlib"
-  url "https://download.gnome.org/sources/json-glib/1.0/json-glib-1.0.4.tar.xz"
-  sha256 "80f3593cb6bd13f1465828e46a9f740e2e9bd3cd2257889442b3e62bd6de05cd"
-
-  bottle do
-    sha256 "08cf8e09c827d20869eb11b6a5422caf49a291142dc3c403cc4392b15d03d1fb" => :el_capitan
-    sha256 "6892a414c3e09d955ddf5ae6b757d5b49c46fc4adb230afda9262a821a5da3af" => :yosemite
-    sha256 "d45ce5b7d2a3077b61a36565792b626e15ffc2b3f3cdc1011b349ee770b6019b" => :mavericks
-    sha256 "ef7772e0fc8f65c2b6b795de8b6743cefad78b309eeccf12e92c23705bd6f4a2" => :mountain_lion
-  end
+  url "https://download.gnome.org/sources/json-glib/1.2/json-glib-1.2.8.tar.xz"
+  sha256 "fd55a9037d39e7a10f0db64309f5f0265fa32ec962bf85066087b83a2807f40a"
 
   depends_on "pkg-config" => :build
+  depends_on "make" => :build
   depends_on "glib"
   depends_on "gobject-introspection"
 
@@ -20,7 +14,7 @@ class JsonGlib < Formula
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-introspection=yes"
-    system "make", "install"
+    system "gmake", "install"
   end
 
   test do


### PR DESCRIPTION
v1.2.8 is the last version to support autoconf.
More recent versions require meson.
Require up to date make as older version in Tiger is unable to build.

Resolves #804 
Ideally should be merged after PR #846 