### PR TITLE
gcc 7.5.0

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -21,9 +21,9 @@ class Gcc < Formula
 
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
-  sha256 "832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz"
+  sha256 "b81946e7f01f90528a1f7352ab08cc602b9ccc05d4e44da4bd501c5a189ee661"
 
   bottle do
     sha256 "dfe5debb5b2d22c65673a38bfc1902042d7094702f49ff3cdfa2ecb30d09308e" => :tiger_g3
@@ -47,6 +47,8 @@ class Gcc < Formula
     depends_on "cctools" => :build
   end
 
+  # Bug 21514 - [DR 488] templates and anonymous enum - fixed in 4.0.2
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=21514
   fails_with :gcc_4_0
   fails_with :llvm
 
@@ -74,17 +76,14 @@ class Gcc < Formula
     sha256 "17afaf7daec1dd207cb8d06a7e026332637b11e83c3ad552b4cd32827f16c1d8"
   end
 
-  # This patch fixes the build on PPC
-  # https://gcc.gnu.org/ml/gcc-testresults/2017-01/msg02971.html
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80865
-  patch do
-    url "https://gist.githubusercontent.com/mistydemeo/d35fcc040587cc75bd24d3464e93a45d/raw/c5fe1f0c6393526ff45803b0fc14e028149a245e/gcc_altivec.patch"
-    sha256 "09a795d013ec3e96107bfb9d5c6bba821cc867b88c3bce494ae1564bfd4ababd"
-  end
-
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
+    # GCC Bug 25127
+    # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=25127
+    # ../../../libgcc/unwind.inc: In function '_Unwind_RaiseException':
+    # ../../../libgcc/unwind.inc:136:1: internal compiler error: in rs6000_emit_prologue, at config/rs6000/rs6000.c:26535
+    ENV.no_optimization if Hardware::CPU.type == :ppc
 
     # Otherwise libstdc++ will be incorrectly tagged with cpusubtype 10 (G4e)
     # https://github.com/mistydemeo/tigerbrew/issues/538
@@ -124,7 +123,7 @@ class Gcc < Formula
 
     # "Building GCC with plugin support requires a host that supports
     # -fPIC, -shared, -ldl and -rdynamic."
-    args << "--enable-plugin" if MacOS.version > :leopard
+    args << "--enable-plugin" if MacOS.version > :tiger
 
     # Otherwise make fails during comparison at stage 3
     # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248

--- a/Library/Formula/openconnect.rb
+++ b/Library/Formula/openconnect.rb
@@ -25,6 +25,7 @@ class Openconnect < Formula
   depends_on "gnutls"
   depends_on "oath-toolkit" => :optional
   depends_on "stoken" => :optional
+  depends_on "libxml2"
 
   resource "vpnc-script" do
     url "http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/a64e23b1b6602095f73c4ff7fdb34cccf7149fd5:/vpnc-script"

--- a/Library/Formula/pcsc-lite.rb
+++ b/Library/Formula/pcsc-lite.rb
@@ -1,7 +1,7 @@
 class PcscLite < Formula
   desc "Middleware to access a smart card using SCard API"
-  homepage "https://pcsclite.alioth.debian.org"
-  url "https://alioth.debian.org/frs/download.php/file/4138/pcsc-lite-1.8.14.tar.bz2"
+  homepage "https://pcsclite.apdu.fr"
+  url "https://pcsclite.apdu.fr/files/pcsc-lite-1.8.14.tar.bz2"
   sha256 "b91f97806042315a41f005e69529cb968621f73f2ddfbd1380111a175b02334e"
 
   bottle do


### PR DESCRIPTION
Enable plugin support as with GCC 5 & 6 formulas.
Built on Tiger PowerPC with GCC 4.2 (only C language support enabled)
 
```
Using built-in specs.
COLLECT_GCC=bin/gcc-7
COLLECT_LTO_WRAPPER=/Sandbox/gcc7tb/Cellar/gcc/7.5.0/libexec/gcc/powerpc-apple-darwin8.11.0/7.5.0/lto-wrapper
Target: powerpc-apple-darwin8.11.0
Configured with: ../configure --build=powerpc-apple-darwin8.11.0 --prefix=/Sandbox/gcc7tb/Cellar/gcc/7.5.0 --libdir=/Sandbox/gcc7tb/Cellar/gcc/7.5.0/lib/gcc/7 --enable-languages=c --program-suffix=-7 --with-gmp=/Sandbox/gcc7tb/opt/gmp --with-mpfr=/Sandbox/gcc7tb/opt/mpfr --with-mpc=/Sandbox/gcc7tb/opt/libmpc --with-isl=/Sandbox/gcc7tb/opt/isl --with-system-zlib --enable-checking=release --with-pkgversion='Tigerbrew gcc 7.5.0' --with-bugurl=https://github.com/mistydemeo/tigerbrew/issues --with-dwarf2 --disable-nls --disable-multilib
Thread model: posix
gcc version 7.5.0 (Tigerbrew gcc 7.5.0)
```