### PR TITLE
openssl3 switch

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -3,10 +3,10 @@ class Curl < Formula
   homepage "https://curl.haxx.se/"
   url "https://curl.se/download/curl-8.4.0.tar.xz"
   sha256 "16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d"
+  revision 1
 
   bottle do
     cellar :any
-    sha256 "0065f0535323140e66b9338dc0bd8397db65e6edecbf1f2f456962fef95d04c4" => :tiger_altivec
   end
 
   keg_only :provided_by_osx
@@ -25,7 +25,7 @@ class Curl < Formula
   depends_on "zlib"
 
   if (build.without?("libressl"))
-    depends_on "openssl"
+    depends_on "openssl3"
   end
 
   depends_on "pkg-config" => :build
@@ -52,9 +52,9 @@ class Curl < Formula
       args << "--with-ssl=#{Formula["libressl"].opt_prefix}"
       args << "--with-ca-bundle=#{etc}/libressl/cert.pem"
     else
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl"].opt_lib}/pkgconfig"
-      args << "--with-ssl=#{Formula["openssl"].opt_prefix}"
-      args << "--with-ca-bundle=#{etc}/openssl/cert.pem"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl3"].opt_lib}/pkgconfig"
+      args << "--with-ssl=#{Formula["openssl3"].opt_prefix}"
+      args << "--with-ca-bundle=#{etc}/openssl@3/cert.pem"
     end
 
     args << (build.with?("libssh2") ? "--with-libssh2" : "--without-libssh2")

--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -7,6 +7,7 @@ class Curl < Formula
 
   bottle do
     cellar :any
+    sha256 "0fbe6c2ca5ea78e6af2c24c0ea1e2a9500f07eea10ba15a239bf2ebac1ed1360" => :tiger_altivec
   end
 
   keg_only :provided_by_osx

--- a/Library/Formula/dovecot.rb
+++ b/Library/Formula/dovecot.rb
@@ -6,6 +6,7 @@ class Dovecot < Formula
   sha256 "05b11093a71c237c2ef309ad587510721cc93bbee6828251549fc1586c36502d"
 
   bottle do
+    sha256 "5a844e280812b18bef1cef8139bd7fb191f0ec1c83e8b010b1d093c063546c4f" => :tiger_altivec
   end
 
   depends_on "bzip2"

--- a/Library/Formula/gambit-scheme.rb
+++ b/Library/Formula/gambit-scheme.rb
@@ -16,12 +16,12 @@ class GambitScheme < Formula
   option "with-single", "Compile each Scheme module as a single C function - Needs GCC >=5"
   option "with-openssl", "Build with TLS support via OpenSSL"
 
-  depends_on "openssl" if build.with? "openssl"
+  depends_on "openssl3" if build.with? "openssl"
 
   def install
     # The build itself tries to set optimisation flags varying between -O1 & -O3 by default.
     ENV.no_optimization
