### PR TITLE
postgresql: Upgrade formula to v15.3

### DIFF
--- a/Library/Formula/fortune.rb
+++ b/Library/Formula/fortune.rb
@@ -1,7 +1,7 @@
 class Fortune < Formula
   desc "Infamous electronic fortune-cookie generator"
-  homepage "http://ftp.ibiblio.org/pub/linux/games/amusements/fortune/!INDEX.html"
-  url "ftp://ftp.ibiblio.org/pub/linux/games/amusements/fortune/fortune-mod-9708.tar.gz"
+  homepage "https://www.ibiblio.org/pub/linux/games/amusements/fortune/!INDEX.html"
+  url "https://www.ibiblio.org/pub/linux/games/amusements/fortune/fortune-mod-9708.tar.gz"
   sha256 "1a98a6fd42ef23c8aec9e4a368afb40b6b0ddfb67b5b383ad82a7b78d8e0602a"
 
   bottle do

--- a/Library/Formula/postgresql.rb
+++ b/Library/Formula/postgresql.rb
@@ -1,50 +1,37 @@
 class Postgresql < Formula
   desc "Object-relational database system"
   homepage "https://www.postgresql.org/"
-  revision 1
-
-  stable do
-    url "https://ftp.postgresql.org/pub/source/v9.4.4/postgresql-9.4.4.tar.bz2"
-    sha256 "538ed99688d6fdbec6fd166d1779cf4588bf2f16c52304e5ef29f904c43b0013"
-  end
-
-  devel do
-    url "https://ftp.postgresql.org/pub/source/v9.5alpha2/postgresql-9.5alpha2.tar.bz2"
-    sha256 "87a55f39fb465ffe47701251665d3bff431760d9941f884be7f5ff67435ba485"
-    version "9.5alpha2"
-  end
-
-  bottle do
-    sha256 "c300df1c732b749654f507498ae77531842dbb3bebc1083fe05cb191e5ee6bb3" => :el_capitan
-    sha256 "25c2e16deaf18141e48f7b567ef02f8c426cc4978a41e1ee0f7f2484d8ddf2c9" => :yosemite
-    sha256 "553b8e7f01b436a9152a737f66addbd7062bb90dc711e1e50a86a6dfa3f3a673" => :mavericks
-    sha256 "78638d3488658f86664b3b98ce78d127dedbe2273e50e2bd4ac7b0af550c20c8" => :mountain_lion
-  end
+  url "https://ftp.postgresql.org/pub/source/v15.3/postgresql-15.3.tar.bz2"
+  sha256 "ffc7d4891f00ffbf5c3f4eab7fbbced8460b8c0ee63c5a5167133b9e6599d932"
 
   option "32-bit"
   option "without-perl", "Build without Perl support"
   option "without-tcl", "Build without Tcl support"
-  option "with-dtrace", "Build with DTrace support"
+  option "with-dtrace", "Build with DTrace support" if MacOS.version >= :leopard
 
   deprecated_option "no-perl" => "without-perl"
   deprecated_option "no-tcl" => "without-tcl"
   deprecated_option "enable-dtrace" => "with-dtrace"
+  deprecated_option "with-python" => "with-python3"
 
   depends_on "openssl"
   depends_on "readline"
-  depends_on "libxml2" if MacOS.version <= :leopard # Leopard libxml is too old
-  depends_on :python => :optional
+  depends_on "libxml2"
+  depends_on "libxslt"
+  depends_on "make" => :build if MacOS.version < :leopard # GNU make 3.81 or newer is required
+  depends_on "perl" if build.with? "perl"
+  depends_on :python3 => :optional
+  depends_on "zlib"
 
   conflicts_with "postgres-xc",
     :because => "postgresql and postgres-xc install the same binaries."
 
-  fails_with :clang do
-    build 211
-    cause "Miscompilation resulting in segfault on queries"
-  end
-
   def install
     ENV.libxml2 if MacOS.version >= :snow_leopard
+    # Breaks build and threading test during configuration
+    ENV.minimal_optimization if ENV.compiler == :gcc_4_0
+    # Build breaks passing -w
+    ENV.enable_warnings if ENV.compiler == :gcc_4_0
 
     args = %W[
       --disable-debug
@@ -60,10 +47,7 @@ class Postgresql < Formula
       --with-libxslt
     ]
 
-    # Postgres fails during configure on Tiger if thread-safety is enabled
-    # https://gist.github.com/shirleyallan/6282644
-    args << "--enable-thread-safety" unless MacOS.version < :leopard
-    args << "--with-python" if build.with? "python"
+    args << "--with-python" if build.with? "python3"
     args << "--with-perl" if build.with? "perl"
 
     # The CLT is required to build Tcl support on 10.7 and 10.8 because
@@ -84,7 +68,7 @@ class Postgresql < Formula
     end
 
     system "./configure", *args
-    system "make", "install-world"
+    system "gmake", "install-world"
   end
 
   def post_install
@@ -94,12 +78,12 @@ class Postgresql < Formula
   end
 
   def caveats; <<-EOS.undent
-    If builds of PostgreSQL 9 are failing and you have version 8.x installed,
+    If builds of PostgreSQL are failing and you have a prior version installed,
     you may need to remove the previous version first. See:
       https://github.com/Homebrew/homebrew/issues/2510
 
-    To migrate existing data from a previous major version (pre-9.4) of PostgreSQL, see:
-      https://www.postgresql.org/docs/9.4/static/upgrading.html
+    To migrate existing data from a previous major version (pre-15.x) of PostgreSQL, see:
+      https://www.postgresql.org/docs/15/upgrading.html
     EOS
   end
 


### PR DESCRIPTION
Postgresql now support Python 3 only.
Use up to date components regardless of OS version though newer versions were needed for Tiger & likely Leopard.
Need to go with minimal compiler optimisation with GCC 4.0.1, works just fine with GCC 5.5.0.

Should be added to the OpenSSL branch I guess, requires #805 and ideally, #823 #833 #888  