### PR TITLE
openssl x86 & Snow Leopard fixes

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -8,10 +8,10 @@ class Openssl < Formula
   option :universal
   option "without-test", "Skip build-time tests (not recommended)"
 
-  # Need a minimum of Perl 5.10 for Configure script
-  depends_on "perl" => :build if MacOS.version < :snow_leopard
+  # Need a minimum of Perl 5.10 for Configure script and Test::More 0.96 for testsuite
+  depends_on "perl" => :build
   depends_on "makedepend" => :build
-  depends_on "curl-ca-bundle" if MacOS.version < :snow_leopard
+  depends_on "curl-ca-bundle"
 
   bottle do
     sha256 "7fa8eeb679ec9e180c5296515c1402207c653b6fd22be981b1c67e81f3fc0c4b" => :tiger_altivec

--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -19,7 +19,7 @@ class Openssl < Formula
 
   def arch_args
     {
-      :x86_64 => %w[darwin64-x86_64-cc enable-ec_nistp_64_gcc_128],
+      :x86_64 => %w[darwin64-x86_64-cc],
       :i386   => %w[darwin-i386-cc],
       :ppc    => %w[darwin-ppc-cc],
       :ppc64  => %w[darwin64-ppc-cc]

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -34,7 +34,7 @@ class Openssl3 < Formula
     if Hardware::CPU.ppc?
       args << "darwin-ppc-cc"
     elsif Hardware::CPU.intel?
-      args << (Hardware::CPU.is_64_bit? ? "darwin64-x86_64-cc enable-ec_nistp_64_gcc_128" : "darwin-i386-cc")
+      args << (Hardware::CPU.is_64_bit? ? "darwin64-x86_64-cc" : "darwin-i386-cc")
     end
     args
   end


### PR DESCRIPTION
Skipping version bump as they would not have built on x86 in the first place.