### PR TITLE
ncurses: Upgrade formula to v6.4

### DIFF
--- a/Library/Formula/ncurses.rb
+++ b/Library/Formula/ncurses.rb
@@ -1,42 +1,17 @@
 class Ncurses < Formula
   desc "Text-based UI library"
   homepage "https://www.gnu.org/s/ncurses/"
-  url "https://ftpmirror.gnu.org/ncurses/ncurses-6.0.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz"
-  sha256 "f551c24b30ce8bfb6e96d9f59b42fbea30fa3a6123384172f9e7284bcf647260"
-  revision 3
-
-  bottle do
-    sha256 "0b9103ce95f809c4ac104679a0c44f54bc2374c517447da9eb55b85bcad7d675" => :sierra
-    sha256 "daf1454abfe7785a642cc614e1b671f1e95ea797d9d1d0daaa5e7cb3800e0b69" => :el_capitan
-    sha256 "a73f869e5dc82d43fa05cdb86200a8a7b7e04b4da1902e9cdf77c90a94d678ad" => :yosemite
-  end
+  url "https://ftpmirror.gnu.org/ncurses/ncurses-6.4.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz"
+  sha256 "6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159"
 
   keg_only :provided_by_osx
 
   depends_on "pkg-config" => :build
 
-  # stable rollup patch created by upstream see
-  # http://invisible-mirror.net/archives/ncurses/6.0/README
-  resource "ncurses-6.0-20160910-patch.sh" do
-    url "http://invisible-mirror.net/archives/ncurses/6.0/ncurses-6.0-20160910-patch.sh.bz2"
-    mirror "https://www.mirrorservice.org/sites/lynx.invisible-island.net/ncurses/6.0/ncurses-6.0-20160910-patch.sh.bz2"
-    sha256 "f570bcfe3852567f877ee6f16a616ffc7faa56d21549ad37f6649022f8662538"
-  end
-
   def install
-    # Fix the build for GCC 5.1
-    # error: expected ')' before 'int' in definition of macro 'mouse_trafo'
-    # See https://lists.gnu.org/archive/html/bug-ncurses/2014-07/msg00022.html
-    # and http://trac.sagemath.org/ticket/18301
-    # Disable linemarker output of cpp
-    ENV.append "CPPFLAGS", "-P"
-
-    (lib/"pkgconfig").mkpath
-
-    # stage and apply patch
-    buildpath.install resource("ncurses-6.0-20160910-patch.sh")
-    system "sh", "ncurses-6.0-20160910-patch.sh"
+    # Build breaks passing -w
+    ENV.enable_warnings if ENV.compiler == :gcc_4_0
 
     system "./configure", "--prefix=#{prefix}",
                           "--enable-pc-files",
@@ -94,13 +69,8 @@ class Ncurses < Formula
   test do
     ENV["TERM"] = "xterm"
     system bin/"tput", "cols"
-
-    system prefix/"test/configure", "--prefix=#{testpath}/test",
-                                    "--with-curses-dir=#{prefix}"
-    system "make", "install"
-
-    system testpath/"test/bin/keynames"
-    system testpath/"test/bin/test_arrays"
-    system testpath/"test/bin/test_vidputs"
+    system prefix/"test/keynames"
+    system prefix/"test/test_arrays"
+    system prefix/"test/test_vidputs"
   end
 end


### PR DESCRIPTION
The test programs are already installed as part of the initial build. Skip the test compile process.