### PR TITLE
lua 5.4.6

### DIFF
--- a/Library/Formula/lua.rb
+++ b/Library/Formula/lua.rb
@@ -8,6 +8,8 @@ class Lua < Formula
   option "with-completion", "Enables advanced readline support"
   option "without-luarocks", "Don't build with Luarocks support embedded"
 
+  depends_on "readline" if build.with? "completion"
+
   # completion provided by advanced readline power patch
   # See http://lua-users.org/wiki/LuaPowerPatches
   if build.with? "completion"

--- a/Library/Formula/lua.rb
+++ b/Library/Formula/lua.rb
@@ -1,59 +1,26 @@
 class Lua < Formula
   desc "Powerful, lightweight programming language"
   homepage "http://www.lua.org/"
-  url "http://www.lua.org/ftp/lua-5.2.4.tar.gz"
-  sha256 "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b"
-  revision 1
-
-  bottle do
-    cellar :any
-    sha256 "b8ab4306d8c3c5ff2a5289986238af1e0090d3793f73987c9c8beb07826b2e64" => :el_capitan
-    sha256 "ad2fceaf391771c9e4120f00ac78c5e634aa3c6cd911566e38d016fec4d6c315" => :yosemite
-    sha256 "997e8eb591ea1e44dc9cf0910cac61137e0e231d228953b61826ff37a452a8dc" => :mavericks
-    sha256 "519abb38296981baf49dd00ac80a2ac742f8e278b0b616d88d7fab8702ad430d" => :mountain_lion
-  end
-
-  fails_with :llvm do
-    build 2326
-    cause "Lua itself compiles with LLVM, but may fail when other software tries to link."
-  end
+  url "https://www.lua.org/ftp/lua-5.4.6.tar.gz"
+  sha256 "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88"
 
   option :universal
   option "with-completion", "Enables advanced readline support"
-  option "without-sigaction", "Revert to ANSI signal instead of improved POSIX sigaction"
   option "without-luarocks", "Don't build with Luarocks support embedded"
-
-  # Be sure to build a dylib, or else runtime modules will pull in another static copy of liblua = crashy
-  # See: https://github.com/Homebrew/homebrew/pull/5043
-  patch :DATA
 
   # completion provided by advanced readline power patch
   # See http://lua-users.org/wiki/LuaPowerPatches
   if build.with? "completion"
     patch do
-      url "http://luajit.org/patches/lua-5.2.0-advanced_readline.patch"
-      sha256 "33d32d11fce4f85b88ce8f9bd54e6a6cbea376dfee3dbf8cdda3640e056bc29d"
-    end
-  end
-
-  # sigaction provided by posix signalling power patch
-  if build.with? "sigaction"
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/master/lua/lua-5.2.3-sig_catch.patch"
-      sha256 "f2e77f73791c08169573658caa3c97ba8b574c870a0a165972ddfbddb948c164"
+      url "http://lua-users.org/files/wiki_insecure/B4rtzUB3/5.4/lua-5.4.3-advanced_readline.patch"
+      sha256 "a2ec8af0a9f5111c9caf698ce5c3b83b1ba5d8a0c15daac4f9776e1d21c62fa5"
     end
   end
 
   resource "luarocks" do
-    url "https://keplerproject.github.io/luarocks/releases/luarocks-2.2.2.tar.gz"
-    sha256 "4f0427706873f30d898aeb1dfb6001b8a3478e46a5249d015c061fe675a1f022"
+    url "https://luarocks.org/releases/luarocks-3.9.2.tar.gz"
+    sha256 "bca6e4ecc02c203e070acdb5f586045d45c078896f6236eb46aa33ccd9b94edb"
   end
-
-  # Tiger requires an extra header to get off_t on Tiger
-  patch do
-    url "https://gist.githubusercontent.com/mistydemeo/8e6fdf696a60eeb496ce/raw/9d286fd209728d815a426fb785c31eb1b2638a99/lua-offt.diff"
-    sha1 "80b42119163f84a883425afca3139dcf5f2018fb"
-  end if MacOS.version < :leopard
 
   def install
     ENV.universal_binary if build.universal?