-    ENV.append "OPENSSL_DIR", "#{Formula["openssl"].opt_prefix}" if build.with? "openssl"
+    ENV.append "OPENSSL_DIR", "#{Formula["openssl3"].opt_prefix}" if build.with? "openssl"
     # Set compiler & interpreter name to avoid conflict with Ghostscript's gsc
     args = %W[
       --disable-debug

--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -4,9 +4,9 @@ class Git < Formula
   url "https://www.kernel.org/pub/software/scm/git/git-2.42.0.tar.xz"
   sha256 "3278210e9fd2994b8484dd7e3ddd9ea8b940ef52170cdb606daa94d887c93b0d"
   head "https://github.com/git/git.git", :shallow => false
+  revision 1
 
   bottle do
-    sha256 "c96ae9197fa159818739fa675d218a0f2c86ed69e2248050d8541778a82aedf0" => :tiger_altivec
   end
 
   resource "html" do
@@ -32,7 +32,7 @@ class Git < Formula
   depends_on :expat
   depends_on "pcre2" => :optional
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "openssh" => :run
   depends_on "curl"
   depends_on "make" => :build

--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -7,6 +7,7 @@ class Git < Formula
   revision 1
 
   bottle do
+    sha256 "7442d605398815cab539b68c140e496a456036530f81e5be5de7f08121a703d1" => :tiger_altivec
   end
 
   resource "html" do

--- a/Library/Formula/irssi.rb
+++ b/Library/Formula/irssi.rb
@@ -3,6 +3,7 @@ class Irssi < Formula
   homepage "http://irssi.org/"
   url "https://codeberg.org/irssi/irssi/releases/download/1.4.4/irssi-1.4.4.tar.xz"
   sha256 "fefe9ec8c7b1475449945c934a2360ab12693454892be47a6d288c63eb107ead"
+  revision 1
 
   head do
     url "https://github.com/irssi/irssi.git"
@@ -13,7 +14,6 @@ class Irssi < Formula
   end
 
   bottle do
-    sha256 "83c8e6d383114da61ac1aedad66ae58e380721e0b35e2c1cce812c009ff4577f" => :tiger_altivec
   end
 
   # Fix crash on exit with Tiger.
@@ -27,7 +27,7 @@ class Irssi < Formula
 
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "dante" => :optional
   depends_on "ncurses"
   depends_on "perl" if build.with? "perl"

--- a/Library/Formula/irssi.rb
+++ b/Library/Formula/irssi.rb
@@ -14,6 +14,7 @@ class Irssi < Formula
   end
 
   bottle do
+    sha256 "9cd240467cb01ccd6ecda35bf7b216ea85ebbc1674f02c3a747c0a36c2b7f1db" => :tiger_altivec
   end
 
   # Fix crash on exit with Tiger.

--- a/Library/Formula/ldns.rb
+++ b/Library/Formula/ldns.rb
@@ -6,6 +6,7 @@ class Ldns < Formula
   revision 1
 
   bottle do
+    sha256 "a5b4184d89dc1d59c0d68f0bff6d3a4ee3913b0137bce0c06f7beb13133470ca" => :tiger_altivec
   end
 
   depends_on :python => :optional

--- a/Library/Formula/ldns.rb
+++ b/Library/Formula/ldns.rb
@@ -3,14 +3,13 @@ class Ldns < Formula
   homepage "https://nlnetlabs.nl/projects/ldns/"
   url "https://nlnetlabs.nl/downloads/ldns/ldns-1.8.3.tar.gz"
   sha256 "c3f72dd1036b2907e3a56e6acf9dfb2e551256b3c1bbd9787942deeeb70e7860"
+  revision 1
 
   bottle do
-    sha256 "3e739c733f9485b9539ec047787e937838d81ad31352d381b5ae639d06c5113d" => :tiger_g4
-    sha256 "a440a72ed9982f71b913036572fcb8d7897a1f3e81142d37e09f1b3b544bbc7b" => :tiger_g5
   end
 
   depends_on :python => :optional
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "swig" => :build if build.with? "python"
 
   def install
@@ -18,7 +17,7 @@ class Ldns < Formula
       --prefix=#{prefix}
       --with-drill
       --with-examples
-      --with-ssl=#{Formula["openssl"].opt_prefix}
+      --with-ssl=#{Formula["openssl3"].opt_prefix}
     ]
 
     args << "--with-pyldns" if build.with? "python"

--- a/Library/Formula/libevent.rb
+++ b/Library/Formula/libevent.rb
@@ -7,6 +7,7 @@ class Libevent < Formula
 
   bottle do
     cellar :any
+    sha256 "5519f9a4cf854b58dbb6c9d61d76d49d4c3dbfdea58e13e9eae80bd25b47d358" => :tiger_altivec
   end
 
   head do

--- a/Library/Formula/libevent.rb
+++ b/Library/Formula/libevent.rb
@@ -3,10 +3,10 @@ class Libevent < Formula
   homepage "http://libevent.org"
   url "https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz"
   sha256 "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
+  revision 1
 
   bottle do
     cellar :any
-    sha256 "a0983219dd22de6526968649699c4a939c2553b5da021874bc2f7cf04fe32cb2" => :tiger_altivec
   end
 
   head do
@@ -19,7 +19,7 @@ class Libevent < Formula
 
   depends_on "doxygen" => [:optional, :build]
   depends_on "pkg-config" => :build
-  depends_on "openssl"
+  depends_on "openssl3"
 
   option :universal
   option "with-doxygen", "Build and install the manpages (using Doxygen)"

--- a/Library/Formula/libssh2.rb
+++ b/Library/Formula/libssh2.rb
@@ -6,6 +6,8 @@ class Libssh2 < Formula
   revision 1
 
   bottle do
+    cellar :any
+    sha256 "199ff7918596f64fab5429e23f6bf6f6e3819563dd1c11031cd5aaae620224c7" => :tiger_altivec
   end
 
   option "with-libressl", "build with LibreSSL instead of OpenSSL"

--- a/Library/Formula/libssh2.rb
+++ b/Library/Formula/libssh2.rb
@@ -3,9 +3,9 @@ class Libssh2 < Formula
   homepage "http://www.libssh2.org/"
   url "https://libssh2.org/download/libssh2-1.11.0.tar.xz"
   sha256 "a488a22625296342ddae862de1d59633e6d446eff8417398e06674a49be3d7c2"
