### PR TITLE
libsigsegv: Upgrade formula to v2.14

### DIFF
--- a/Library/Formula/libsigsegv.rb
+++ b/Library/Formula/libsigsegv.rb
@@ -1,23 +1,9 @@
 class Libsigsegv < Formula
   desc "Library for handling page faults in user mode"
   homepage "https://www.gnu.org/software/libsigsegv/"
-  url "http://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.10.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.10.tar.gz"
-  sha256 "8460a4a3dd4954c3d96d7a4f5dd5bc4d9b76f5754196aa245287553b26d2199a"
-
-  bottle do
-    cellar :any
-    revision 2
-    sha256 "d19b0b407f01626b9e68974848cae096d3a00c8af5314b19be2278879c57275f" => :el_capitan
-    sha256 "7cc35675981e54794ac49dcadd6daa30abaf4aaae34a18fdc8a6358fb2201896" => :yosemite
-    sha256 "1eb98d94bf58591e7e2cec76725de88f08c8280db6e4f6216fc5b4eeb6623190" => :mavericks
-    sha256 "70fcc5532a085c178a68d378f75d9926d06ee27b5733e0fb7a8d2e1288e8d80a" => :mountain_lion
-  end
-
-  fails_with :llvm do
-    build 2336
-    cause "Fails make check with LLVM GCC from XCode 4 on Snow Leopard"
-  end
+  url "http://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.14.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.14.tar.gz"
+  sha256 "cdac3941803364cf81a908499beb79c200ead60b6b5b40cad124fd1e06caa295"
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -69,7 +55,7 @@ class Libsigsegv < Formula
       }
     EOS
 
-    system ENV.cc, "test.c", "-lsigsegv", "-o", "test"
+    system ENV.cc, "test.c", "-L#{prefix}/lib", "-lsigsegv", "-o", "test"
     assert_match /Test passed/, shell_output("./test")
   end
 end


### PR DESCRIPTION
Fix test but guiding compiler to find libsigsegv to link against.