### PR TITLE
Library/Homebrew/software_spec.rb: Save on the 301 redirect

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -281,7 +281,7 @@ end
 class BottleSpecification
   DEFAULT_PREFIX = "/usr/local".freeze
   DEFAULT_CELLAR = "/usr/local/Cellar".freeze
-  DEFAULT_DOMAIN = (ENV["HOMEBREW_BOTTLE_DOMAIN"] || "https://ia902307.us.archive.org/31/items/tigerbrew").freeze
+  DEFAULT_DOMAIN = (ENV["HOMEBREW_BOTTLE_DOMAIN"] || "https://ia904500.us.archive.org/24/items/tigerbrew").freeze
 
   attr_rw :prefix, :cellar, :revision
   alias_method :rebuild, :revision


### PR DESCRIPTION
Old $HOMEBREW_BOTTLE_DOMAIN redirects, so save on the roundtrip every time.