### PR TITLE
glib 2.59.0

### DIFF
--- a/Library/Formula/glib.rb
+++ b/Library/Formula/glib.rb
@@ -1,15 +1,19 @@
 class Glib < Formula
   desc "Core application library for C"
   homepage "https://developer.gnome.org/glib/"
-  url "https://download.gnome.org/sources/glib/2.50/glib-2.50.1.tar.xz"
-  sha256 "2ef87a78f37c1eb5b95f4cc95efd5b66f69afad9c9c0899918d04659cf6df7dd"
-  revision 1
+  url "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/glib/2.59/glib-2.59.0.tar.xz"
+  sha256 "664a5dee7307384bb074955f8e5891c7cecece349bbcc8a8311890dc185b428e"
 
   bottle do
-    sha256 "b2bcafc89c8b6706fa852bc8e792e7508d52b64febd5bdb0a6cfa82aef815472" => :tiger_altivec
   end
 
-  option :universal
+  # Fixes g_get_monotonic_time on non-Intel Macs; submitted upstream:
+  # https://bugzilla.gnome.org/show_bug.cgi?id=728123
+  # https://bugzilla.gnome.org/show_bug.cgi?id=673135 Resolved as wontfix,
+  # but needed to fix an assumption about the location of the d-bus machine
+  # id file.
+  patch :p0, :DATA
+
   option "with-test", "Build a debug build and run tests. NOTE: Not all tests succeed yet"
   option "with-static", "Build glib with a static archive."
 
@@ -17,75 +21,20 @@ class Glib < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
+  depends_on "libiconv"
   depends_on "libffi"
   depends_on "pcre"
-  depends_on :python if MacOS.version < :leopard
-  # the version of zlib which comes with Tiger does not
-  # export some symbols glib expects
-  depends_on "zlib" if MacOS.version == :tiger
-
-  fails_with :llvm do
-    build 2334
-    cause "Undefined symbol errors while linking"
-  end
-
-  resource "config.h.ed" do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/eb51d82/glib/config.h.ed"
-    version "111532"
-    sha256 "9f1e23a084bc879880e589893c17f01a2f561e20835d6a6f08fcc1dad62388f1"
-  end
-
-  # https://bugzilla.gnome.org/show_bug.cgi?id=673135 Resolved as wontfix,
-  # but needed to fix an assumption about the location of the d-bus machine
-  # id file.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/patches/59e4d327791d4fe3423c2c871adb98e3f3f07633/glib/hardcoded-paths.diff"
-    sha256 "a4cb96b5861672ec0750cb30ecebe1d417d38052cac12fbb8a77dbf04a886fcb"
-  end
-
-  # Fixes compilation with FSF GCC. Doesn't fix it on every platform, due
-  # to unrelated issues in GCC, but improves the situation.
-  # Patch submitted upstream: https://bugzilla.gnome.org/show_bug.cgi?id=672777
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/a39dec26/glib/gio.patch"
-    sha256 "284cbf626f814c21f30167699e6e59dcc0d31000d71151f25862b997a8c8493d"
-  end
-
-  patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/fe50d25d/glib/universal.diff"
-      sha256 "e21f902907cca543023c930101afe1d0c1a7ad351daa0678ba855341f3fd1b57"
-  end if build.universal?
-
-  # Fixes g_get_monotonic_time on non-Intel Macs; submitted upstream:
-  # https://bugzilla.gnome.org/show_bug.cgi?id=728123
-  patch do
-    url "https://gist.githubusercontent.com/mistydemeo/a34250bb0864a87602f6128784dd87a8/raw/1b0006a1e0cdd2c6740fb0a0223b3104a8ed1c21/g_get_monotonic_time.patch"
-    sha256 "7133b8087952bba71a60cccc2f380aa565c837842b705a90d51ac8beb0fd41cb"
-  end
-
-  # Reverts GNotification support on macOS.
-  # This only supports OS X 10.9, and the reverted commits removed the
-  # ability to build glib on older versions of OS X.
-  # https://bugzilla.gnome.org/show_bug.cgi?id=747146
-  # Reverts upstream commits 36e093a31a9eb12021e7780b9e322c29763ffa58
-  # and 89058e8a9b769ab223bc75739f5455dab18f7a3d, with equivalent changes
-  # also applied to configure and gio/Makefile.in
-  if MacOS.version < :mavericks
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/a4fe61b/glib/gnotification-mountain.patch"
-      sha256 "5bf6d562dd2be811d71e6f84eb43fc6c51a112db49ec0346c1b30f4f6f4a4233"
-    end
-  end
+  depends_on "python3"
+  depends_on "zlib"
+  # glib's switched to using Meson to build
+  # 2.59.0 is the last version to ship with autoconf support but we need to bootstrap
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "libtool" => :build
 
   def install
