### PR TITLE
wget 1.21.3

### DIFF
--- a/Library/Formula/wget.rb
+++ b/Library/Formula/wget.rb
@@ -4,22 +4,15 @@
 class Wget < Formula
   desc "Internet file retriever"
   homepage "https://www.gnu.org/software/wget/"
-  url "http://ftpmirror.gnu.org/wget/wget-1.16.3.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/wget/wget-1.16.3.tar.xz"
-  sha256 "67f7b7b0f5c14db633e3b18f53172786c001e153d545cfc85d82759c5c2ffb37"
-
-  bottle do
-    sha256 "fb5c9be7a3a077cf5f5f8feb5114ce9c8bd8294c5601a6d85b9d82e4e24dc42d" => :tiger_altivec
-    sha256 "cdcfb345558d8373ee75de0ef538d60a41374847304475c430f05bac356cf7e5" => :leopard_g3
-    sha256 "64e80dbf71fe2b1741e054c3942dce0201bb0149eb938169bc2524523cadff04" => :leopard_altivec
-  end
+  url "https://ftpmirror.gnu.org/wget/wget-1.21.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/wget/wget-1.21.3.tar.gz"
+  sha256 "5726bb8bc5ca0f6dc7110f6416e4bb7019e2d2ff5bf93d1ca2ffcc6656f220e5"
 
   head do
     url "git://git.savannah.gnu.org/wget.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "xz" => :build
     depends_on "gettext"
   end
 
@@ -32,9 +25,11 @@ class Wget < Formula
   depends_on "openssl" => :recommended
   depends_on "libressl" => :optional
   depends_on "libidn" if build.with? "iri"
-  depends_on "pcre" => :optional
+  depends_on "pcre2" => :optional
+  depends_on "zlib"
 
   def install
+  ENV.append "CFLAGS", "-std=gnu99"
     args = %W[
       --prefix=#{prefix}
       --sysconfdir=#{etc}
@@ -57,6 +52,6 @@ class Wget < Formula
   end
 
   test do
-    system bin/"wget", "-O", "-", "https://google.com"
+    system bin/"wget", "-O", "-", "https://github.com"
   end
 end


### PR DESCRIPTION
v1.21.4 includes the latest version of gnulib which is incompatible with Tiger, requiring integration with libsigsegv.
Stick with this version for now which is sufficient for building against current OpenSSL.