### PR TITLE
git: Upgrade formula to v2.40.1

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -1,8 +1,8 @@
 class Git < Formula
   desc "Distributed revision control system"
   homepage "https://git-scm.com"
-  url "https://www.kernel.org/pub/software/scm/git/git-2.10.2.tar.xz"
-  sha256 "94802903dd707d85ca3b9a2be35e936a54ce86375f52c6a789efe7ce7e238671"
+  url "https://www.kernel.org/pub/software/scm/git/git-2.40.1.tar.xz"
+  sha256 "4893b8b98eefc9fdc4b0e7ca249e340004faa7804a433d17429e311e1fef21d2"
   head "https://github.com/git/git.git", :shallow => false
 
   bottle do
@@ -11,34 +11,32 @@ class Git < Formula
   end
 
   resource "html" do
-    url "https://www.kernel.org/pub/software/scm/git/git-htmldocs-2.10.2.tar.xz"
-    sha256 "dd43111c3518a92a7fe64ac5cd32a5d4d77d49c67f7d89dce3e8293bc3d6b491"
+    url "https://www.kernel.org/pub/software/scm/git/git-htmldocs-2.40.1.tar.xz"
+    sha256 "8c08b31087566e719f6a7d16bb102255a8b9b970aefba6e306d6340eefe368ee"
   end
 
   resource "man" do
-    url "https://www.kernel.org/pub/software/scm/git/git-manpages-2.10.2.tar.xz"
-    sha256 "83b0a317f6039ad95ef6af6a182cf659c2d053eed5d8f70b06710eb787f8aa6f"
+    url "https://www.kernel.org/pub/software/scm/git/git-manpages-2.40.1.tar.xz"
+    sha256 "fe059c948ba3d169537b5b6b24f19726881057dfd4e5987f37789884d42fde13"
   end
 
   option "with-blk-sha1", "Compile with the block-optimized SHA1 implementation"
   option "without-completions", "Disable bash/zsh completions from 'contrib' directory"
-  option "with-brewed-curl", "Use Homebrew's version of cURL library" if MacOS.version > :snow_leopard
   option "with-brewed-svn", "Use Homebrew's version of SVN"
   option "with-persistent-https", "Build git-remote-persistent-https from 'contrib' directory"
 
   if MacOS.version == :tiger
     # system tar has odd permissions errors
     depends_on "gnu-tar" => :build
-    # Tiger's ld produces bad install-names for a keg-only curl
-    depends_on "ld64" => :build
-    depends_on "cctools" => :build
   end
 
   depends_on :expat
-  depends_on "pcre" => :optional
-  depends_on "gettext" => :optional
+  depends_on "pcre2" => :optional
+  depends_on "gettext"
   depends_on "openssl"
-  depends_on "curl" if MacOS.version < :snow_leopard || build.with?("brewed-curl")
+  depends_on "openssh" => :run
+  depends_on "curl"
+  depends_on "make" => :build
   depends_on "go" => :build if build.with? "persistent-https"
   # Trigger an install of swig before subversion, as the "swig" doesn't get pulled in otherwise
   # See https://github.com/Homebrew/homebrew/issues/34554
@@ -47,18 +45,9 @@ class Git < Formula
     depends_on "subversion" => "with-perl"
   end
 
-  # ld64 understands -rpath but rejects it on Tiger
-  patch :p1 do
-    url "https://trac.macports.org/export/106975/trunk/dports/devel/git-core/files/patch-Makefile.diff"
-    sha1 "f033e5b78ecbfcc14b7994f98a74dfdbe607eea0"
-  end if MacOS.version < :leopard
-
   def install
-    # git's index-pack will segfault unless compiled without optimization
-    # with the Tigerbrew apple-gcc42 on Tiger
-    if MacOS.version < :leopard && ENV.compiler == :gcc
-      ENV.no_optimization
-    end
+    # GCC is invoked with -w
+    ENV.enable_warnings if ENV.compiler == :gcc_4_0
 
     if MacOS.version == :tiger
       tar = Formula['gnu-tar']
@@ -76,13 +65,9 @@ class Git < Formula
     ENV["NO_R_TO_GCC_LINKER"] = "1" # pass arguments to LD correctly
     ENV["PYTHON_PATH"] = which "python"
     ENV["PERL_PATH"] = which "perl"
-    ENV["CURLDIR"] = Formula["curl"].opt_prefix if MacOS.version < :snow_leopard
+    ENV["CURLDIR"] = Formula["curl"].opt_prefix
     ENV["NO_APPLE_COMMON_CRYPTO"] = "1" if MacOS.version < :leopard
-
-    # Support Tcl versions before "lime" color name was introduced
-    # https://github.com/Homebrew/homebrew-core/issues/115
-    # https://www.mail-archive.com/git%40vger.kernel.org/msg92017.html
-    inreplace "gitk-git/gitk", "lime", '"#99FF00"'
+    ENV.append "CFLAGS", "-std=gnu99"
 
     perl_version = /\d\.\d+/.match(`perl --version`)
 
@@ -107,9 +92,9 @@ class Git < Formula
 
     ENV["BLK_SHA1"] = "1" if build.with? "blk-sha1"
 
-    if build.with? "pcre"
+    if build.with? "pcre2"
       ENV["USE_LIBPCRE"] = "1"
