### PR TITLE
muttils: Upgrade formula to v1.4

### DIFF
--- a/Library/Formula/muttils.rb
+++ b/Library/Formula/muttils.rb
@@ -1,16 +1,9 @@
 class Muttils < Formula
   desc "Provides utilities for use with console mail clients, eg. Mutt."
-  homepage "https://bitbucket.org/blacktrash/muttils/"
-  url "https://bitbucket.org/blacktrash/muttils/get/1.3.tar.gz"
-  sha256 "c8b456b660461441de8927ccff7e9f444894d6550d0777ed7bd160b8f9caddbf"
-  bottle do
-    cellar :any
-    sha256 "d976f7445a3142ff1c311cf19302b5fcc2976b0a26c0bb48e57e157bd4c7002f" => :yosemite
-    sha256 "01f0c26274540336fa829a8718bb0c3a2a5b5aa3c96c1f4ec7cf79e6263b837b" => :mavericks
-    sha256 "63e819c0bb96a56ed0f159ab816aeac84805a52333bd23298a17cd2abddcb17b" => :mountain_lion
-  end
-
-  head "https://bitbucket.org/blacktrash/muttils", :using => :hg
+  homepage "https://hg.phloxic.productions/muttils"
+  url "https://hg.phloxic.productions/muttils/archive/07e310d44b55.tar.bz2"
+  sha256 "f3392a027b0def2c37478de9d3e8e8e4fe087004f690e84d536aa39dd4b9cc80"
+  version "1.4"
 
   depends_on :python if MacOS.version <= :snow_leopard
 


### PR DESCRIPTION
After v1.4, head dropped Python 2 support and now requires 3.8 min.
Since we currently package 3.7, drop support for building head for now.