@@ -74,13 +41,13 @@ class Lua < Formula
     (lib+"pkgconfig/lua.pc").write pc_file
 
     # Fix some software potentially hunting for different pc names.
-    bin.install_symlink "lua" => "lua5.2"
-    bin.install_symlink "lua" => "lua-5.2"
-    bin.install_symlink "luac" => "luac5.2"
-    bin.install_symlink "luac" => "luac-5.2"
-    include.install_symlink include => "#{include}/lua5.2"
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua5.2.pc"
-    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-5.2.pc"
+    bin.install_symlink "lua" => "lua5.4"
+    bin.install_symlink "lua" => "lua-5.4"
+    bin.install_symlink "luac" => "luac5.4"
+    bin.install_symlink "luac" => "luac-5.4"
+    include.install_symlink include => "#{include}/lua5.4"
+    (lib/"pkgconfig").install_symlink "lua.pc" => "lua5.4.pc"
+    (lib/"pkgconfig").install_symlink "lua.pc" => "lua-5.4.pc"
 
     # This resource must be handled after the main install, since there's a lua dep.
     # Keeping it in install rather than postinstall means we can bottle.
@@ -89,31 +56,23 @@ class Lua < Formula
         ENV.prepend_path "PATH", bin
 
         system "./configure", "--prefix=#{libexec}", "--rocks-tree=#{HOMEBREW_PREFIX}",
-                              "--sysconfdir=#{etc}/luarocks52", "--with-lua=#{prefix}",
-                              "--lua-version=5.2", "--versioned-rocks-dir"
+                              "--with-lua=#{prefix}", "--lua-version=5.4", "--sysconfdir=#{etc}"
         system "make", "build"
         system "make", "install"
 
-        (share+"lua/5.2/luarocks").install_symlink Dir["#{libexec}/share/lua/5.2/luarocks/*"]
-        bin.install_symlink libexec/"bin/luarocks-5.2"
-        bin.install_symlink libexec/"bin/luarocks-admin-5.2"
+        (share+"lua/5.4/luarocks").install_symlink Dir["#{libexec}/share/lua/5.4/luarocks/*"]
+        bin.install_symlink libexec/"bin/luarocks-5.4"
+        bin.install_symlink libexec/"bin/luarocks-admin-5.4"
         bin.install_symlink libexec/"bin/luarocks"
         bin.install_symlink libexec/"bin/luarocks-admin"
 
-        # This block ensures luarock exec scripts don't break across updates.
-        inreplace libexec/"share/lua/5.2/luarocks/site_config.lua" do |s|
-          s.gsub! libexec.to_s, opt_libexec
-          s.gsub! include.to_s, "#{HOMEBREW_PREFIX}/include"
-          s.gsub! lib.to_s, "#{HOMEBREW_PREFIX}/lib"
-          s.gsub! bin.to_s, "#{HOMEBREW_PREFIX}/bin"
-        end
       end
     end
   end
 
   def pc_file; <<-EOS.undent
-    V= 5.2
-    R= 5.2.4
+    V= 5.4
+    R= 5.4.6
     prefix=#{HOMEBREW_PREFIX}
     INSTALL_BIN= ${prefix}/bin
     INSTALL_INC= ${prefix}/include
@@ -127,7 +86,7 @@ class Lua < Formula
 
     Name: Lua
     Description: An Extensible Extension Language
-    Version: 5.2.4
+    Version: 5.4.6
     Requires:
     Libs: -L${libdir} -llua -lm
     Cflags: -I${includedir}
@@ -136,7 +95,7 @@ class Lua < Formula
 
   def caveats; <<-EOS.undent
     Please be aware due to the way Luarocks is designed any binaries installed
-    via Luarocks-5.2 AND 5.1 will overwrite each other in #{HOMEBREW_PREFIX}/bin.
+    via Luarocks-5.4 AND 5.1 will overwrite each other in #{HOMEBREW_PREFIX}/bin.
 
     This is, for now, unavoidable. If this is troublesome for you, you can build
     rocks with the `--tree=` command to a special, non-conflicting location and
