### PR TITLE
rancid 3.13

### DIFF
--- a/Library/Formula/rancid.rb
+++ b/Library/Formula/rancid.rb
@@ -1,20 +1,21 @@
 class Rancid < Formula
   desc "Really Awesome New Cisco confIg Differ"
   homepage "http://www.shrubbery.net/rancid/"
-  url "ftp://ftp.shrubbery.net/pub/rancid/rancid-3.2.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/r/rancid/rancid_3.2.orig.tar.gz"
-  sha256 "e7da7242c1f072700b8d6077314be91c1fabe62528de2bdf91349b7094729e75"
+  url "https://shrubbery.net/pub/rancid/rancid-3.13.tar.gz"
+  mirror "https://mirrors.edge.kernel.org/debian/pool/main/r/rancid/rancid_3.13.orig.tar.gz"
+  sha256 "7241d2972b1f6f76a28bdaa0e7942b1257e08b404a15d121c9dee568178f8bf5"
 
   bottle do
-    sha256 "361593d9d0604f9a82761737e7452aa26d5e9d82c7d14209ffdc1fb8e40c2ddb" => :yosemite
-    sha256 "b58dfdca8ca5769648a3eec9f801bac32419185e2602043a1c7ee032de06da8c" => :mavericks
-    sha256 "dc6eb5f1cec36fb614ba2dc1bfd5590b19d9b57aaac1a88d00c635af5f46b2ae" => :mountain_lion
   end
 
   conflicts_with "par", :because => "both install `par` binaries"
 
+  depends_on "git"
+  depends_on "openssh"
+  depends_on "perl" # Socket version 2.006 required
+
   def install
-    system "./configure", "--prefix=#{prefix}", "--exec-prefix=#{prefix}", "--mandir=#{man}"
+    system "./configure", "--prefix=#{prefix}", "--exec-prefix=#{prefix}", "--mandir=#{man}", "--with-git"
     system "make", "install"
   end
 


### PR DESCRIPTION
Use git instead of CVS.
Though git is a runtime dep, configure checks for git.

Tested on Tiger.