### PR TITLE
vala: Upgrade formula to v0.56.9

### DIFF
--- a/Library/Formula/vala.rb
+++ b/Library/Formula/vala.rb
@@ -1,18 +1,14 @@
 class Vala < Formula
   desc "Compiler for the GObject type system"
   homepage "https://live.gnome.org/Vala"
-  url "https://download.gnome.org/sources/vala/0.34/vala-0.34.2.tar.xz"
-  sha256 "765e9c2b429a66db93247940f8588319b43f35c173d057bcae5717a97d765c41"
-
-  bottle do
-    sha256 "753e21159857f26069bf64ae2a3137c445a72e0d2b5d8fe2b9c9263480c6df40" => :sierra
-    sha256 "669cfa17a3563a234a9e0bd75d39c5be25ca44c6903e3b192acaf3eaee18e23b" => :el_capitan
-    sha256 "9d82bdc6e081c4f14996361d108be5c0408a621dbfa3242eab67a8b5b68b425f" => :yosemite
-  end
+  url "http://download.gnome.org/sources/vala/0.56/vala-0.56.9.tar.xz"
+  sha256 "55578c7c4f067ace028e541806af240f8084cb6ff0cc554caa8ac08cbf8bce2f"
 
   depends_on "pkg-config" => :run
   depends_on "gettext"
   depends_on "glib"
+  depends_on "graphviz"
+  depends_on "libxslt"
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
Need libxslt since the version shipped with OS is likely out of date & the build breaks.

Requires #887, #888