@@ -147,72 +106,10 @@ class Lua < Formula
   test do
     system "#{bin}/lua", "-e", "print ('Ducks are cool')"
 
-    if File.exist?(bin/"luarocks-5.2")
+    if File.exist?(bin/"luarocks-5.4")
       mkdir testpath/"luarocks"
-      system bin/"luarocks-5.2", "install", "moonscript", "--tree=#{testpath}/luarocks"
+      system bin/"luarocks-5.4", "install", "moonscript", "--tree=#{testpath}/luarocks"
       assert File.exist? testpath/"luarocks/bin/moon"
     end
   end
 end
-
-__END__
-diff --git a/Makefile b/Makefile
-index bd9515f..5940ba9 100644
---- a/Makefile
-+++ b/Makefile
-@@ -41,7 +41,7 @@ PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
- # What to install.
- TO_BIN= lua luac
- TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
--TO_LIB= liblua.a
-+TO_LIB= liblua.5.2.4.dylib
- TO_MAN= lua.1 luac.1
-
- # Lua version and release.
-@@ -63,6 +63,8 @@ install: dummy
-	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
-	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
-	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
-+	ln -s -f liblua.5.2.4.dylib $(INSTALL_LIB)/liblua.5.2.dylib
-+	ln -s -f liblua.5.2.dylib $(INSTALL_LIB)/liblua.dylib
-
- uninstall:
-	cd src && cd $(INSTALL_BIN) && $(RM) $(TO_BIN)
-diff --git a/src/Makefile b/src/Makefile
-index 8c9ee67..7f92407 100644
---- a/src/Makefile
-+++ b/src/Makefile
-@@ -28,7 +28,7 @@ MYOBJS=
-
- PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
-
--LUA_A=	liblua.a
-+LUA_A=	liblua.5.2.4.dylib
- CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
-	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
-	ltm.o lundump.o lvm.o lzio.o
-@@ -56,11 +56,12 @@ o:	$(ALL_O)
- a:	$(ALL_A)
-
- $(LUA_A): $(BASE_O)
--	$(AR) $@ $(BASE_O)
--	$(RANLIB) $@
-+	$(CC) -dynamiclib -install_name HOMEBREW_PREFIX/lib/liblua.5.2.dylib \
-+		-compatibility_version 5.2 -current_version 5.2.4 \
-+		-o liblua.5.2.4.dylib $^
-
- $(LUA_T): $(LUA_O) $(LUA_A)
--	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
-+	$(CC) -fno-common $(MYLDFLAGS) -o $@ $(LUA_O) $(LUA_A) -L. -llua.5.2.4 $(LIBS)
-
- $(LUAC_T): $(LUAC_O) $(LUA_A)
-	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
-@@ -106,7 +107,7 @@ linux:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -ldl -lreadline"
-
- macosx:
--	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline" CC=cc
-+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -fno-common" SYSLIBS="-lreadline" CC=cc
-
- mingw:
-	$(MAKE) "LUA_A=lua52.dll" "LUA_T=lua.exe" \


### PR DESCRIPTION
Drop the dylib patch, at the time, issue was specific to 10.6 but was unable to recreate it using [the reproducer in the ticket](https://github.com/Homebrew/legacy-homebrew/pull/5043#issuecomment-1039652) on 10.4 -> 10.6.

```
require 'luarocks.loader'
require'lfs'
count = 0
for i = 1, 9999 do
  for file in lfs.dir'/tmp' do
    count = count + 1
  end
end
```
luarocks configs are versioned so there's no need to suffix sysconfdir with lua version. A subdirectory called luarocks is created anyway. Still need to pass in sysconfdir otherwise directory isn't created.

Tested on Tiger powerpc with GCC 4.0.1, Leopard powerpc with GCC 4.2, Snow Leopard with GCC 4.2 & LLVM-GCC 4.2.