### PR TITLE
pixman: Upgrade formula to v0.42.2

### DIFF
--- a/Library/Formula/pixman.rb
+++ b/Library/Formula/pixman.rb
@@ -1,16 +1,8 @@
 class Pixman < Formula
   desc "Low-level library for pixel manipulation"
   homepage "http://cairographics.org/"
-  url "http://cairographics.org/releases/pixman-0.32.6.tar.gz"
-  sha256 "3dfed13b8060eadabf0a4945c7045b7793cc7e3e910e748a8bb0f0dc3e794904"
-
-  bottle do
-    cellar :any
-    revision 3
-    sha256 "524fdd4815e099818205d1db925e0e648a489fca91f9f5cc727c825ac62451b8" => :el_capitan
-    sha256 "07e3ec0198efc4799e7841dbb64f2faeadcf846707f6f8eabe2d2dc037b2ee97" => :yosemite
-    sha256 "28508d2b6737c68a50020b9b4659ad2575437d032d13c496e57dbac9aee18cbb" => :mavericks
-  end
+  url "https://www.cairographics.org/releases/pixman-0.42.2.tar.gz"
+  sha256 "ea1480efada2fd948bc75366f7c349e1c96d3297d09a3fe62626e38e234a625e"
 
   option :universal
 
@@ -59,4 +51,24 @@ class Pixman < Formula
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end
+
+  # Older versions of GCC have issue with scaled_nearest_scanline_vmx_8888_8888_OVER()
+  # https://lists.freedesktop.org/archives/pixman/2016-April/004577.html
+  patch :p0, :DATA
+
 end
+__END__
+--- pixman/pixman-vmx.c.orig	2023-05-26 02:25:41.000000000 +0100
++++ pixman/pixman-vmx.c	2023-05-26 02:27:10.000000000 +0100
+@@ -2933,10 +2933,7 @@
+ 	while (vx >= 0)
+ 	    vx -= src_width_fixed;
+ 
+-	tmp[0] = tmp1;
+-	tmp[1] = tmp2;
+-	tmp[2] = tmp3;
+-	tmp[3] = tmp4;
++	tmp = (vector unsigned int){tmp1, tmp2, tmp3, tmp4};
+ 
+ 	vsrc = combine4 ((const uint32_t *) &tmp, pm);
+ 


### PR DESCRIPTION
TODO:
The code in the test section works, and completes successfully. The test is considered a failure by brew though as pixman_image_unref() returns a boolean value where true is successful, and brew expects a zero (false).