+  revision 1
 
   bottle do
-    sha256 "eb70ab12fe7e6a56beaaa7ff9ef43eb43d7c8817286a8086f9786bf76904ad24" => :tiger_altivec
   end
 
   option "with-libressl", "build with LibreSSL instead of OpenSSL"
@@ -18,7 +18,7 @@ class Libssh2 < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl" => :recommended
+  depends_on "openssl3" => :recommended
   depends_on "libressl" => :optional
   depends_on "zlib"
 
@@ -36,7 +36,7 @@ class Libssh2 < Formula
     if build.with? "libressl"
       args << "--with-libssl-prefix=#{Formula["libressl"].opt_prefix}"
     else
-      args << "--with-libssl-prefix=#{Formula["openssl"].opt_prefix}"
+      args << "--with-libssl-prefix=#{Formula["openssl3"].opt_prefix}"
     end
 
     system "./buildconf" if build.head?

--- a/Library/Formula/lynx.rb
+++ b/Library/Formula/lynx.rb
@@ -7,6 +7,7 @@ class Lynx < Formula
   revision 1
 
   bottle do
+    sha256 "700740b3e28325962d8ed7c07aeed624a099843bf91d9a74f4784dec2ca7d0a5" => :tiger_altivec
   end
 
   depends_on "bzip2"

--- a/Library/Formula/lynx.rb
+++ b/Library/Formula/lynx.rb
@@ -4,12 +4,14 @@ class Lynx < Formula
   url "http://invisible-mirror.net/archives/lynx/tarballs/lynx2.8.9rel.1.tar.bz2"
   version "2.8.9rel.1"
   sha256 "387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
+  revision 1
 
   bottle do
-    sha256 "30a681fc44b5c512910cff3b0fa016786ee0f8a69e1ae1e56597c8d2b17b0ebc" => :tiger_altivec
   end
 
-  depends_on "openssl"
+  depends_on "bzip2"
+  depends_on "openssl3"
+  depends_on "zlib"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
@@ -19,7 +21,7 @@ class Lynx < Formula
                           "--enable-default-colors",
                           "--with-zlib",
                           "--with-bzlib",
-                          "--with-ssl=#{Formula["openssl"].opt_prefix}",
+                          "--with-ssl=#{Formula["openssl3"].opt_prefix}",
                           "--enable-ipv6"
     system "make", "install"
   end

--- a/Library/Formula/midnight-commander.rb
+++ b/Library/Formula/midnight-commander.rb
@@ -8,6 +8,7 @@ class MidnightCommander < Formula
   head "https://github.com/MidnightCommander/mc.git"
 
   bottle do
+    sha256 "aecc87ac3a43ecac7fe46a14b1a8adb2b98ed58c2bf95cfb2dc981fad583e7b9" => :tiger_altivec
   end
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/midnight-commander.rb
+++ b/Library/Formula/midnight-commander.rb
@@ -1,19 +1,18 @@
 class MidnightCommander < Formula
   desc "Terminal-based visual file manager"
   homepage "https://www.midnight-commander.org/"
-  url "http://ftp.midnight-commander.org/mc-4.8.29.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/m/mc/mc_4.8.29.orig.tar.xz"
-  sha256 "01d8a3b94f58180cca5bf17257b5078d1fd6fd27a9b5c0e970ec767549540ad4"
+  url "http://ftp.midnight-commander.org/mc-4.8.30.tar.xz"
+  mirror "https://ftp.osuosl.org/pub/midnightcommander/mc-4.8.30.tar.xz"
+  sha256 "5ebc3cb2144b970c5149fda556c4ad50b78780494696cdf2d14a53204c95c7df"
 
   head "https://github.com/MidnightCommander/mc.git"
 
   bottle do
-    sha256 "3544876d1ec441cdaba7b0e4c51c832bea76433e910915229f66a7a8b253472a" => :tiger_altivec
   end
 
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "s-lang"
   depends_on "libssh2"
 

--- a/Library/Formula/mutt.rb
+++ b/Library/Formula/mutt.rb
@@ -17,6 +17,7 @@ class Mutt < Formula
   revision 1
 
   bottle do
+    sha256 "03c1583614ae55f5e7a6edac7d3377f7914d1057063e403be68b1cebfcb60b7d" => :tiger_altivec
   end
 
   unless Tab.for_name("signing-party").with? "rename-pgpring"