-    ENV.universal_binary if build.universal?
-
     inreplace %w[gio/gdbusprivate.c gio/xdgmime/xdgmime.c glib/gutils.c],
-      "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
-
-    # renaming is necessary for patches to work
-    mv "gio/gcocoanotificationbackend.c", "gio/gcocoanotificationbackend.m" unless MacOS.version < :mavericks
-    mv "gio/gnextstepsettingsbackend.c", "gio/gnextstepsettingsbackend.m"
+      "HOMEBREWPREFIX", HOMEBREW_PREFIX
 
     # Disable dtrace; see https://trac.macports.org/ticket/30413
     args = %W[
@@ -101,14 +50,11 @@ class Glib < Formula
 
     args << "--enable-static" if build.with? "static"
 
+    # autogen.sh defaults to running configure itself, without any args
+    system "env NOCONFIGURE=1 ./autogen.sh"
     system "./configure", *args
 
-    if build.universal?
-      buildpath.install resource("config.h.ed")
-      system "ed -s - config.h <config.h.ed"
-    end
-
-    # disable creating directory for GIO_MOUDLE_DIR, we will do this manually in post_install
+    # disable creating directory for GIO_MODULE_DIR, we will do this manually in post_install
     inreplace "gio/Makefile", "$(mkinstalldirs) $(DESTDIR)$(GIO_MODULE_DIR)", ""
 
     system "make"
@@ -126,7 +72,6 @@ class Glib < Formula
               "Cflags: -I${includedir}/glib-2.0 -I${libdir}/glib-2.0/include -I#{gettext}/include"
     end
 
-    (share+"gtk-doc").rmtree
   end
 
   def post_install
@@ -149,23 +94,132 @@ class Glib < Formula
           return (strcmp(str, result_2) == 0) ? 0 : 1;
       }
       EOS
-    flags = ["-I#{include}/glib-2.0", "-I#{lib}/glib-2.0/include", "-lglib-2.0"]
+    flags = ["-I#{include}/glib-2.0", "-I#{lib}/glib-2.0/include", "-L#{lib}", "-lglib-2.0.0"]
     system ENV.cc, "-o", "test", "test.c", *(flags + ENV.cflags.to_s.split)
     system "./test"
   end
+
 end
-
 __END__
