### PR TITLE
Fix zlib URL to point to fossils/ folder

### DIFF
--- a/Library/Formula/zlib.rb
+++ b/Library/Formula/zlib.rb
@@ -1,7 +1,7 @@
 class Zlib < Formula
   desc "General-purpose lossless data-compression library"
   homepage "http://www.zlib.net/"
-  url "http://zlib.net/zlib-1.2.13.tar.gz"
+  url "http://zlib.net/fossils/zlib-1.2.13.tar.gz"
   sha256 "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 
   bottle do


### PR DESCRIPTION
This PR corrects the URL for zlib source code. The URL without the fossils/ folder only works for the latest release.