### PR TITLE
nginx: Upgrade formula to v1.25.2

### DIFF
--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -1,22 +1,9 @@
 class Nginx < Formula
   desc "HTTP(S) server and reverse proxy, and IMAP/POP3 proxy server"
   homepage "http://nginx.org/"
-  url "http://nginx.org/download/nginx-1.8.0.tar.gz"
-  sha256 "23cca1239990c818d8f6da118320c4979aadf5386deda691b1b7c2c96b9df3d5"
+  url "https://nginx.org/download/nginx-1.25.2.tar.gz"
+  sha256 "05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711"
   head "http://hg.nginx.org/nginx/", :using => :hg
-
-  bottle do
-    revision 1
-    sha256 "e6bb9cc02def5205747dc20ffd7c24a3c0e34a7494355a9b0dade58dd8ce9dcf" => :el_capitan
-    sha256 "6df7b883f9214c5c0969559f6cc9ed56f9537263a1ef4882dae77b0b7af5a1df" => :yosemite
-    sha256 "68741910d6ee58f7ee1134c7b4c62dfd490ee337c9c0beb0d188edc418b0bd93" => :mavericks
-    sha256 "a622d0e1bfd55d8634520d72b41319da19828b9ab11063b6243d5b5f3d77ad08" => :mountain_lion
-  end
-
-  devel do
-    url "http://nginx.org/download/nginx-1.9.5.tar.gz"
-    sha256 "48e2787a6b245277e37cb7c5a31b1549a0bbacf288aa4731baacf9eaacdb481b"
-  end
 
   env :userpaths
 
@@ -26,36 +13,37 @@ class Nginx < Formula
   option "with-passenger", "Compile with support for Phusion Passenger module"
   option "with-webdav", "Compile with support for WebDAV module"
   option "with-debug", "Compile with support for debug log"
-  option "with-spdy", "Compile with support for SPDY module"
+  option "with-http3", "Compile with support for HTTP/3 module"
   option "with-gunzip", "Compile with support for gunzip module"
 
-  depends_on "pcre"
+  depends_on "pcre2"
   depends_on "passenger" => :optional
   depends_on "openssl" => :recommended
   depends_on "libressl" => :optional
+  depends_on "zlib"
 
   def install
     # Changes default port to 8080
     inreplace "conf/nginx.conf", "listen       80;", "listen       8080;"
     inreplace "conf/nginx.conf", "    #}\n\n}", "    #}\n    include servers/*;\n}"
 
-    pcre = Formula["pcre"]
+    pcre = Formula["pcre2"]
     openssl = Formula["openssl"]
     libressl = Formula["libressl"]
+    zlib = Formula["zlib"]
 
     if build.with? "libressl"
-      cc_opt = "-I#{pcre.include} -I#{libressl.include}"
-      ld_opt = "-L#{pcre.lib} -L#{libressl.lib}"
+      cc_opt = "-I#{pcre.include} -I#{libressl.include} -I#{zlib.include}"
+      ld_opt = "-L#{pcre.lib} -L#{libressl.lib} -L#{zlib.lib}"
     else
-      cc_opt = "-I#{pcre.include} -I#{openssl.include}"
-      ld_opt = "-L#{pcre.lib} -L#{openssl.lib}"
+      cc_opt = "-I#{pcre.include} -I#{openssl.include} -I#{zlib.include}"
+      ld_opt = "-L#{pcre.lib} -L#{openssl.lib} -L#{zlib.lib}"
     end
 
     args = %W[
       --prefix=#{prefix}
       --with-http_ssl_module
       --with-pcre
-      --with-ipv6
       --sbin-path=#{bin}/nginx
       --with-cc-opt=#{cc_opt}
       --with-ld-opt=#{ld_opt}
@@ -70,6 +58,7 @@ class Nginx < Formula
       --http-log-path=#{var}/log/nginx/access.log
       --error-log-path=#{var}/log/nginx/error.log
       --with-http_gzip_static_module
+      --with-http_v2_module
     ]
 
     if build.with? "passenger"
@@ -80,17 +69,7 @@ class Nginx < Formula
     args << "--with-http_dav_module" if build.with? "webdav"
     args << "--with-debug" if build.with? "debug"
     args << "--with-http_gunzip_module" if build.with? "gunzip"
-
-    # This became "with-http_v2_module" in 1.9.5
-    # http://nginx.org/en/docs/http/ngx_http_spdy_module.html
-    # We handle devel/stable block variable options badly, so this installs
-    # the expected module rather than fatally bailing out of configure.
-    # The option should be deprecated to the new name when stable.
-    if build.devel? || build.head? && build.with?("spdy")
-      args << "--with-http_v2_module"
-    elsif build.with?("spdy")
-      args << "--with-http_spdy_module"
-    end
+    args << "--with-http_v3_module" if build.with? "http3"
 
     if build.head?
       system "./auto/configure", *args


### PR DESCRIPTION
Switch from PCRE to PCRE2 as that former is EoL.
Avoid using the OS supplied zlib
Build HTTP/2 support by default as it's standardised, introduce HTTP/3 support as an option in its place which is now experimental.

Needs PR #805 