### PR TITLE
dovecot: Upgrade formula to v2.3.20

### DIFF
--- a/Library/Formula/dovecot.rb
+++ b/Library/Formula/dovecot.rb
@@ -1,24 +1,18 @@
 class Dovecot < Formula
   desc "IMAP/POP3 server"
   homepage "http://dovecot.org/"
-  url "http://dovecot.org/releases/2.2/dovecot-2.2.18.tar.gz"
-  mirror "https://fossies.org/linux/misc/dovecot-2.2.18.tar.gz"
-  sha256 "b6d8468cea47f1227f47b80618f7fb872e2b2e9d3302adc107a005dd083865bb"
-
-  bottle do
-    revision 1
-    sha256 "c4d12d64c360b9f5f45925695e25f23d8adea7ca1241fc9232be4657f88094c6" => :el_capitan
-    sha256 "b0213868f3a9db6992b04d688209c8d35aa472beeb2fd03b937f112857e7f0c0" => :yosemite
-    sha256 "03c6c26881f816b9206efe6ff97df76ceb179696466f8f177ce3d625ad270e2c" => :mavericks
-    sha256 "54ed311a625d029291a644117a3a16c0d9b5ab1158c0ceffe229635ca3a62008" => :mountain_lion
-  end
+  url "https://dovecot.org/releases/2.3/dovecot-2.3.20.tar.gz"
+  mirror "https://fossies.org/linux/misc/dovecot-2.3.20.tar.gz"
+  sha256 "caa832eb968148abdf35ee9d0f534b779fa732c0ce4a913d9ab8c3469b218552"
 
   depends_on "openssl"
   depends_on "clucene" => :optional
 
-  option "with-pam", "Build with PAM support"
-
   def install
+    # Need unsetenv(3) to return int, not void
+    ENV.append_to_cflags "-D__DARWIN_UNIX03" if MacOS.version == :tiger
+    # dovecot expect newer support from kqueue which Leopard and Tiger lack.
+    # disable ioloop & notify kqueue support otherwise dovect will fail to run.
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
@@ -29,10 +23,12 @@ class Dovecot < Formula
       --with-sqlite
       --with-zlib
       --with-bzlib
+      --with-ioloop=none
+      --with-notify=none
+      --with-pam
     ]
 
     args << "--with-lucene" if build.with? "clucene"
-    args << "--with-pam" if build.with? "pam"
 
     system "./configure",  *args
     system "make", "install"
@@ -74,4 +70,27 @@ class Dovecot < Formula
   test do
     assert_match /#{version}/, shell_output("#{sbin}/dovecot --version")
   end
+
+  # .data & .used are members of a union, nested in struct buffer
+  patch :p0, :DATA
 end
+__END__
+--- ./src/lib-smtp/test-smtp-params.c.orig	2023-07-21 15:11:25.000000000 +0100
++++ ./src/lib-smtp/test-smtp-params.c	2023-07-21 15:16:23.000000000 +0100
+@@ -26,12 +26,12 @@
+ };
+ 
+ static struct buffer test_params_buffer1 = {
+-	.data = (void*)&test_params1,
+-	.used = sizeof(test_params1)
++	{{ .data = (void*)&test_params1,
++	.used = sizeof(test_params1) }}
+ };
+ static struct buffer test_params_buffer2 = {
+-	.data = (void*)&test_params2,
+-	.used = sizeof(test_params2)
++	{{ .data = (void*)&test_params2,
++	.used = sizeof(test_params2) }}
+ };
+ 
+ /* Valid mail params tests */

--- a/Library/Formula/fortune.rb
+++ b/Library/Formula/fortune.rb
@@ -1,7 +1,7 @@
 class Fortune < Formula
   desc "Infamous electronic fortune-cookie generator"
-  homepage "http://ftp.ibiblio.org/pub/linux/games/amusements/fortune/!INDEX.html"
-  url "ftp://ftp.ibiblio.org/pub/linux/games/amusements/fortune/fortune-mod-9708.tar.gz"
+  homepage "https://www.ibiblio.org/pub/linux/games/amusements/fortune/!INDEX.html"
+  url "https://www.ibiblio.org/pub/linux/games/amusements/fortune/fortune-mod-9708.tar.gz"
   sha256 "1a98a6fd42ef23c8aec9e4a368afb40b6b0ddfb67b5b383ad82a7b78d8e0602a"
 
   bottle do


### PR DESCRIPTION
Build with PAM support by default, Apple's build of dovecot would patch in OpenDirectory support so auth would likely work without PAM, however without such patch auth fails since user account live in OD, not in the passwd file.

Dovecot detects that kqueue is available and tries to use it for ioloop and notify, however, the version of kqueue in Leopard and Tiger is too old. So while it'll compile ok, it'll fail at runtime when it tries to set the events on startup.

Should be added to the OpenSSL branch I guess, requires #805 

Skipping on making a recommendation for the pam config to add into /etc/pam.d for now since the documentation's advice for OS X doesn't apply to Tiger (they advise using `pam_opendirectory.so` which doesn't exist on the desktop OS. something available on OS X Server?)