-      ENV["LIBPCREDIR"] = Formula["pcre"].opt_prefix
+      ENV["LIBPCREDIR"] = Formula["pcre2"].opt_prefix
     end
 
     ENV["NO_GETTEXT"] = "1" if build.without? "gettext"
@@ -122,20 +107,20 @@ class Git < Formula
       LDFLAGS=#{ENV.ldflags}
     ]
 
-    system "make", "install", *args
+    system "gmake", "install", *args
 
     # Install the OS X keychain credential helper
     cd "contrib/credential/osxkeychain" do
-      system "make", "CC=#{ENV.cc}",
+      system "gmake", "CC=#{ENV.cc}",
                      "CFLAGS=#{ENV.cflags}",
                      "LDFLAGS=#{ENV.ldflags}"
       bin.install "git-credential-osxkeychain"
-      system "make", "clean"
+      system "gmake", "clean"
     end
 
     # Install git-subtree
     cd "contrib/subtree" do
-      system "make", "CC=#{ENV.cc}",
+      system "gmake", "CC=#{ENV.cc}",
                      "CFLAGS=#{ENV.cflags}",
                      "LDFLAGS=#{ENV.ldflags}"
       bin.install "git-subtree"
@@ -143,7 +128,7 @@ class Git < Formula
 
     if build.with? "persistent-https"
       cd "contrib/persistent-https" do
-        system "make"
+        system "gmake"
         bin.install "git-remote-persistent-http",
                     "git-remote-persistent-https",
                     "git-remote-persistent-https--proxy"
@@ -199,4 +184,71 @@ class Git < Formula
     system bin/"git", "commit", "-a", "-m", "Initial Commit"
     assert_equal "haunted\nhouse", shell_output("#{bin}/git ls-files").strip
   end
+  # Fix PowerPC build and support for OS X Tiger
+  # e.g supplied pcre is too old, lacks some file system monitoring functionality
+  patch :p0, :DATA
 end
+__END__
+--- sha1dc/sha1.c.orig	2023-04-08 03:00:31.000000000 +0000
++++ sha1dc/sha1.c
+@@ -102,6 +102,10 @@
+  */
+ #define SHA1DC_BIGENDIAN
+ 
++#elif (defined(__APPLE__) && defined(__BIG_ENDIAN__) && !defined(SHA1DC_BIGENDIAN))
++/* older gcc compilers which are the default on Apple PPC do not define __BYTE_ORDER__ */
++#define SHA1DC_BIGENDIAN
++
+ /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> or <os whitelist> */
+ #elif defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
+ /*
+--- config.mak.uname.orig	2023-05-17 06:25:11.000000000 +0100
++++ config.mak.uname	2023-05-17 06:27:15.000000000 +0100
+@@ -127,6 +127,9 @@
+ 	ifeq ($(shell expr "$(uname_R)" : '[15678]\.'),2)
+ 		OLD_ICONV = UnfortunatelyYes
+ 		NO_APPLE_COMMON_CRYPTO = YesPlease
++		NO_REGEX=YesPlease
++	else
++		USE_ENHANCED_BASIC_REGULAR_EXPRESSIONS = YesPlease
+ 	endif
+ 	ifeq ($(shell expr "$(uname_R)" : '[15]\.'),2)
+ 		NO_STRLCPY = YesPlease
+@@ -146,8 +149,7 @@
+ 	HAVE_BSD_SYSCTL = YesPlease
+ 	FREAD_READS_DIRECTORIES = UnfortunatelyYes
+ 	HAVE_NS_GET_EXECUTABLE_PATH = YesPlease
+-	CSPRNG_METHOD = arc4random
+-	USE_ENHANCED_BASIC_REGULAR_EXPRESSIONS = YesPlease
++	CSPRNG_METHOD = openssl
+ 
+ 	# Workaround for `gettext` being keg-only and not even being linked via
+ 	# `brew link --force gettext`, should be obsolete as of
+@@ -160,6 +162,7 @@
+ 		endif
+ 	endif
+ 
++	ifneq ($(shell expr "$(uname_R)" : '[15678]\.'),2)
+ 	# The builtin FSMonitor on MacOS builds upon Simple-IPC.  Both require
+ 	# Unix domain sockets and PThreads.
+ 	ifndef NO_PTHREADS
+@@ -168,6 +171,7 @@
+ 	FSMONITOR_OS_SETTINGS = darwin
+ 	endif
+ 	endif
++	endif
+ 
+ 	BASIC_LDFLAGS += -framework CoreServices
+ endif
+--- Makefile.orig       2023-05-19 19:22:10.000000000 +0100
++++ Makefile    2023-05-19 19:22:53.000000000 +0100
+@@ -1351,7 +1351,7 @@
+ # Older versions of GCC may require adding "-std=gnu99" at the end.
+ CFLAGS = -g -O2 -Wall
+ LDFLAGS =
+-CC_LD_DYNPATH = -Wl,-rpath,
++CC_LD_DYNPATH = -L
+ BASIC_CFLAGS = -I.
+ BASIC_LDFLAGS =
+ 
+


### PR DESCRIPTION
Git now requires pcre2, and a more recent version of make than is bundled with Tiger at least.
Use curl from tigerbrew regardless of OS version as we need to use modern openssl.
gitk now specifies a different set of colours specified in hex.
Built on Tiger with GCC 4.0 using `--with-brewed-svn --with-pcre2`

Needs #805, #810, #811, #836 and ideally #860 