### PR TITLE
bdw-gc: Upgrade formula to v7.6.12

### DIFF
--- a/Library/Formula/bdw-gc.rb
+++ b/Library/Formula/bdw-gc.rb
@@ -1,16 +1,8 @@
 class BdwGc < Formula
   desc "Garbage collector for C and C++"
   homepage "http://www.hboehm.info/gc/"
-  url "http://www.hboehm.info/gc/gc_source/gc-7.4.2.tar.gz"
-  sha256 "63320ad7c45460e4a40e03f5aa4c6893783f21a16416c3282b994f933312afa2"
-
-  bottle do
-    revision 2
-    sha256 "ba0257546369cd1879d66d3f1302194ae39767ccb5b012a20d16fdf5595b4326" => :el_capitan
-    sha256 "bb654d5b6952c8b22ce74d0081f900f3fd8628bb79105ba1b1ddc672fea6b067" => :yosemite
-    sha256 "ebbedf4fe84fbc6ccf621c7da954623443f1bc7596ca8c95efe72d4cba353d25" => :mavericks
-    sha256 "e5725f4c6b23ce7dc75e3e8fff51cd1f9f90858bad20d1ce00cf33499edf8f6b" => :mountain_lion
-  end
+  url "https://www.hboehm.info/gc/gc_source/gc-7.6.12.tar.gz"
+  sha256 "6cafac0d9365c2f8604f930aabd471145ac46ab6f771e835e57995964e845082"
 
   head do
     url "https://github.com/ivmai/bdwgc.git"


### PR DESCRIPTION
The 8.x branch can make use of newer pthread features but the tests don't seem to be working correctly as they pass on Tiger despite the functionality definitely not being there.
Update to the most recent 7.x release for now.