### PR TITLE
av98: Update test target hostname

### DIFF
--- a/Library/Formula/av98.rb
+++ b/Library/Formula/av98.rb
@@ -19,6 +19,6 @@ class Av98 < Formula
   end
 
   test do
-    system "#{bin}/av98 gemini.circumlunar.space < /dev/null"
+    system "#{bin}/av98 geminiprotocol.net < /dev/null"
   end
 end


### PR DESCRIPTION
There's now a dedicated geminiprotocol.net domain.
Use that for testing instead.