--- a/Library/Formula/mutt.rb
+++ b/Library/Formula/mutt.rb
@@ -14,9 +14,9 @@ class Mutt < Formula
   url "http://ftp.mutt.org/pub/mutt/mutt-2.2.12.tar.gz"
   mirror "https://bitbucket.org/mutt/mutt/downloads/mutt-2.2.12.tar.gz"
   sha256 "043af312f64b8e56f7fd0bf77f84a205d4c498030bd9586457665c47bb18ce38"
+  revision 1
 
   bottle do
-    sha256 "397bb66757f31227db8b4d20a476cce30ebca29b610361468680a3cd75eeacd5" => :tiger_altivec
   end
 
   unless Tab.for_name("signing-party").with? "rename-pgpring"
@@ -32,7 +32,7 @@ class Mutt < Formula
 
   # mutt can't compile against Tiger's system version
   depends_on "cyrus-sasl" if MacOS.version < :leopard
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "tokyo-cabinet"
   depends_on "zlib"
   depends_on "s-lang" => :optional

--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -7,6 +7,7 @@ class Nginx < Formula
   revision 1
 
   bottle do
+    sha256 "c2640340f79102c0bbe1db54e8cb280149e88b71a8378dce6ddb2fe10ca2b733" => :tiger_altivec
   end
 
   env :userpaths

--- a/Library/Formula/nginx.rb
+++ b/Library/Formula/nginx.rb
@@ -4,9 +4,9 @@ class Nginx < Formula
   url "https://nginx.org/download/nginx-1.25.2.tar.gz"
   sha256 "05dd6d9356d66a74e61035f2a42162f8c754c97cf1ba64e7a801ba158d6c0711"
   head "http://hg.nginx.org/nginx/", :using => :hg
+  revision 1
 
   bottle do
-    sha256 "79d4d0139ee3a8c96cc72ed94bf804cf90e7c40134902196c2470859ae348344" => :tiger_altivec
   end
 
   env :userpaths
@@ -22,7 +22,7 @@ class Nginx < Formula
 
   depends_on "pcre2"
   depends_on "passenger" => :optional
-  depends_on "openssl" => :recommended
+  depends_on "openssl3" => :recommended
   depends_on "libressl" => :optional
   depends_on "zlib"
 
@@ -32,7 +32,7 @@ class Nginx < Formula
     inreplace "conf/nginx.conf", "    #}\n\n}", "    #}\n    include servers/*;\n}"
 
     pcre = Formula["pcre2"]
-    openssl = Formula["openssl"]
+    openssl = Formula["openssl3"]
     libressl = Formula["libressl"]
     zlib = Formula["zlib"]
 

--- a/Library/Formula/ntp.rb
+++ b/Library/Formula/ntp.rb
@@ -8,6 +8,7 @@ class Ntp < Formula
   revision 1
 
   bottle do
+    sha256 "0cca8aeee41ac7f9f6ffca7d48cf4e9afc5aabb5614a012bda20cf1151084bfe" => :tiger_altivec
   end
 
   depends_on "libevent"

--- a/Library/Formula/ntp.rb
+++ b/Library/Formula/ntp.rb
@@ -5,12 +5,13 @@ class Ntp < Formula
   version "4.2.8p17"
   sha256 "103dd272e6a66c5b8df07dce5e9a02555fcd6f1397bdfb782237328e89d3a866"
   license all_of: ["BSD-2-Clause", "NTP"]
+  revision 1
 
   bottle do
-    sha256 "328717f558bfb5137571df39fbd4402b602019bc14ee891bd86e026ec18fdcdf" => :tiger_altivec
   end
 
-  depends_on "openssl"
+  depends_on "libevent"
+  depends_on "openssl3"
 
   def install
     args = %W[
@@ -18,8 +19,8 @@ class Ntp < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-openssl-libdir=#{Formula["openssl"].lib}
-      --with-openssl-incdir=#{Formula["openssl"].include}
+      --with-openssl-libdir=#{Formula["openssl3"].lib}
+      --with-openssl-incdir=#{Formula["openssl3"].include}
       --with-net-snmp-config=no
     ]
 

--- a/Library/Formula/openconnect.rb
+++ b/Library/Formula/openconnect.rb
@@ -6,6 +6,7 @@ class Openconnect < Formula
   revision 1
 
   bottle do
+    sha256 "4c379a66a6367ab6219a6a86bf4b429266af1c53ebfed5a1cc601fe3ff521878" => :tiger_altivec
   end
 
   head do

