### PR TITLE
git Snow Leopard fix

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -212,7 +212,7 @@ __END__
  		OLD_ICONV = UnfortunatelyYes
  		NO_APPLE_COMMON_CRYPTO = YesPlease
  	endif
-+	ifeq ($(shell expr "$(uname_R)" : '[156789]\.'),2)
++	ifeq ($(shell test "`expr "$(uname_R)" : '\([0-9][0-9]*\)\.'`" -lt 11 && echo 1),1)
 +		NO_REGEX=YesPlease
 +	else
 +		USE_ENHANCED_BASIC_REGULAR_EXPRESSIONS = YesPlease


### PR DESCRIPTION
Set anything before Lion (Darwin 11) to NO_REGEX otherwise build breaks as REG_ENHANCED is not defined as not supported.
This may need bumping again, as I haven't tested on Lion.
 
Tested on Tiger PowerPC & Snow Leopard x86.
Resolves #978 