### PR TITLE
openconnect 9.12

### DIFF
--- a/Library/Formula/openconnect.rb
+++ b/Library/Formula/openconnect.rb
@@ -1,13 +1,10 @@
 class Openconnect < Formula
   desc "Open client for Cisco AnyConnect VPN"
   homepage "http://www.infradead.org/openconnect.html"
-  url "ftp://ftp.infradead.org/pub/openconnect/openconnect-7.06.tar.gz"
-  sha256 "facf695368dc4537a6a30e2147be90b1d77ee3cb2d269eaef070b6d9ddab70f2"
+  url "https://www.infradead.org/openconnect/download/openconnect-9.12.tar.gz"
+  sha256 "a2bedce3aa4dfe75e36e407e48e8e8bc91d46def5335ac9564fbf91bd4b2413e"
 
   bottle do
-    sha256 "7d514ce407dee1972abf23a51ff2acfe7d72bfde9854639bd6097bb39e6ab058" => :yosemite
-    sha256 "1d83fa61da006086115e7d0b2e4ce04577c3812b10e553aa9b1b33b7d450f1de" => :mavericks
-    sha256 "3d59f71840eac1512237bcda0668c38f51fff38d7a905011fcea2db94f7b5cda" => :mountain_lion
   end
 
   head do
@@ -17,19 +14,18 @@ class Openconnect < Formula
     depends_on "libtool" => :build
   end
 
-  # No longer compiles against OpenSSL 1.0.2 - It chooses the system OpenSSL instead.
-  # http://lists.infradead.org/pipermail/openconnect-devel/2015-February/002757.html
-
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "gnutls"
+  depends_on "openssl"
   depends_on "oath-toolkit" => :optional
+  depends_on "p11-kit"
   depends_on "stoken" => :optional
   depends_on "libxml2"
+  depends_on "zlib"
 
   resource "vpnc-script" do
-    url "http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/a64e23b1b6602095f73c4ff7fdb34cccf7149fd5:/vpnc-script"
-    sha256 "cc30b74788ca76928f23cc7bc6532425df8ea3701ace1454d38174ca87d4b9c5"
+    url "https://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/78050150f712d96f81dcade1efe5d16d017e8471:/vpnc-script"
+    sha256 "48cdff979f5f941e2740193c4ee2a90f55549908afcb1fcee64a66f8c0fec05f"
   end
 
   def install
@@ -53,6 +49,6 @@ class Openconnect < Formula
   end
 
   test do
-    assert_match /AnyConnect VPN/, pipe_output("#{bin}/openconnect 2>&1")
+    assert_match /anyconnect/, shell_output("#{bin}/openconnect -V")
   end
 end


### PR DESCRIPTION
Use latest vpnc-script
Switch back to using OpenSSL now that it is up to date (gnutls isn't and it requires C11 support).
Fix test

Build tested on Tiger powerpc with GCC 4.0.1, haven't tried to establish a VPN connection to a supported appliance.