-diff --git a/gobject/gtype.h b/gobject/gtype.h
-index 8a1bff2..4474ede 100644
---- a/gobject/gtype.h
-+++ b/gobject/gtype.h
-@@ -1580,7 +1580,7 @@ type_name##_get_type (void) \
-  */
- #define G_DEFINE_BOXED_TYPE_WITH_CODE(TypeName, type_name, copy_func, free_func, _C_) _G_DEFINE_BOXED_TYPE_BEGIN (TypeName, type_name, copy_func, free_func) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
-
--#if !defined (__cplusplus) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 7))
-+#if !defined (__cplusplus) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 7) && !defined (__ppc64__))
- #define _G_DEFINE_BOXED_TYPE_BEGIN(TypeName, type_name, copy_func, free_func) \
- GType \
- type_name##_get_type (void) \
+--- gio/gosxcontenttype.m.orig	2023-05-24 18:28:06.000000000 +0100
++++ gio/gosxcontenttype.m	2023-05-24 18:28:28.000000000 +0100
+@@ -24,6 +24,7 @@
+ #include "gthemedicon.h"
+ 
+ #include <CoreServices/CoreServices.h>
++#include <ApplicationServices/ApplicationServices.h>
+ 
+ #define XDG_PREFIX _gio_xdg
+ #include "xdgmime/xdgmime.h"
+--- glib/gmain.c.orig	2023-05-24 18:52:38.000000000 +0100
++++ glib/gmain.c	2023-05-24 18:56:15.000000000 +0100
+@@ -2768,46 +2768,35 @@
+ g_get_monotonic_time (void)
+ {
+   static mach_timebase_info_data_t timebase_info;
++  static double absolute_to_micro;
+ 
+   if (timebase_info.denom == 0)
+     {
+-      /* This is a fraction that we must use to scale
+-       * mach_absolute_time() by in order to reach nanoseconds.
+-       *
+-       * We've only ever observed this to be 1/1, but maybe it could be
+-       * 1000/1 if mach time is microseconds already, or 1/1000 if
+-       * picoseconds.  Try to deal nicely with that.
++      /* mach_absolute_time() returns "absolute time units", rather than
++         seconds; the mach_timebase_info_data_t struct provides a
++         fraction that can be used to convert these units into seconds.
+        */
+       mach_timebase_info (&timebase_info);
+ 
+-      /* We actually want microseconds... */
+-      if (timebase_info.numer % 1000 == 0)
+-        timebase_info.numer /= 1000;
+-      else
+-        timebase_info.denom *= 1000;
+-
+-      /* We want to make the numer 1 to avoid having to multiply... */
+-      if (timebase_info.denom % timebase_info.numer == 0)
+-        {
+-          timebase_info.denom /= timebase_info.numer;
+-          timebase_info.numer = 1;
+-        }
+-      else
+-        {
+-          /* We could just multiply by timebase_info.numer below, but why
+-           * bother for a case that may never actually exist...
+-           *
+-           * Plus -- performing the multiplication would risk integer
+-           * overflow.  If we ever actually end up in this situation, we
+-           * should more carefully evaluate the correct course of action.
+-           */
+-          mach_timebase_info (&timebase_info); /* Get a fresh copy for a better message */
+-          g_error ("Got weird mach timebase info of %d/%d.  Please file a bug against GLib.",
+-                   timebase_info.numer, timebase_info.denom);
+-        }
++      absolute_to_micro = 1e-3 * timebase_info.numer / timebase_info.denom;
+     }
+ 
+-  return mach_absolute_time () / timebase_info.denom;
++  if (timebase_info.denom == 1 && timebase_info.numer == 1)
++    {
++      /* On Intel, the fraction has been 1/1 to date, so we can shortcut
++         the conversion into microseconds.
++       */
++      return mach_absolute_time () / 1000;
++    }
++  else
++    {
++      /* On ARM and PowerPC, the value is unpredictable and is hardware
++         dependent, so we can't guess. Both the units and numer/denom
++         are extremely large, so the conversion number is stored as a
++         double in order to avoid integer overflow.
++       */
++      return mach_absolute_time () * absolute_to_micro;
++    }
+ }
+ #else
+ gint64
+--- gio/gdbusprivate.c.orig	2018-12-23 13:10:41.000000000 +0000
++++ gio/gdbusprivate.c	2023-11-26 21:19:10.000000000 +0000
+@@ -2098,7 +2098,7 @@
+   /* TODO: use PACKAGE_LOCALSTATEDIR ? */
+   ret = NULL;
+   first_error = NULL;
+-  if (!g_file_get_contents ("/var/lib/dbus/machine-id",
++  if (!g_file_get_contents ("HOMEBREWPREFIX/var/lib/dbus/machine-id",
+                             &ret,
+                             NULL,
+                             &first_error) &&
+@@ -2108,7 +2108,7 @@
+                             NULL))
+     {
+       g_propagate_prefixed_error (error, first_error,
+-                                  _("Unable to load /var/lib/dbus/machine-id or /etc/machine-id: "));
++                                  _("Unable to load HOMEBREWPREFIX or /etc/machine-id: "));
+     }
+   else
+     {
+--- gio/xdgmime/xdgmime.c.orig	2018-12-23 13:10:41.000000000 +0000
++++ gio/xdgmime/xdgmime.c	2023-11-26 21:19:10.000000000 +0000
+@@ -235,7 +235,7 @@
+   xdg_data_dirs = getenv ("XDG_DATA_DIRS");
+ 
+   if (xdg_data_dirs == NULL)
+-    xdg_data_dirs = "/usr/local/share/:/usr/share/";
++    xdg_data_dirs = "HOMEBREWPREFIX/share/:/usr/share/";
+ 
+   /* Work out how many dirs we’re dealing with. */
+   if (xdg_data_home != NULL || home != NULL)
+--- glib/gutils.c.orig	2018-12-23 13:10:41.000000000 +0000
++++ glib/gutils.c	2023-11-26 21:19:10.000000000 +0000
+@@ -2125,7 +2125,7 @@
+    */
+ #ifndef G_OS_WIN32
+   if (!data_dirs || !data_dirs[0])
+-    data_dirs = "/usr/local/share/:/usr/share/";
++    data_dirs = "HOMEBREWPREFIX/share/:/usr/share/";
+ 
+   data_dir_vector = g_strsplit (data_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
+ #else


### PR DESCRIPTION
v2.59.0 is the last version to support autoconf'd builds. Project switched to Meson builds from there on.

I have dropped universal build support patches.

Built with GCC 4.0 on Tiger.