### PR TITLE
gambit-scheme: Upgrade formula to v4.9.5

### DIFF
--- a/Library/Formula/gambit-scheme.rb
+++ b/Library/Formula/gambit-scheme.rb
@@ -1,40 +1,37 @@
 class GambitScheme < Formula
   desc "Complete, portable implementation of Scheme"
-  homepage "http://dynamo.iro.umontreal.ca/~gambit/wiki/index.php/Main_Page"
-  url "http://www.iro.umontreal.ca/~gambit/download/gambit/v4.7/source/gambc-v4_7_9.tgz"
-  sha256 "17e4a2eebbd0f5ebd807b4ad79a98b89b2a5eef00199c318a885db4ef950f14f"
+  homepage "http://gambitscheme.org"
+  url "http://gambitscheme.org/latest/gambit-v4_9_5.tgz"
+  sha256 "e28ef8db5f0e7b1159720c150053dcab8f7c4cae1f0e5c838944797073f8c1dc"
 
-  bottle do
-    sha256 "d1d2cf026e85f5c62ebe7373c1eed03cd84c590ef3f588cba447fc912f9287d6" => :yosemite
-    sha256 "7de3b06bde1d0a2a8ce3288dfed388aa4161f0753692cb53eade22372eba1bd3" => :mavericks
-    sha256 "24f6d6f75f044bec4c7d0a87cc65e66234cc68e772d6a9d86ccd13495ce6aba5" => :mountain_lion
-  end
-
-  conflicts_with "ghostscript", :because => "both install `gsc` binaries"
   conflicts_with "scheme48", :because => "both install `scheme-r5rs` binaries"
 
   deprecated_option "enable-shared" => "with-shared"
   option "with-check", 'Execute "make check" before installing'
   option "with-shared", "Build Gambit Scheme runtime as shared library"
+  option "with-single", "Compile each Scheme module as a single C function - Needs GCC >=5"
+  option "with-openssl", "Build with TLS support via OpenSSL"
 
-  fails_with :llvm
-  fails_with :clang
-  # According to the docs, gambit-scheme requires absurd amounts of RAM
-  # to build using GCC 4.2 or 4.3; see
-  # https://github.com/mistydemeo/tigerbrew/issues/389
-  fails_with :gcc
-  fails_with :gcc => "4.3"
+  depends_on "openssl" if build.with? "openssl"
 
   def install
+    # The build itself tries to set optimisation flags varying between -O1 & -O3 by default.
+    ENV.no_optimization
+    ENV.append "OPENSSL_DIR", "#{Formula["openssl"].opt_prefix}" if build.with? "openssl"
+    # Set compiler & interpreter name to avoid conflict with Ghostscript's gsc
     args = %W[
       --disable-debug
       --prefix=#{prefix}
       --libdir=#{lib}/gambit-c
       --infodir=#{info}
       --docdir=#{doc}
-      --enable-single-host
+      --enable-dynamic-clib
+      --enable-compiler-name=gsc-gambit
+      --enable-interpreter-name=gsi-gambit
     ]
 
+    args << "--enable-openssl" if build.with? "openssl"
+    args << "--enable-single-host" if build.with? "single"
     args << "--enable-shared" if build.with? "shared"
 
     system "./configure", *args
@@ -47,4 +44,26 @@ class GambitScheme < Formula
   test do
     system "#{bin}/gsi", "-e", '(print "hello world")'
   end
+
+  # Allow the location of OpenSSL to be set during build.
+  # https://github.com/gambit/gambit/pull/846 
+  patch :p0, :DATA
+
 end
+__END__
+--- configure
++++ configure
+@@ -10221,8 +10221,11 @@ if test "$ENABLE_OPENSSL" = yes; then
+ 
+   case "$target_os" in
+     darwin*) # macOS ships an old version of the OpenSSL library, so it should
+-             # be installed with "brew install openssl"
+-             OPENSSL_DIR="/usr/local/opt/openssl@1.1"
++             # be installed with "brew install openssl" or another means and
++             # set the OPENSSL_DIR environment variable to prefix where installed.
++             if test "${OPENSSL_DIR+set}" != set; then
++               OPENSSL_DIR="/usr/local/opt/openssl@1.1"
++             fi
+              if test "$ENABLE_OPENSSL_STATIC_LINK" = yes; then
+                LIBS="$LIBS $OPENSSL_DIR/lib/libssl.a $OPENSSL_DIR/lib/libcrypto.a"
+              else


### PR DESCRIPTION
Make building with --enable-single-host optional since that requires a newer compiler.
Enable the dynamic-clib optimisation since the build suggests it.
By setting names, we avoid the conflict with Ghostscript. Add an option to build with OpenSSL support.
Turned off optimisation since the build process sets different optimisation flags for different components varying from O1 to O3. The build process supports more options related to compiler optimisation flags, but I did not explore any further.

Tested with GCC 4.0.1 on Tiger with OpenSSL 1.1.1u
OpenSSL support is optional, but it requires v1.1.1, so needs to be added to the OpenSSL branch for #805 or merged after if it is going to built it.

When running 'make check' there's 28 tests which fail since the unit tests try to load files from the install destination directory. [gambit/#814](https://github.com/gambit/gambit/issues/814)
