### PR TITLE
libxslt: Upgrade formula to v1.1.38

### DIFF
--- a/Library/Formula/libxslt.rb
+++ b/Library/Formula/libxslt.rb
@@ -1,17 +1,8 @@
 class Libxslt < Formula
   desc "C XSLT library for GNOME"
   homepage "http://xmlsoft.org/XSLT/"
-  url "http://xmlsoft.org/sources/libxslt-1.1.28.tar.gz"
-  mirror "ftp://xmlsoft.org/libxml2/libxslt-1.1.28.tar.gz"
-  sha256 "5fc7151a57b89c03d7b825df5a0fae0a8d5f05674c0e7cf2937ecec4d54a028c"
-  revision 1
-
-  bottle do
-    sha256 "491daabbc8d2ebbe0184bdd6c6ebe7c99f72899cfabe259c7f7ebcc37947b20b" => :el_capitan
-    sha256 "6d183c0aec7ca84802c54256289d401d05b2ae153956e118df357f70f388fed9" => :yosemite
-    sha256 "3f674b2296134366637b6ab6f8880c124926b768d4ce5230564d4a1265a8797d" => :mavericks
-    sha256 "2530cd13170900d9f6e5cc4c9d57312cffcb0f16a20d12cc4e82ac8e5f4455d9" => :mountain_lion
-  end
+  url "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.38.tar.xz"
+  sha256 "1f32450425819a09acaff2ab7a5a7f8a2ec7956e505d7beeb45e843d0e1ecab1"
 
   keg_only :provided_by_osx
 
@@ -36,6 +27,7 @@ class Libxslt < Formula
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--without-python",
                           "--with-libxml-prefix=#{Formula["libxml2"].opt_prefix}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
Disable python support since in relies on libxml2 and support is optional there.