--- a/Library/Formula/openconnect.rb
+++ b/Library/Formula/openconnect.rb
@@ -3,9 +3,9 @@ class Openconnect < Formula
   homepage "http://www.infradead.org/openconnect.html"
   url "https://www.infradead.org/openconnect/download/openconnect-9.12.tar.gz"
   sha256 "a2bedce3aa4dfe75e36e407e48e8e8bc91d46def5335ac9564fbf91bd4b2413e"
+  revision 1
 
   bottle do
-    sha256 "ac170fd498f2f668253bdc60080039795491eb5b81cd120f39f40cdbf465ac27" => :tiger_altivec
   end
 
   head do
@@ -17,7 +17,7 @@ class Openconnect < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "oath-toolkit" => :optional
   depends_on "p11-kit"
   depends_on "stoken" => :optional

--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -9,6 +9,7 @@ class Openssh < Formula
   revision 1
 
   bottle do
+    sha256 "0df72214140fac75a70abaeaa924ca7e15556c8a094abbed3b15d33525201226" => :tiger_altivec
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.

--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -6,9 +6,9 @@ class Openssh < Formula
   version "9.5p1"
   sha256 "f026e7b79ba7fb540f75182af96dc8a8f1db395f922bbc9f6ca603672686086b"
   license "SSH-OpenSSH"
+  revision 1
 
   bottle do
-    sha256 "17cce12458f27b4db3dd5bd4b574764cf213dd6520582919e8e5c79a775d8c27" => :tiger_altivec
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.
@@ -16,7 +16,7 @@ class Openssh < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ldns"
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "zlib"
 
     # Both these patches are applied by Apple.
@@ -45,7 +45,7 @@ class Openssh < Formula
       --with-libedit
       --with-kerberos5
       --with-pam
-      --with-ssl-dir=#{Formula["openssl"].opt_prefix}
+      --with-ssl-dir=#{Formula["openssl3"].opt_prefix}
       --with-zlib=#{Formula["zlib"].opt_prefix}
     ]
 

--- a/Library/Formula/postgresql.rb
+++ b/Library/Formula/postgresql.rb
@@ -6,6 +6,7 @@ class Postgresql < Formula
   revision 1
 
   bottle do
+    sha256 "ed31af40b9f8b7c73afac0004061fca1e3c18a15bb5b5a7b756e8101c379a478" => :tiger_altivec
   end
 
   option "32-bit"

--- a/Library/Formula/postgresql.rb
+++ b/Library/Formula/postgresql.rb
@@ -3,9 +3,9 @@ class Postgresql < Formula
   homepage "https://www.postgresql.org/"
   url "https://ftp.postgresql.org/pub/source/v15.4/postgresql-15.4.tar.bz2"
   sha256 "baec5a4bdc4437336653b6cb5d9ed89be5bd5c0c58b94e0becee0a999e63c8f9"
+  revision 1
 
   bottle do
-    sha256 "16c9282d83e6b64b60bee66764ba6febc5514128aaa9d2e6525d574015765d63" => :tiger_altivec
   end
 
   option "32-bit"
@@ -18,7 +18,7 @@ class Postgresql < Formula
   deprecated_option "enable-dtrace" => "with-dtrace"
   deprecated_option "with-python" => "with-python3"
 
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "readline"
   depends_on "libxml2"
   depends_on "libxslt"

--- a/Library/Formula/rsync.rb
+++ b/Library/Formula/rsync.rb
@@ -6,13 +6,13 @@ class Rsync < Formula
   mirror "https://www.mirrorservice.org/sites/rsync.samba.org/rsync-3.2.7.tar.gz"
   sha256 "4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
-    sha256 "67bb955b3d96f3c4316770f8633110f7b4d8e7431a3c95d06ce41845ef21371a" => :tiger_altivec
   end
 
   depends_on "lz4"
-  depends_on "openssl"
+  depends_on "openssl3"
   depends_on "popt"
   depends_on "xxhash"
   depends_on "zlib"

--- a/Library/Formula/rsync.rb
+++ b/Library/Formula/rsync.rb
@@ -9,6 +9,7 @@ class Rsync < Formula
   revision 1
 
   bottle do
+    sha256 "bafb84b70feffa4c4c695301cd849ca2fae9c92c3b2a46231362eea26187990c" => :tiger_altivec
   end
 
   depends_on "lz4"


### PR DESCRIPTION
Start switching formulas to openssl3 now that openssl 1.1.1 is EoL.
Ideally should be merged after the openssl3 update in #981

Libraries such as ldns, libevent, libssh2 should be built first, before applications, otherwise openssl 1.1.1 creeps in as a dependency.