### PR TITLE
Use prdownloads.sourceforge.net

### DIFF
--- a/Library/Formula/aalib.rb
+++ b/Library/Formula/aalib.rb
@@ -1,7 +1,7 @@
 class Aalib < Formula
   desc "Portable ASCII art graphics library"
   homepage "http://aa-project.sourceforge.net/aalib/"
-  url "https://downloads.sourceforge.net/aa-project/aalib-1.4rc5.tar.gz"
+  url "https://prdownloads.sourceforge.net/aa-project/aalib-1.4rc5.tar.gz"
   sha256 "fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee"
 
   bottle do

--- a/Library/Formula/aap.rb
+++ b/Library/Formula/aap.rb
@@ -1,7 +1,7 @@
 class Aap < Formula
   desc "Aap is a make-like tool to download, build, and install software"
   homepage "http://www.a-a-p.org"
-  url "https://downloads.sourceforge.net/project/a-a-p/aap-1.094.zip"
+  url "https://prdownloads.sourceforge.net/project/a-a-p/aap-1.094.zip"
   sha256 "3f53b2fc277756042449416150acc477f29de93692944f8a77e8cef285a1efd8"
 
   bottle do

--- a/Library/Formula/abook.rb
+++ b/Library/Formula/abook.rb
@@ -1,7 +1,7 @@
 class Abook < Formula
   desc "Address book with mutt support"
   homepage "http://abook.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/abook/abook/0.5.6/abook-0.5.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/abook/abook/0.5.6/abook-0.5.6.tar.gz"
   sha256 "0646f6311a94ad3341812a4de12a5a940a7a44d5cb6e9da5b0930aae9f44756e"
   revision 1
 

--- a/Library/Formula/adplug.rb
+++ b/Library/Formula/adplug.rb
@@ -1,7 +1,7 @@
 class Adplug < Formula
   desc "Free, hardware independent AdLib sound player library"
   homepage "http://adplug.sf.net"
-  url "https://downloads.sourceforge.net/project/adplug/AdPlug%20core%20library/2.2.1/adplug-2.2.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/adplug/AdPlug%20core%20library/2.2.1/adplug-2.2.1.tar.bz2"
   sha256 "f95a015268a0dfe9ff5782f3ea7b2a69e09b8d36ccd19ebf4d979d767b6e53ef"
 
   bottle do

--- a/Library/Formula/aften.rb
+++ b/Library/Formula/aften.rb
@@ -1,7 +1,7 @@
 class Aften < Formula
   desc "Audio encoder which generates ATSC A/52 compressed audio streams"
   homepage "http://aften.sourceforge.net/"
-  url "https://downloads.sourceforge.net/aften/aften-0.0.8.tar.bz2"
+  url "https://prdownloads.sourceforge.net/aften/aften-0.0.8.tar.bz2"
   sha256 "87cc847233bb92fbd5bed49e2cdd6932bb58504aeaefbfd20ecfbeb9532f0c0a"
 
   depends_on "cmake" => :build

--- a/Library/Formula/allegro.rb
+++ b/Library/Formula/allegro.rb
@@ -3,7 +3,7 @@ class Allegro < Formula
   homepage "http://liballeg.org/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/alleg/allegro/5.0.11/allegro-5.0.11.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/alleg/allegro/5.0.11/allegro-5.0.11.tar.gz"
     sha256 "49fe14c9571463ba08db4ff778d1fbb15e49f9c33bdada3ac8599e04330ea531"
   end
   bottle do
@@ -15,7 +15,7 @@ class Allegro < Formula
   end
 
   devel do
-    url "https://downloads.sourceforge.net/project/alleg/allegro-unstable/5.1.11/allegro-5.1.11.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/alleg/allegro-unstable/5.1.11/allegro-5.1.11.tar.gz"
     sha256 "7a071635e39105ce52cd82c8641a8f3841efbdfe8fdb39f7a5ae1be6db3be07f"
 
     depends_on "theora" => :recommended

--- a/Library/Formula/ant-contrib.rb
+++ b/Library/Formula/ant-contrib.rb
@@ -1,7 +1,7 @@
 class AntContrib < Formula
   desc "Collection of tasks for Apache Ant"
   homepage "http://ant-contrib.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz"
   sha256 "6e58c2ee65e1f4df031796d512427ea213a92ae40c5fc0b38d8ac82701f42a3c"
   version "1.0b3"
 

--- a/Library/Formula/anttweakbar.rb
+++ b/Library/Formula/anttweakbar.rb
@@ -1,7 +1,7 @@
 class Anttweakbar < Formula
   desc "C/C++ library for adding GUIs to OpenGL apps"
   homepage "http://www.antisphere.com/Wiki/tools:anttweakbar"
-  url "https://downloads.sourceforge.net/project/anttweakbar/AntTweakBar_116.zip"
+  url "https://prdownloads.sourceforge.net/project/anttweakbar/AntTweakBar_116.zip"
   version "1.16"
   sha256 "fbceb719c13ceb13b9fd973840c2c950527b6e026f9a7a80968c14f76fcf6e7c"
 

--- a/Library/Formula/apt-dater.rb
+++ b/Library/Formula/apt-dater.rb
@@ -1,7 +1,7 @@
 class AptDater < Formula
   desc "Manage package updates on remote hosts using SSH"
   homepage "http://www.ibh.de/apt-dater/"
-  url "https://downloads.sourceforge.net/project/apt-dater/apt-dater/0.9.0/apt-dater-0.9.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/apt-dater/apt-dater/0.9.0/apt-dater-0.9.0.tar.gz"
   sha256 "10b8335c156dabae249aa071cf8689900fae325c2e9540e36a840a2a77d3eeb4"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/arabica.rb
+++ b/Library/Formula/arabica.rb
@@ -1,7 +1,7 @@
 class Arabica < Formula
   desc "XML toolkit written in C++"
   homepage "http://www.jezuk.co.uk/cgi-bin/view/arabica"
-  url "https://downloads.sourceforge.net/project/arabica/arabica/November-12/arabica-2012-November.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/arabica/arabica/November-12/arabica-2012-November.tar.gz"
   version "20121126"
   sha256 "2e64e38d773ff37f5d7da181fe07d6dde2c35e633b9772b604439a286cd4f98b"
 

--- a/Library/Formula/argtable.rb
+++ b/Library/Formula/argtable.rb
@@ -1,7 +1,7 @@
 class Argtable < Formula
   desc "ANSI C library for parsing GNU-style command-line options"
   homepage "http://argtable.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/argtable/argtable/argtable-2.13/argtable2-13.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/argtable/argtable/argtable-2.13/argtable2-13.tar.gz"
   version "2.13"
   sha256 "8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf"
 

--- a/Library/Formula/aria2.rb
+++ b/Library/Formula/aria2.rb
@@ -1,7 +1,7 @@
 class Aria2 < Formula
   desc "Download with resuming and segmented downloading"
   homepage "http://aria2.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/aria2/stable/aria2-1.19.0/aria2-1.19.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/aria2/stable/aria2-1.19.0/aria2-1.19.0.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/a/aria2/aria2_1.19.0.orig.tar.bz2"
   sha256 "ae2b6fce7a0974c9156415cccf2395cd258580ab34eec2b34a8e76120b7240ce"
 

--- a/Library/Formula/arss.rb
+++ b/Library/Formula/arss.rb
@@ -1,7 +1,7 @@
 class Arss < Formula
   desc "Analyze a sound file into a spectrogram"
   homepage "http://arss.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/arss/arss/0.2.3/arss-0.2.3-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/arss/arss/0.2.3/arss-0.2.3-src.tar.gz"
   sha256 "e2faca8b8a3902226353c4053cd9ab71595eec6ead657b5b44c14b4bef52b2b2"
 
   depends_on "cmake" => :build

--- a/Library/Formula/asciidoc.rb
+++ b/Library/Formula/asciidoc.rb
@@ -1,7 +1,7 @@
 class Asciidoc < Formula
   desc "Formatter/translator for text files to numerous formats"
   homepage "http://asciidoc.org/"
-  url "https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
   sha256 "78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0"
 
   bottle do

--- a/Library/Formula/asciitex.rb
+++ b/Library/Formula/asciitex.rb
@@ -1,7 +1,7 @@
 class Asciitex < Formula
   desc "Generate ASCII-art representations of mathematical equations"
   homepage "http://asciitex.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/asciitex/asciiTeX-0.21.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/asciitex/asciiTeX-0.21.tar.gz"
   sha256 "abf964818833d8b256815eb107fb0de391d808fe131040fb13005988ff92a48d"
 
   bottle do

--- a/Library/Formula/aspcud.rb
+++ b/Library/Formula/aspcud.rb
@@ -1,7 +1,7 @@
 class Aspcud < Formula
   desc "Package dependency solver"
   homepage "http://potassco.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/potassco/aspcud/1.9.1/aspcud-1.9.1-source.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/potassco/aspcud/1.9.1/aspcud-1.9.1-source.tar.gz"
   sha256 "e0e917a9a6c5ff080a411ff25d1174e0d4118bb6759c3fe976e2e3cca15e5827"
 
   bottle do

--- a/Library/Formula/assimp.rb
+++ b/Library/Formula/assimp.rb
@@ -1,7 +1,7 @@
 class Assimp < Formula
   desc "Portable library for importing many well-known 3D model formats"
   homepage "http://assimp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/assimp/assimp-3.1/assimp-3.1.1_no_test_models.zip"
+  url "https://prdownloads.sourceforge.net/project/assimp/assimp-3.1/assimp-3.1.1_no_test_models.zip"
   sha256 "da9827876f10a8b447270368753392cfd502e70a2e9d1361554e5dfcb1fede9e"
   version "3.1.1"
 

--- a/Library/Formula/astyle.rb
+++ b/Library/Formula/astyle.rb
@@ -1,7 +1,7 @@
 class Astyle < Formula
   desc "Source code beautifier for C, C++, C#, and Java"
   homepage "http://astyle.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_macosx.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_macosx.tar.gz"
   sha256 "de66da286dee2b9de1dc1c05092cbf5368c0889f25d1e2ee8b51766aff8e4baf"
   head "svn://svn.code.sf.net/p/astyle/code/trunk/AStyle"
 

--- a/Library/Formula/ats2-postiats.rb
+++ b/Library/Formula/ats2-postiats.rb
@@ -1,7 +1,7 @@
 class Ats2Postiats < Formula
   desc "ATS programming language implementation"
   homepage "http://www.ats-lang.org/"
-  url "https://downloads.sourceforge.net/project/ats2-lang/ats2-lang/ats2-postiats-0.2.3/ATS2-Postiats-0.2.3.tgz"
+  url "https://prdownloads.sourceforge.net/project/ats2-lang/ats2-lang/ats2-postiats-0.2.3/ATS2-Postiats-0.2.3.tgz"
   sha256 "a2a50305ddfc8c88d475e0378a9f476887d11c0a64f381b849f2b9f1746258cd"
 
   bottle do

--- a/Library/Formula/automysqlbackup.rb
+++ b/Library/Formula/automysqlbackup.rb
@@ -1,7 +1,7 @@
 class Automysqlbackup < Formula
   desc "Automate MySQL backups"
   homepage "http://sourceforge.net/projects/automysqlbackup/"
-  url "https://downloads.sourceforge.net/project/automysqlbackup/AutoMySQLBackup/AutoMySQLBackup%20VER%203.0/automysqlbackup-v3.0_rc6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/automysqlbackup/AutoMySQLBackup/AutoMySQLBackup%20VER%203.0/automysqlbackup-v3.0_rc6.tar.gz"
   version "3.0-rc6"
   sha256 "889e064d086b077e213da11e937ea7242a289f9217652b9051c157830dc23cc0"
 

--- a/Library/Formula/autopano-sift-c.rb
+++ b/Library/Formula/autopano-sift-c.rb
@@ -1,7 +1,7 @@
 class AutopanoSiftC < Formula
   desc "Find control points in overlapping image pairs"
   homepage "http://wiki.panotools.org/Autopano-sift-C"
-  url "https://downloads.sourceforge.net/project/hugin/autopano-sift-C/autopano-sift-C-2.5.1/autopano-sift-C-2.5.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/hugin/autopano-sift-C/autopano-sift-C-2.5.1/autopano-sift-C-2.5.1.tar.gz"
   sha256 "9a9029353f240b105a9c0e31e4053b37b0f9ef4bd9166dcb26be3e819c431337"
 
   depends_on "libpano"

--- a/Library/Formula/autopsy.rb
+++ b/Library/Formula/autopsy.rb
@@ -1,7 +1,7 @@
 class Autopsy < Formula
   desc "Graphical interface to Sleuth Kit investigation tools"
   homepage "http://www.sleuthkit.org/autopsy/index.php"
-  url "https://downloads.sourceforge.net/project/autopsy/autopsy/2.24/autopsy-2.24.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/autopsy/autopsy/2.24/autopsy-2.24.tar.gz"
   sha256 "ab787f519942783d43a561d12be0554587f11f22bc55ab79d34d8da703edc09e"
 
   depends_on "sleuthkit"

--- a/Library/Formula/autotrace.rb
+++ b/Library/Formula/autotrace.rb
@@ -1,7 +1,7 @@
 class Autotrace < Formula
   desc "Convert bitmap to vector graphics"
   homepage "http://autotrace.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/autotrace/AutoTrace/0.31.1/autotrace-0.31.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/autotrace/AutoTrace/0.31.1/autotrace-0.31.1.tar.gz"
   sha256 "5a1a923c3335dfd7cbcccb2bbd4cc3d68cafe7713686a2f46a1591ed8a92aff6"
   revision 1
 

--- a/Library/Formula/aview.rb
+++ b/Library/Formula/aview.rb
@@ -1,7 +1,7 @@
 class Aview < Formula
   desc "ASCII-art image browser and animation viewer"
   homepage "http://aa-project.sourceforge.net/aview/"
-  url "https://downloads.sourceforge.net/aa-project/aview-1.3.0rc1.tar.gz"
+  url "https://prdownloads.sourceforge.net/aa-project/aview-1.3.0rc1.tar.gz"
   sha256 "42d61c4194e8b9b69a881fdde698c83cb27d7eda59e08b300e73aaa34474ec99"
 
   depends_on "aalib"

--- a/Library/Formula/avra.rb
+++ b/Library/Formula/avra.rb
@@ -1,7 +1,7 @@
 class Avra < Formula
   desc "Assember for the Atmel AVR microcontroller family"
   homepage "http://avra.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/avra/1.3.0/avra-1.3.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/avra/1.3.0/avra-1.3.0.tar.bz2"
   sha256 "a62cbf8662caf9cc4e75da6c634efce402778639202a65eb2d149002c1049712"
 
   bottle do

--- a/Library/Formula/bacula-fd.rb
+++ b/Library/Formula/bacula-fd.rb
@@ -1,7 +1,7 @@
 class BaculaFd < Formula
   desc "Network backup solution"
   homepage "http://www.bacula.org/"
-  url "https://downloads.sourceforge.net/project/bacula/bacula/7.0.5/bacula-7.0.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bacula/bacula/7.0.5/bacula-7.0.5.tar.gz"
   sha256 "1457849eb33011b43371801b62ffa13d29bebe51be8d5a36da563b87bb094a49"
   revision 1
 

--- a/Library/Formula/bashdb.rb
+++ b/Library/Formula/bashdb.rb
@@ -1,7 +1,7 @@
 class Bashdb < Formula
   desc "Bash shell debugger"
   homepage "http://bashdb.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/bashdb/bashdb/4.3-0.91/bashdb-4.3-0.91.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/bashdb/bashdb/4.3-0.91/bashdb-4.3-0.91.tar.bz2"
   sha256 "60117745813f29070a034c590c9d70153cc47f47024ae54bfecdc8cd86d9e3ea"
   version "4.3-0.91"
 

--- a/Library/Formula/bashish.rb
+++ b/Library/Formula/bashish.rb
@@ -1,7 +1,7 @@
 class Bashish < Formula
   desc "Theme environment for text terminals"
   homepage "http://bashish.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/bashish/bashish/2.2.4/bashish-2.2.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bashish/bashish/2.2.4/bashish-2.2.4.tar.gz"
   sha256 "3de48bc1aa69ec73dafc7436070e688015d794f22f6e74d5c78a0b09c938204b"
 
   depends_on "dialog"

--- a/Library/Formula/bbe.rb
+++ b/Library/Formula/bbe.rb
@@ -1,7 +1,7 @@
 class Bbe < Formula
   desc "Sed-like editor for binary files"
   homepage "http://bbe-.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/bbe-/bbe/0.2.2/bbe-0.2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bbe-/bbe/0.2.2/bbe-0.2.2.tar.gz"
   sha256 "baaeaf5775a6d9bceb594ea100c8f45a677a0a7d07529fa573ba0842226edddb"
 
   def install

--- a/Library/Formula/beecrypt.rb
+++ b/Library/Formula/beecrypt.rb
@@ -1,7 +1,7 @@
 class Beecrypt < Formula
   desc "C/C++ cryptography library"
   homepage "http://beecrypt.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/beecrypt/beecrypt/4.2.1/beecrypt-4.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/beecrypt/beecrypt/4.2.1/beecrypt-4.2.1.tar.gz"
   sha256 "286f1f56080d1a6b1d024003a5fa2158f4ff82cae0c6829d3c476a4b5898c55d"
   revision 3
 

--- a/Library/Formula/bibutils.rb
+++ b/Library/Formula/bibutils.rb
@@ -1,7 +1,7 @@
 class Bibutils < Formula
   desc "Bibliography conversion utilities"
   homepage "http://sourceforge.net/p/bibutils/home/Bibutils/"
-  url "https://downloads.sourceforge.net/project/bibutils/bibutils_5.6_src.tgz"
+  url "https://prdownloads.sourceforge.net/project/bibutils/bibutils_5.6_src.tgz"
   sha256 "9fc7ba38b69379e501af9d6228f6e2ebaebcca52b6810583d901219d83537423"
 
   bottle do

--- a/Library/Formula/bitchx.rb
+++ b/Library/Formula/bitchx.rb
@@ -1,7 +1,7 @@
 class Bitchx < Formula
   desc "BitchX IRC client"
   homepage "http://bitchx.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/bitchx/ircii-pana/bitchx-1.2.1/bitchx-1.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bitchx/ircii-pana/bitchx-1.2.1/bitchx-1.2.1.tar.gz"
   sha256 "2d270500dd42b5e2b191980d584f6587ca8a0dbda26b35ce7fadb519f53c83e2"
   revision 1
 

--- a/Library/Formula/blitz.rb
+++ b/Library/Formula/blitz.rb
@@ -1,7 +1,7 @@
 class Blitz < Formula
   desc "C++ class library for scientific computing"
   homepage "http://blitz.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/blitz/blitz/Blitz++%200.10/blitz-0.10.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/blitz/blitz/Blitz++%200.10/blitz-0.10.tar.gz"
   sha256 "804ef0e6911d43642a2ea1894e47c6007e4c185c866a7d68bad1e4c8ac4e6f94"
 
   head do

--- a/Library/Formula/boost-bcp.rb
+++ b/Library/Formula/boost-bcp.rb
@@ -1,7 +1,7 @@
 class BoostBcp < Formula
   desc "Utility for extracting subsets of the Boost library"
   homepage "http://www.boost.org/doc/tools/bcp/"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
   sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
 
   head "https://github.com/boostorg/boost.git"

--- a/Library/Formula/boost-python.rb
+++ b/Library/Formula/boost-python.rb
@@ -1,7 +1,7 @@
 class BoostPython < Formula
   desc "C++ library for C++/Python interoperability"
   homepage "http://www.boost.org"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
   sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
   head "https://github.com/boostorg/boost.git"
 

--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -1,7 +1,7 @@
 class Boost < Formula
   desc "Collection of portable C++ source libraries"
   homepage "http://www.boost.org"
-  url "https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2"
   sha256 "fdfc204fc33ec79c99b9a74944c3e54bd78be4f7f15e260c0e2700a36dc7d3e5"
 
   head "https://github.com/boostorg/boost.git"

--- a/Library/Formula/brag.rb
+++ b/Library/Formula/brag.rb
@@ -1,7 +1,7 @@
 class Brag < Formula
   desc "Download and assemble multipart binaries from newsgroups"
   homepage "http://brag.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/brag/brag/1.4.3/brag-1.4.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/brag/brag/1.4.3/brag-1.4.3.tar.gz"
   sha256 "f2c8110c38805c31ad181f4737c26e766dc8ecfa2bce158197b985be892cece6"
 
   depends_on "uudeview"

--- a/Library/Formula/briss.rb
+++ b/Library/Formula/briss.rb
@@ -1,7 +1,7 @@
 class Briss < Formula
   desc "Crop PDF files"
   homepage "http://briss.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/briss/release%200.9/briss-0.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/briss/release%200.9/briss-0.9.tar.gz"
   sha256 "45dd668a9ceb9cd59529a9fefe422a002ee1554a61be07e6fc8b3baf33d733d9"
 
   def install

--- a/Library/Formula/bsdsfv.rb
+++ b/Library/Formula/bsdsfv.rb
@@ -1,7 +1,7 @@
 class Bsdsfv < Formula
   desc "SFV utility tools"
   homepage "http://bsdsfv.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/bsdsfv/bsdsfv/1.18/bsdsfv-1.18.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bsdsfv/bsdsfv/1.18/bsdsfv-1.18.tar.gz"
   sha256 "577245da123d1ea95266c1628e66a6cf87b8046e1a902ddd408671baecf88495"
 
   # bug report:

--- a/Library/Formula/bsponmpi.rb
+++ b/Library/Formula/bsponmpi.rb
@@ -1,7 +1,7 @@
 class Bsponmpi < Formula
   desc "Implements the BSPlib standard on top of MPI"
   homepage "http://sourceforge.net/projects/bsponmpi"
-  url "https://downloads.sourceforge.net/project/bsponmpi/bsponmpi/0.3/bsponmpi-0.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bsponmpi/bsponmpi/0.3/bsponmpi-0.3.tar.gz"
   sha256 "bc90ca22155be9ff65aca4e964d8cd0bef5f0facef0a42bc1db8b9f822c92a90"
 
   depends_on "scons" => :build

--- a/Library/Formula/bvi.rb
+++ b/Library/Formula/bvi.rb
@@ -1,7 +1,7 @@
 class Bvi < Formula
   desc "Vi-like binary file (hex) editor"
   homepage "http://bvi.sourceforge.net"
-  url "https://downloads.sourceforge.net/bvi/bvi-1.4.0.src.tar.gz"
+  url "https://prdownloads.sourceforge.net/bvi/bvi-1.4.0.src.tar.gz"
   sha256 "015a3c2832c7c097d98a5527deef882119546287ba8f2a70c736227d764ef802"
 
   bottle do

--- a/Library/Formula/camellia.rb
+++ b/Library/Formula/camellia.rb
@@ -1,7 +1,7 @@
 class Camellia < Formula
   desc "Image Processing & Computer Vision library written in C"
   homepage "http://camellia.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/camellia/Unix_Linux%20Distribution/v2.7.0/CamelliaLib-2.7.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/camellia/Unix_Linux%20Distribution/v2.7.0/CamelliaLib-2.7.0.tar.gz"
   sha256 "a3192c350f7124d25f31c43aa17e23d9fa6c886f80459cba15b6257646b2f3d2"
 
   def install

--- a/Library/Formula/cbmbasic.rb
+++ b/Library/Formula/cbmbasic.rb
@@ -1,7 +1,7 @@
 class Cbmbasic < Formula
   desc "Commodore BASIC V2 as a scripting language"
   homepage "https://github.com/mist64/cbmbasic"
-  url "https://downloads.sourceforge.net/project/cbmbasic/cbmbasic/1.0/cbmbasic-1.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/cbmbasic/cbmbasic/1.0/cbmbasic-1.0.tgz"
   sha256 "2735dedf3f9ad93fa947ad0fb7f54acd8e84ea61794d786776029c66faf64b04"
   head "https://github.com/mist64/cbmbasic.git"
 

--- a/Library/Formula/ccd2iso.rb
+++ b/Library/Formula/ccd2iso.rb
@@ -1,7 +1,7 @@
 class Ccd2iso < Formula
   desc "Convert CloneCD images to ISO images"
   homepage "http://ccd2iso.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ccd2iso/ccd2iso/ccd2iso-0.3/ccd2iso-0.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ccd2iso/ccd2iso/ccd2iso-0.3/ccd2iso-0.3.tar.gz"
   sha256 "f874b8fe26112db2cdb016d54a9f69cf286387fbd0c8a55882225f78e20700fc"
 
   bottle do

--- a/Library/Formula/ccextractor.rb
+++ b/Library/Formula/ccextractor.rb
@@ -1,7 +1,7 @@
 class Ccextractor < Formula
   desc "Free, GPL licensed closed caption tool"
   homepage "http://ccextractor.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ccextractor/ccextractor/0.75/ccextractor.src.0.75.zip"
+  url "https://prdownloads.sourceforge.net/project/ccextractor/ccextractor/0.75/ccextractor.src.0.75.zip"
   sha256 "fb6ed33d516b9198e1b625fec4fce99f079e28f1c556eff4552f53c92ecc9cca"
   head "https://github.com/ccextractor/ccextractor.git"
   revision 1

--- a/Library/Formula/cclive.rb
+++ b/Library/Formula/cclive.rb
@@ -1,7 +1,7 @@
 class Cclive < Formula
   desc "Command-line video extraction utility"
   homepage "http://cclive.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cclive/0.7/cclive-0.7.16.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/cclive/0.7/cclive-0.7.16.tar.xz"
   sha256 "586a120faddcfa16f5bb058b5c901f1659336c6fc85a0d3f1538882a44ee10e1"
 
   conflicts_with "clozure-cl", :because => "both install a ccl binary"

--- a/Library/Formula/cdpr.rb
+++ b/Library/Formula/cdpr.rb
@@ -1,7 +1,7 @@
 class Cdpr < Formula
   desc "Cisco Discovery Protocol Reporter"
   homepage "http://www.monkeymental.com/"
-  url "https://downloads.sourceforge.net/project/cdpr/cdpr/2.4/cdpr-2.4.tgz"
+  url "https://prdownloads.sourceforge.net/project/cdpr/cdpr/2.4/cdpr-2.4.tgz"
   sha256 "32d3b58d8be7e2f78834469bd5f48546450ccc2a86d513177311cce994dfbec5"
 
   def install

--- a/Library/Formula/cdrdao.rb
+++ b/Library/Formula/cdrdao.rb
@@ -1,7 +1,7 @@
 class Cdrdao < Formula
   desc "Record CDs in Disk-At-Once mode"
   homepage "http://cdrdao.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cdrdao/cdrdao/1.2.3/cdrdao-1.2.3.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/cdrdao/cdrdao/1.2.3/cdrdao-1.2.3.tar.bz2"
   sha256 "8193cb8fa6998ac362c55807e89ad0b3c63edc6b01afaeb3d5042519527fb75e"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/cdrtools.rb
+++ b/Library/Formula/cdrtools.rb
@@ -3,7 +3,7 @@ class Cdrtools < Formula
   homepage "http://cdrecord.org/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/cdrtools/cdrtools-3.01.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/cdrtools/cdrtools-3.01.tar.bz2"
     sha256 "ed282eb6276c4154ce6a0b5dee0bdb81940d0cbbfc7d03f769c4735ef5f5860f"
   end
 

--- a/Library/Formula/cfv.rb
+++ b/Library/Formula/cfv.rb
@@ -1,7 +1,7 @@
 class Cfv < Formula
   desc "Test and create various files (e.g., .sfv, .csv, .crc., .torrent)"
   homepage "http://cfv.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cfv/cfv/1.18.3/cfv-1.18.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cfv/cfv/1.18.3/cfv-1.18.3.tar.gz"
   sha256 "ff28a8aa679932b83eb3b248ed2557c6da5860d5f8456ffe24686253a354cff6"
 
   bottle do

--- a/Library/Formula/chadwick.rb
+++ b/Library/Formula/chadwick.rb
@@ -1,7 +1,7 @@
 class Chadwick < Formula
   desc "Chadwick tools for parsing Retrosheet MLB play-by-play files."
   homepage "http://chadwick.sourceforge.net/doc/index.html"
-  url "https://downloads.sourceforge.net/project/chadwick/chadwick-0.6/chadwick-0.6.4/chadwick-0.6.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/chadwick/chadwick-0.6/chadwick-0.6.4/chadwick-0.6.4.tar.gz"
   sha256 "2fcc44b4110c3aebf8b9f3daaccf22ccaba3760d3d878e65d38b86127b913559"
 
   bottle do
@@ -13,7 +13,7 @@ class Chadwick < Formula
 
   resource "event_files" do
     url "http://www.retrosheet.org/events/2014eve.zip"
-    sha256 "f2bdcf2c587ea8b67d5c5485edad67c688a8e02325c2b787362ab360b79abdbd"
+    sha256 "a699c9be2cfd5d3fb8baa56401e1ff47ee2cb3e4194b5053b7f94a73d2cf7da3"
   end
 
   def install

--- a/Library/Formula/check.rb
+++ b/Library/Formula/check.rb
@@ -1,7 +1,7 @@
 class Check < Formula
   desc "C unit testing framework"
   homepage "http://check.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/check/check/0.10.0/check-0.10.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/check/check/0.10.0/check-0.10.0.tar.gz"
   sha256 "f5f50766aa6f8fe5a2df752666ca01a950add45079aa06416b83765b1cf71052"
 
   bottle do

--- a/Library/Formula/chordii.rb
+++ b/Library/Formula/chordii.rb
@@ -1,7 +1,7 @@
 class Chordii < Formula
   desc "Text file to music sheet converter"
   homepage "http://www.vromans.org/johan/projects/Chordii/"
-  url "https://downloads.sourceforge.net/project/chordii/chordii/4.5/chordii-4.5.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/chordii/chordii/4.5/chordii-4.5.1.tar.gz"
   sha256 "16a3fe92a82ca734cb6d08a573e513510acd41d4020a6306ac3769f6af5aa08d"
 
   bottle do

--- a/Library/Formula/cidrmerge.rb
+++ b/Library/Formula/cidrmerge.rb
@@ -1,7 +1,7 @@
 class Cidrmerge < Formula
   desc "CIDR merging with white listing (network exclusion)"
   homepage "http://cidrmerge.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/cidrmerge/cidrmerge/cidrmerge-1.5.3/cidrmerge-1.5.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cidrmerge/cidrmerge/cidrmerge-1.5.3/cidrmerge-1.5.3.tar.gz"
   sha256 "21b36fc8004d4fc4edae71dfaf1209d3b7c8f8f282d1a582771c43522d84f088"
 
   bottle do

--- a/Library/Formula/clasp.rb
+++ b/Library/Formula/clasp.rb
@@ -1,7 +1,7 @@
 class Clasp < Formula
   desc "Answer set solver for (extended) normal logic programs"
   homepage "http://potassco.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/potassco/clasp/3.1.3/clasp-3.1.3-source.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/potassco/clasp/3.1.3/clasp-3.1.3-source.tar.gz"
   sha256 "f08684eadfa5ae5efa5c06439edc361b775fc55b7c1a9ca862eda8f5bf7e5f1f"
 
   bottle do

--- a/Library/Formula/clean.rb
+++ b/Library/Formula/clean.rb
@@ -1,7 +1,7 @@
 class Clean < Formula
   desc "Search for files matching a regex and delete them"
   homepage "http://clean.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/clean/clean/3.4/clean-3.4.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/clean/clean/3.4/clean-3.4.tar.bz2"
   sha256 "761f3a9e1ed50747b6a62a8113fa362a7cc74d359ac6e8e30ba6b30d59115320"
 
   def install

--- a/Library/Formula/cloc.rb
+++ b/Library/Formula/cloc.rb
@@ -1,7 +1,7 @@
 class Cloc < Formula
   desc "Statistics utility to count lines of code"
   homepage "http://cloc.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cloc/cloc/v1.64/cloc-1.64.pl"
+  url "https://prdownloads.sourceforge.net/project/cloc/cloc/v1.64/cloc-1.64.pl"
   sha256 "79edea7ea1f442b1632001e23418193ae4571810e60de8bd25e491036d60eb3d"
 
   bottle do

--- a/Library/Formula/clpbar.rb
+++ b/Library/Formula/clpbar.rb
@@ -1,7 +1,7 @@
 class Clpbar < Formula
   desc "Command-line progress bar"
   homepage "http://clpbar.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/clpbar/clpbar/bar-1.11.1/bar_1.11.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/clpbar/clpbar/bar-1.11.1/bar_1.11.1.tar.gz"
   sha256 "fa0f5ec5c8400316c2f4debdc6cdcb80e186e668c2e4471df4fec7bfcd626503"
 
   def install

--- a/Library/Formula/clucene.rb
+++ b/Library/Formula/clucene.rb
@@ -1,7 +1,7 @@
 class Clucene < Formula
   desc "C++ port of Lucene: high-performance, full-featured text search engine"
   homepage "http://clucene.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/clucene/clucene-core-unstable/2.3/clucene-core-2.3.3.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/clucene/clucene-core-unstable/2.3/clucene-core-2.3.3.4.tar.gz"
   sha256 "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab"
   head "git://clucene.git.sourceforge.net/gitroot/clucene/clucene"
 

--- a/Library/Formula/cmu-pocketsphinx.rb
+++ b/Library/Formula/cmu-pocketsphinx.rb
@@ -1,7 +1,7 @@
 class CmuPocketsphinx < Formula
   desc "Lightweight speech recognition engine for mobile devices"
   homepage "http://cmusphinx.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cmusphinx/pocketsphinx/0.8/pocketsphinx-0.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cmusphinx/pocketsphinx/0.8/pocketsphinx-0.8.tar.gz"
   sha256 "874c4c083d91c8ff26a2aec250b689e537912ff728923c141c4dac48662cce7a"
 
   head do

--- a/Library/Formula/cmu-sphinxbase.rb
+++ b/Library/Formula/cmu-sphinxbase.rb
@@ -1,7 +1,7 @@
 class CmuSphinxbase < Formula
   desc "Lightweight speech recognition engine for mobile devices"
   homepage "http://cmusphinx.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cmusphinx/sphinxbase/0.8/sphinxbase-0.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cmusphinx/sphinxbase/0.8/sphinxbase-0.8.tar.gz"
   sha256 "55708944872bab1015b8ae07b379bf463764f469163a8fd114cbb16c5e486ca8"
 
   head do

--- a/Library/Formula/cmuclmtk.rb
+++ b/Library/Formula/cmuclmtk.rb
@@ -1,7 +1,7 @@
 class Cmuclmtk < Formula
   desc "Language model tools (from CMU Sphinx)"
   homepage "http://cmusphinx.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cmusphinx/cmuclmtk/0.7/cmuclmtk-0.7.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cmusphinx/cmuclmtk/0.7/cmuclmtk-0.7.tar.gz"
   sha256 "d23e47f00224667c059d69ac942f15dc3d4c3dd40e827318a6213699b7fa2915"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/cntlm.rb
+++ b/Library/Formula/cntlm.rb
@@ -1,7 +1,7 @@
 class Cntlm < Formula
   desc "NTLM authentication proxy with tunneling"
   homepage "http://cntlm.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cntlm/cntlm/cntlm%200.92.3/cntlm-0.92.3.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/cntlm/cntlm/cntlm%200.92.3/cntlm-0.92.3.tar.bz2"
   sha256 "7b603d6200ab0b26034e9e200fab949cc0a8e5fdd4df2c80b8fc5b1c37e7b930"
 
   def install

--- a/Library/Formula/collada-dom.rb
+++ b/Library/Formula/collada-dom.rb
@@ -1,7 +1,7 @@
 class ColladaDom < Formula
   desc "C++ library for loading and saving COLLADA data"
   homepage "http://www.collada.org/mediawiki/index.php/Portal:COLLADA_DOM"
-  url "https://downloads.sourceforge.net/project/collada-dom/Collada%20DOM/Collada%20DOM%202.4/collada-dom-2.4.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/collada-dom/Collada%20DOM/Collada%20DOM%202.4/collada-dom-2.4.0.tgz"
   sha256 "5ca2d12f744bdceff0066ed3067b3b23d6859581fb0d657f98ba4487d8fa3896"
 
   depends_on "cmake" => :build

--- a/Library/Formula/cppcms.rb
+++ b/Library/Formula/cppcms.rb
@@ -1,7 +1,7 @@
 class Cppcms < Formula
   desc "Free High Performance Web Development Framework"
   homepage "http://cppcms.com/wikipp/en/page/main"
-  url "https://downloads.sourceforge.net/project/cppcms/cppcms/1.0.5/cppcms-1.0.5.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/cppcms/cppcms/1.0.5/cppcms-1.0.5.tar.bz2"
   sha256 "84b685977bca97c3e997497f227bd5906adb80555066d811a7046b01c2f51865"
 
   bottle do

--- a/Library/Formula/cpptest.rb
+++ b/Library/Formula/cpptest.rb
@@ -1,7 +1,7 @@
 class Cpptest < Formula
   desc "Unit testing framework handling automated tests in C++"
   homepage "http://cpptest.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cpptest/cpptest/cpptest-1.1.2/cpptest-1.1.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cpptest/cpptest/cpptest-1.1.2/cpptest-1.1.2.tar.gz"
   sha256 "9e4fdf156b709397308536eb6b921e3aea1f463c6613f9a0c1dfec9614386027"
 
   bottle do

--- a/Library/Formula/cracklib.rb
+++ b/Library/Formula/cracklib.rb
@@ -1,7 +1,7 @@
 class Cracklib < Formula
   desc "LibCrack password checking library"
   homepage "http://cracklib.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cracklib/cracklib/2.9.5/cracklib-2.9.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cracklib/cracklib/2.9.5/cracklib-2.9.5.tar.gz"
   sha256 "59ab0138bc8cf90cccb8509b6969a024d5e58d2d02bcbdccbb9ba9b88be3fa33"
 
   bottle do
@@ -13,7 +13,7 @@ class Cracklib < Formula
   end
 
   resource "cracklib-words" do
-    url "https://downloads.sourceforge.net/project/cracklib/cracklib-words/2008-05-07/cracklib-words-20080507.gz"
+    url "https://prdownloads.sourceforge.net/project/cracklib/cracklib-words/2008-05-07/cracklib-words-20080507.gz"
     sha256 "e0c7f452c1fd80d551ae4a7d1afa7fa19cbf47c2d6d5dafc1255c1e76502cb71"
   end
 

--- a/Library/Formula/crunch.rb
+++ b/Library/Formula/crunch.rb
@@ -3,7 +3,7 @@ require "formula"
 class Crunch < Formula
   desc "Wordlist generator"
   homepage "http://sourceforge.net/projects/crunch-wordlist"
-  url "https://downloads.sourceforge.net/project/crunch-wordlist/crunch-wordlist/crunch-3.6.tgz"
+  url "https://prdownloads.sourceforge.net/project/crunch-wordlist/crunch-wordlist/crunch-3.6.tgz"
   sha1 "51bdf8b9dfb9e4486fa6a85e0224522569de4557"
 
   def install

--- a/Library/Formula/cryptopp.rb
+++ b/Library/Formula/cryptopp.rb
@@ -1,7 +1,7 @@
 class Cryptopp < Formula
   desc "Free C++ class library of cryptographic schemes"
   homepage "http://www.cryptopp.com/"
-  url "https://downloads.sourceforge.net/project/cryptopp/cryptopp/5.6.2/cryptopp562.zip"
+  url "https://prdownloads.sourceforge.net/project/cryptopp/cryptopp/5.6.2/cryptopp562.zip"
   mirror "http://www.cryptopp.com/cryptopp562.zip"
   sha256 "5cbfd2fcb4a6b3aab35902e2e0f3b59d9171fee12b3fc2b363e1801dfec53574"
   version "5.6.2"

--- a/Library/Formula/cscope.rb
+++ b/Library/Formula/cscope.rb
@@ -1,7 +1,7 @@
 class Cscope < Formula
   desc "Tool for browsing source code"
   homepage "http://cscope.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cscope/cscope/15.8a/cscope-15.8a.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cscope/cscope/15.8a/cscope-15.8a.tar.gz"
   sha256 "eb736ac40d5abebe8fa46820c7a8eccc8a17966a9a5f70375367b77177874d1e"
 
   bottle do

--- a/Library/Formula/ctags.rb
+++ b/Library/Formula/ctags.rb
@@ -1,7 +1,7 @@
 class Ctags < Formula
   desc "Reimplementation of ctags(1)"
   homepage "http://ctags.sourceforge.net/"
-  url "https://downloads.sourceforge.net/ctags/ctags-5.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/ctags/ctags-5.8.tar.gz"
   sha256 "0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7"
   revision 1
 

--- a/Library/Formula/ctorrent.rb
+++ b/Library/Formula/ctorrent.rb
@@ -1,7 +1,7 @@
 class Ctorrent < Formula
   desc "BitTorrent command-line client"
   homepage "http://www.rahul.net/dholmes/ctorrent/"
-  url "https://downloads.sourceforge.net/project/dtorrent/dtorrent/3.3.2/ctorrent-dnh3.3.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dtorrent/dtorrent/3.3.2/ctorrent-dnh3.3.2.tar.gz"
   sha256 "c87366c91475931f75b924119580abd06a7b3cb3f00fef47346552cab1e24863"
   revision 1
 

--- a/Library/Formula/cunit.rb
+++ b/Library/Formula/cunit.rb
@@ -1,7 +1,7 @@
 class Cunit < Formula
   desc "Lightweight unit testing framework for C"
   homepage "http://cunit.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cunit/CUnit/2.1-3/CUnit-2.1-3.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/cunit/CUnit/2.1-3/CUnit-2.1-3.tar.bz2"
   sha256 "f5b29137f845bb08b77ec60584fdb728b4e58f1023e6f249a464efa49a40f214"
 
   bottle do

--- a/Library/Formula/cutter.rb
+++ b/Library/Formula/cutter.rb
@@ -1,7 +1,7 @@
 class Cutter < Formula
   desc "Unit Testing Framework for C and C++"
   homepage "http://cutter.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/cutter/cutter/1.2.5/cutter-1.2.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cutter/cutter/1.2.5/cutter-1.2.5.tar.gz"
   sha256 "e53613445e8fe20173a656db5a70a7eb0c4586be1d9f33dc93e2eddd2f646b20"
   head "https://github.com/clear-code/cutter.git"
 

--- a/Library/Formula/daemonlogger.rb
+++ b/Library/Formula/daemonlogger.rb
@@ -1,7 +1,7 @@
 class Daemonlogger < Formula
   desc "Network packet logger and soft tap daemon"
   homepage "http://sourceforge.net/projects/daemonlogger/"
-  url "https://downloads.sourceforge.net/project/daemonlogger/daemonlogger-1.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/daemonlogger/daemonlogger-1.2.1.tar.gz"
   sha256 "79fcd34d815e9c671ffa1ea3c7d7d50f895bb7a79b4448c4fd1c37857cf44a0b"
 
   bottle do

--- a/Library/Formula/dar.rb
+++ b/Library/Formula/dar.rb
@@ -1,7 +1,7 @@
 class Dar < Formula
   desc "Backup directory tree and files"
   homepage "http://dar.linux.free.fr/doc/index.html"
-  url "https://downloads.sourceforge.net/project/dar/dar/2.4.17/dar-2.4.17.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dar/dar/2.4.17/dar-2.4.17.tar.gz"
   sha256 "5d861c39698b77124680914741e1e40e7e9bedb3fcedc6df8d468e619479833c"
 
   bottle do

--- a/Library/Formula/davmail.rb
+++ b/Library/Formula/davmail.rb
@@ -1,7 +1,7 @@
 class Davmail < Formula
   desc "POP/IMAP/SMTP/Caldav/Carddav/LDAP exchange gateway"
   homepage "http://davmail.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/davmail/davmail/4.5.1/davmail-4.5.1-2303.zip"
+  url "https://prdownloads.sourceforge.net/project/davmail/davmail/4.5.1/davmail-4.5.1-2303.zip"
   sha256 "d69f0c8cf6cf5b76c1fb0ff82fe7cecd22d470c83206fa3fecbe486c758c080d"
 
   def install

--- a/Library/Formula/dbacl.rb
+++ b/Library/Formula/dbacl.rb
@@ -1,7 +1,7 @@
 class Dbacl < Formula
   desc "Digramic Bayesian classifier"
   homepage "http://dbacl.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/dbacl/dbacl/1.14.1/dbacl-1.14.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dbacl/dbacl/1.14.1/dbacl-1.14.1.tar.gz"
   sha256 "ff0dfb67682e863b1c3250acc441ce77c033b9b21d8e8793e55b622e42005abd"
 
   def install

--- a/Library/Formula/dc3dd.rb
+++ b/Library/Formula/dc3dd.rb
@@ -1,7 +1,7 @@
 class Dc3dd < Formula
   desc "Patched GNU dd that is intended for forensic acquisition of data"
   homepage "http://sourceforge.net/projects/dc3dd/"
-  url "https://downloads.sourceforge.net/project/dc3dd/dc3dd/7.1.0/dc3dd-7.1.614.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dc3dd/dc3dd/7.1.0/dc3dd-7.1.614.tar.gz"
   sha256 "f6fb4d921928e6354e9f8ff2a8415ebc42b129959996e1ab0d10899c11aac198"
 
   def install

--- a/Library/Formula/dcfldd.rb
+++ b/Library/Formula/dcfldd.rb
@@ -1,7 +1,7 @@
 class Dcfldd < Formula
   desc "Enhanced version of dd for forensics and security"
   homepage "http://dcfldd.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/dcfldd/dcfldd/1.3.4-1/dcfldd-1.3.4-1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dcfldd/dcfldd/1.3.4-1/dcfldd-1.3.4-1.tar.gz"
   sha256 "f5143a184da56fd5ac729d6d8cbcf9f5da8e1cf4604aa9fb97c59553b7e6d5f8"
 
   def install

--- a/Library/Formula/ddclient.rb
+++ b/Library/Formula/ddclient.rb
@@ -1,7 +1,7 @@
 class Ddclient < Formula
   desc "Update dynamic DNS entries"
   homepage "http://sourceforge.net/p/ddclient/wiki/Home"
-  url "https://downloads.sourceforge.net/project/ddclient/ddclient/ddclient-3.8.3/ddclient-3.8.3.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/ddclient/ddclient/ddclient-3.8.3/ddclient-3.8.3.tar.bz2"
   sha256 "d40e2f1fd3f4bff386d27bbdf4b8645199b1995d27605a886b8c71e44d819591"
 
   head "https://github.com/wimpunk/ddclient.git"

--- a/Library/Formula/detox.rb
+++ b/Library/Formula/detox.rb
@@ -1,7 +1,7 @@
 class Detox < Formula
   desc "Utility to replace problematic characters in filenames"
   homepage "http://detox.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/detox/detox/1.2.0/detox-1.2.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/detox/detox/1.2.0/detox-1.2.0.tar.bz2"
   sha256 "abfad90ee7d3e0fc53ce3b9da3253f9a800cdd92e3f8cc12a19394a7b1dcdbf8"
 
   def install

--- a/Library/Formula/devil.rb
+++ b/Library/Formula/devil.rb
@@ -1,7 +1,7 @@
 class Devil < Formula
   desc "Cross-platform image library"
   homepage "http://sourceforge.net/projects/openil/"
-  url "https://downloads.sourceforge.net/project/openil/DevIL/1.7.8/DevIL-1.7.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/openil/DevIL/1.7.8/DevIL-1.7.8.tar.gz"
   sha256 "682ffa3fc894686156337b8ce473c954bf3f4fb0f3ecac159c73db632d28a8fd"
   revision 2
 

--- a/Library/Formula/dex2jar.rb
+++ b/Library/Formula/dex2jar.rb
@@ -1,7 +1,7 @@
 class Dex2jar < Formula
   desc "Tools to work with and reverse-engineer Android .dex and Java .class files"
   homepage "https://github.com/pxb1988/dex2jar"
-  url "https://downloads.sourceforge.net/project/dex2jar/dex2jar-2.0.zip"
+  url "https://prdownloads.sourceforge.net/project/dex2jar/dex2jar-2.0.zip"
   mirror "https://bitbucket.org/pxb1988/dex2jar/downloads/dex2jar-2.0.zip"
   sha256 "7907eb4d6e9280b6e17ddce7ee0507eae2ef161ee29f70a10dbc6944fdca75bc"
 

--- a/Library/Formula/dict.rb
+++ b/Library/Formula/dict.rb
@@ -1,7 +1,7 @@
 class Dict < Formula
   desc "Dictionary Server Protocol (RFC2229) client"
   homepage "http://www.dict.org/"
-  url "https://downloads.sourceforge.net/project/dict/dictd/dictd-1.12.1/dictd-1.12.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dict/dictd/dictd-1.12.1/dictd-1.12.1.tar.gz"
   sha256 "a237f6ecdc854ab10de5145ed42eaa2d9b6d51ffdc495f7daee59b05cc363656"
 
   depends_on "libtool" => :build

--- a/Library/Formula/diffuse.rb
+++ b/Library/Formula/diffuse.rb
@@ -1,7 +1,7 @@
 class Diffuse < Formula
   desc "Graphical tool for merging and comparing text files"
   homepage "http://diffuse.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/diffuse/diffuse/0.4.8/diffuse-0.4.8.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/diffuse/diffuse/0.4.8/diffuse-0.4.8.tar.bz2"
   sha256 "c1d3b79bba9352fcb9aa4003537d3fece248fb824781c5e21f3fcccafd42df2b"
 
   depends_on "pygtk"

--- a/Library/Formula/disktype.rb
+++ b/Library/Formula/disktype.rb
@@ -2,7 +2,7 @@ class Disktype < Formula
   desc "Detect content format of a disk or disk image"
   homepage "http://disktype.sourceforge.net/"
   head ":pserver:anonymous:@disktype.cvs.sourceforge.net:/cvsroot/disktype", :using => :cvs
-  url "https://downloads.sourceforge.net/project/disktype/disktype/9/disktype-9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/disktype/disktype/9/disktype-9.tar.gz"
   sha256 "b6701254d88412bc5d2db869037745f65f94b900b59184157d072f35832c1111"
 
   def install

--- a/Library/Formula/ditaa.rb
+++ b/Library/Formula/ditaa.rb
@@ -1,7 +1,7 @@
 class Ditaa < Formula
   desc "Convert ASCII diagrams into proper bitmap graphics"
   homepage "http://ditaa.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ditaa/ditaa/0.9/ditaa0_9.zip"
+  url "https://prdownloads.sourceforge.net/project/ditaa/ditaa/0.9/ditaa0_9.zip"
   sha256 "d689e933b80b065cd7c349e489cfb8feea69dd3e91ca78931edc6fa6e098e689"
 
   def install

--- a/Library/Formula/djvulibre.rb
+++ b/Library/Formula/djvulibre.rb
@@ -1,7 +1,7 @@
 class Djvulibre < Formula
   desc "DjVu viewer"
   homepage "http://djvu.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/djvu/DjVuLibre/3.5.27/djvulibre-3.5.27.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/djvu/DjVuLibre/3.5.27/djvulibre-3.5.27.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/d/djvulibre/djvulibre_3.5.27.orig.tar.gz"
   sha256 "e69668252565603875fb88500cde02bf93d12d48a3884e472696c896e81f505f"
   revision 1

--- a/Library/Formula/docbook-xsl.rb
+++ b/Library/Formula/docbook-xsl.rb
@@ -1,7 +1,7 @@
 class DocbookXsl < Formula
   desc "XML vocabulary to create presentation-neutral documents"
   homepage "http://docbook.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/docbook/docbook-xsl/1.78.1/docbook-xsl-1.78.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/docbook/docbook-xsl/1.78.1/docbook-xsl-1.78.1.tar.bz2"
   sha256 "c98f7296ab5c8ccd2e0bc07634976a37f50847df2d8a59bdb1e157664700b467"
   revision 1
 
@@ -15,7 +15,7 @@ class DocbookXsl < Formula
   depends_on "docbook"
 
   resource "ns" do
-    url "https://downloads.sourceforge.net/project/docbook/docbook-xsl-ns/1.78.1/docbook-xsl-ns-1.78.1.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/docbook/docbook-xsl-ns/1.78.1/docbook-xsl-ns-1.78.1.tar.bz2"
     sha256 "cf8ede7284d7f825c24b95ea273551439c55e9af9a4209ac89e3a7d915607af4"
   end
 

--- a/Library/Formula/docbook2x.rb
+++ b/Library/Formula/docbook2x.rb
@@ -1,7 +1,7 @@
 class Docbook2x < Formula
   desc "Convert DocBook to UNIX manpages and GNU TeXinfo"
   homepage "http://docbook2x.sourceforge.net/"
-  url "https://downloads.sourceforge.net/docbook2x/docbook2X-0.8.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/docbook2x/docbook2X-0.8.8.tar.gz"
   sha256 "4077757d367a9d1b1427e8d5dfc3c49d993e90deabc6df23d05cfe9cd2fcdc45"
 
   depends_on "docbook"

--- a/Library/Formula/dos2unix.rb
+++ b/Library/Formula/dos2unix.rb
@@ -2,7 +2,7 @@ class Dos2unix < Formula
   desc "Convert text between DOS, UNIX, and Mac formats"
   homepage "http://waterlan.home.xs4all.nl/dos2unix.html"
   url "https://waterlan.home.xs4all.nl/dos2unix/dos2unix-7.5.0.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/dos2unix/dos2unix/7.5.0/dos2unix-7.5.0.tar.gz"
+  mirror "https://prdownloads.sourceforge.net/project/dos2unix/dos2unix/7.5.0/dos2unix-7.5.0.tar.gz"
   sha256 "7a3b01d01e214d62c2b3e04c3a92e0ddc728a385566e4c0356efa66fd6eb95af"
 
   devel do

--- a/Library/Formula/doublecpp.rb
+++ b/Library/Formula/doublecpp.rb
@@ -1,7 +1,7 @@
 class Doublecpp < Formula
   desc "Double dispatch in C++"
   homepage "http://doublecpp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/doublecpp/doublecpp-0.6.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/doublecpp/doublecpp-0.6.3.tar.gz"
   sha256 "232f8bf0d73795558f746c2e77f6d7cb54e1066cbc3ea7698c4fba80983423af"
 
   def install

--- a/Library/Formula/doxygen.rb
+++ b/Library/Formula/doxygen.rb
@@ -2,7 +2,7 @@ class Doxygen < Formula
   desc "Generate documentation for several programming languages"
   homepage "http://www.doxygen.org/"
   url "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.10.src.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.8.10/doxygen-1.8.10.src.tar.gz"
+  mirror "https://prdownloads.sourceforge.net/project/doxygen/rel-1.8.10/doxygen-1.8.10.src.tar.gz"
   sha256 "cedf78f6d213226464784ecb999b54515c97eab8a2f9b82514292f837cf88b93"
   head "https://github.com/doxygen/doxygen.git"
 

--- a/Library/Formula/doxymacs.rb
+++ b/Library/Formula/doxymacs.rb
@@ -1,7 +1,7 @@
 class Doxymacs < Formula
   desc "Elisp package for using doxygen under Emacs"
   homepage "http://doxymacs.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/doxymacs/doxymacs/1.8.0/doxymacs-1.8.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/doxymacs/doxymacs/1.8.0/doxymacs-1.8.0.tar.gz"
   sha256 "a23fd833bc3c21ee5387c62597610941e987f9d4372916f996bf6249cc495afa"
 
   bottle do

--- a/Library/Formula/dtach.rb
+++ b/Library/Formula/dtach.rb
@@ -1,7 +1,7 @@
 class Dtach < Formula
   desc "Emulates the detach feature of screen"
   homepage "http://dtach.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/dtach/dtach/0.8/dtach-0.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dtach/dtach/0.8/dtach-0.8.tar.gz"
   sha256 "16614ebddf8ab2811d3dc0e7f329c7de88929ac6a9632d4cb4aef7fe11b8f2a9"
 
   def install

--- a/Library/Formula/duff.rb
+++ b/Library/Formula/duff.rb
@@ -1,7 +1,7 @@
 class Duff < Formula
   desc "Quickly find duplicates in a set of files from the command-line"
   homepage "http://duff.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/duff/duff/0.5.2/duff-0.5.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/duff/duff/0.5.2/duff-0.5.2.tar.gz"
   sha256 "15b721f7e0ea43eba3fd6afb41dbd1be63c678952bf3d80350130a0e710c542e"
 
   def install

--- a/Library/Formula/duply.rb
+++ b/Library/Formula/duply.rb
@@ -1,7 +1,7 @@
 class Duply < Formula
   desc "Frontend to the duplicity backup system"
   homepage "http://duply.net"
-  url "https://downloads.sourceforge.net/project/ftplicity/duply%20(simple%20duplicity)/1.9.x/duply_1.9.1.tgz"
+  url "https://prdownloads.sourceforge.net/project/ftplicity/duply%20(simple%20duplicity)/1.9.x/duply_1.9.1.tgz"
   sha256 "e5f11c5a31a55de24cc5101a6429ea3eac14c0d3f0d6dec344b687089845efc5"
 
   depends_on "duplicity"

--- a/Library/Formula/dvdauthor.rb
+++ b/Library/Formula/dvdauthor.rb
@@ -1,7 +1,7 @@
 class Dvdauthor < Formula
   desc "DVD-authoring toolset"
   homepage "http://dvdauthor.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/dvdauthor/dvdauthor/0.7.1/dvdauthor-0.7.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dvdauthor/dvdauthor/0.7.1/dvdauthor-0.7.1.tar.gz"
   sha256 "501fb11b09c6eb9c5a229dcb400bd81e408cc78d34eab6749970685023c51fe9"
   revision 1
 

--- a/Library/Formula/dvdbackup.rb
+++ b/Library/Formula/dvdbackup.rb
@@ -1,7 +1,7 @@
 class Dvdbackup < Formula
   desc "Rip DVD's from the command-line"
   homepage "http://dvdbackup.sourceforge.net"
-  url "https://downloads.sourceforge.net/dvdbackup/dvdbackup-0.4.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/dvdbackup/dvdbackup-0.4.2.tar.gz"
   sha256 "0a37c31cc6f2d3c146ec57064bda8a06cf5f2ec90455366cb250506bab964550"
 
   depends_on "libdvdread"

--- a/Library/Formula/dylibbundler.rb
+++ b/Library/Formula/dylibbundler.rb
@@ -1,7 +1,7 @@
 class Dylibbundler < Formula
   desc "Utility to bundle libraries into executables for OS X"
   homepage "https://github.com/auriamg/macdylibbundler"
-  url "https://downloads.sourceforge.net/project/macdylibbundler/macdylibbundler/0.4.4/dylibbundler-0.4.4.zip"
+  url "https://prdownloads.sourceforge.net/project/macdylibbundler/macdylibbundler/0.4.4/dylibbundler-0.4.4.zip"
   sha256 "65d050327df99d12d96ae31a693bace447f4115e6874648f1b3960a014362200"
   head "https://github.com/auriamg/macdylibbundler.git"
 

--- a/Library/Formula/e2fsprogs.rb
+++ b/Library/Formula/e2fsprogs.rb
@@ -1,9 +1,9 @@
 class E2fsprogs < Formula
   desc "Utilities for the ext2, ext3, and ext4 file systems"
   homepage "http://e2fsprogs.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.42.13/e2fsprogs-1.42.13.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.42.13/e2fsprogs-1.42.13.tar.gz"
   mirror "https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.42.13/e2fsprogs-1.42.13.tar.gz"
-  sha256 "59993ff3a44f82e504561e0ebf95e8c8fa9f9f5746eb6a7182239605d2a4e2d4"
+  sha256 "e59e1b9973339f48024afaf19ec47a37c84181173eeade4f318f62e61a326622"
 
   head "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
 

--- a/Library/Formula/ebook-tools.rb
+++ b/Library/Formula/ebook-tools.rb
@@ -1,7 +1,7 @@
 class EbookTools < Formula
   desc "Access and convert several ebook formats"
   homepage "http://sourceforge.net/projects/ebook-tools"
-  url "https://downloads.sourceforge.net/project/ebook-tools/ebook-tools/0.2.2/ebook-tools-0.2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ebook-tools/ebook-tools/0.2.2/ebook-tools-0.2.2.tar.gz"
   sha256 "cbc35996e911144fa62925366ad6a6212d6af2588f1e39075954973bbee627ae"
 
   bottle do

--- a/Library/Formula/editorconfig.rb
+++ b/Library/Formula/editorconfig.rb
@@ -1,7 +1,7 @@
 class Editorconfig < Formula
   desc "Maintain consistent coding style between multiple editors"
   homepage "http://editorconfig.org"
-  url "https://downloads.sourceforge.net/project/editorconfig/EditorConfig-C-Core/0.12.0/source/editorconfig-core-c-0.12.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/editorconfig/EditorConfig-C-Core/0.12.0/source/editorconfig-core-c-0.12.0.tar.gz"
   sha256 "98c581d1dce24158160c9235190ce93eeae121f978aa84a89c7de258b5122e01"
 
   bottle do

--- a/Library/Formula/ekhtml.rb
+++ b/Library/Formula/ekhtml.rb
@@ -1,7 +1,7 @@
 class Ekhtml < Formula
   desc "Forgiving SAX-style HTML parser"
   homepage "http://ekhtml.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ekhtml/ekhtml/0.3.2/ekhtml-0.3.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ekhtml/ekhtml/0.3.2/ekhtml-0.3.2.tar.gz"
   sha256 "1ed1f0166cd56552253cd67abcfa51728ff6b88f39bab742dbf894b2974dc8d6"
 
   def install

--- a/Library/Formula/engine_pkcs11.rb
+++ b/Library/Formula/engine_pkcs11.rb
@@ -1,7 +1,7 @@
 class EnginePkcs11 < Formula
   desc "Implementation of OpenSSL engine interface"
   homepage "https://github.com/OpenSC/OpenSC/wiki/OpenSSL-engine-for-PKCS%2311-modules"
-  url "https://downloads.sourceforge.net/project/opensc/engine_pkcs11/engine_pkcs11-0.1.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/opensc/engine_pkcs11/engine_pkcs11-0.1.8.tar.gz"
   sha256 "de7d7e41e7c42deef40c53e10ccc3f88d2c036d6656ecee7e82e8be07b06a2e5"
 
   head do

--- a/Library/Formula/epsilon.rb
+++ b/Library/Formula/epsilon.rb
@@ -1,7 +1,7 @@
 class Epsilon < Formula
   desc "Powerful wavelet image compressor"
   homepage "http://epsilon-project.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/epsilon-project/epsilon/0.9.2/epsilon-0.9.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/epsilon-project/epsilon/0.9.2/epsilon-0.9.2.tar.gz"
   sha256 "5421a15969d4d7af0ac0a11d519ba8d1d2147dc28d8c062bf0c52f3a0d4c54c4"
 
   depends_on "popt"

--- a/Library/Formula/esniper.rb
+++ b/Library/Formula/esniper.rb
@@ -1,7 +1,7 @@
 class Esniper < Formula
   desc "Snipe eBay auctions from the command-line"
   homepage "http://sourceforge.net/projects/esniper/"
-  url "https://downloads.sourceforge.net/project/esniper/esniper/2.31.0/esniper-2-31-0.tgz"
+  url "https://prdownloads.sourceforge.net/project/esniper/esniper/2.31.0/esniper-2-31-0.tgz"
   version "2.31"
   sha256 "30d2378c700b72b5363c8af59e7566564d9ec8cd4b44cd389c2830907d7bc676"
 

--- a/Library/Formula/espeak.rb
+++ b/Library/Formula/espeak.rb
@@ -1,7 +1,7 @@
 class Espeak < Formula
   desc "Text to speech, software speech synthesizer"
   homepage "http://espeak.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/espeak/espeak/espeak-1.48/espeak-1.48.04-source.zip"
+  url "https://prdownloads.sourceforge.net/project/espeak/espeak/espeak-1.48/espeak-1.48.04-source.zip"
   sha256 "bf9a17673adffcc28ff7ea18764f06136547e97bbd9edf2ec612f09b207f0659"
 
   bottle do

--- a/Library/Formula/ex-vi.rb
+++ b/Library/Formula/ex-vi.rb
@@ -1,7 +1,7 @@
 class ExVi < Formula
   desc "UTF8-friendly version of tradition vi"
   homepage "http://ex-vi.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ex-vi/ex-vi/050325/ex-050325.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/ex-vi/ex-vi/050325/ex-050325.tar.bz2"
   sha256 "da4be7cf67e94572463b19e56850aa36dc4e39eb0d933d3688fe8574bb632409"
 
   conflicts_with "vim",

--- a/Library/Formula/exif.rb
+++ b/Library/Formula/exif.rb
@@ -1,7 +1,7 @@
 class Exif < Formula
   desc "Read, write, modify, and display EXIF data on the command-line"
   homepage "http://libexif.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libexif/exif/0.6.21/exif-0.6.21.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libexif/exif/0.6.21/exif-0.6.21.tar.gz"
   sha256 "1e2e40e5d919edfb23717308eb5aeb5a11337741e6455c049852128a42288e6d"
 
   bottle do

--- a/Library/Formula/faac.rb
+++ b/Library/Formula/faac.rb
@@ -1,7 +1,7 @@
 class Faac < Formula
   desc "ISO AAC audio encoder"
   homepage "http://www.audiocoding.com/faac.html"
-  url "https://downloads.sourceforge.net/project/faac/faac-src/faac-1.28/faac-1.28.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/faac/faac-src/faac-1.28/faac-1.28.tar.gz"
   sha256 "c5141199f4cfb17d749c36ba8cfe4b25f838da67c22f0fec40228b6b9c3d19df"
 
   bottle do

--- a/Library/Formula/faad2.rb
+++ b/Library/Formula/faad2.rb
@@ -1,7 +1,7 @@
 class Faad2 < Formula
   desc "ISO AAC audio decoder"
   homepage "http://www.audiocoding.com/faad2.html"
-  url "https://downloads.sourceforge.net/project/faac/faad2-src/faad2-2.7/faad2-2.7.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/faac/faad2-src/faad2-2.7/faad2-2.7.tar.bz2"
   sha256 "14561b5d6bc457e825bfd3921ae50a6648f377a9396eaf16d4b057b39a3f63b5"
 
   # unknown flag: -compatibility_version

--- a/Library/Formula/fastjar.rb
+++ b/Library/Formula/fastjar.rb
@@ -1,7 +1,7 @@
 class Fastjar < Formula
   desc "Implementation of Sun's jar tool"
   homepage "http://sourceforge.net/projects/fastjar/"
-  url "https://downloads.sourceforge.net/project/fastjar/fastjar/0.94/fastjar-0.94.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/fastjar/fastjar/0.94/fastjar-0.94.tar.gz"
   sha256 "5a217fc3e3017efb18fd1316b38d2aaa7370280fcf5732ad8fff7e27ec867b95"
 
   def install

--- a/Library/Formula/fdk-aac.rb
+++ b/Library/Formula/fdk-aac.rb
@@ -1,7 +1,7 @@
 class FdkAac < Formula
   desc "Standalone library of the Fraunhofer FDK AAC code from Android"
   homepage "http://sourceforge.net/projects/opencore-amr/"
-  url "https://downloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/opencore-amr/fdk-aac/fdk-aac-0.1.4.tar.gz"
   sha256 "5910fe788677ca13532e3f47b7afaa01d72334d46a2d5e1d1f080f1173ff15ab"
 
   bottle do

--- a/Library/Formula/ffe.rb
+++ b/Library/Formula/ffe.rb
@@ -1,7 +1,7 @@
 class Ffe < Formula
   desc "Parse flat file structures and print them in different formats"
   homepage "http://ff-extractor.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ff-extractor/ff-extractor/0.3.5/ffe-0.3.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ff-extractor/ff-extractor/0.3.5/ffe-0.3.5.tar.gz"
   sha256 "5ed5b4bf04bd8e2e438d8c37d3cec8ec681844b5318da8ac14565838c19c41da"
 
   bottle do

--- a/Library/Formula/findbugs.rb
+++ b/Library/Formula/findbugs.rb
@@ -1,7 +1,7 @@
 class Findbugs < Formula
   desc "Find bugs in Java programs through static analysis"
   homepage "http://findbugs.sourceforge.net/index.html"
-  url "https://downloads.sourceforge.net/project/findbugs/findbugs/3.0.1/findbugs-3.0.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/findbugs/findbugs/3.0.1/findbugs-3.0.1.tar.gz"
   sha256 "e80e0da0c213a27504ef3188ef25f107651700ffc66433eac6a7454bbe336419"
 
   conflicts_with "fb-client",

--- a/Library/Formula/fizsh.rb
+++ b/Library/Formula/fizsh.rb
@@ -3,7 +3,7 @@ class Fizsh < Formula
   homepage "https://github.com/zsh-users/fizsh"
 
   stable do
-    url "https://downloads.sourceforge.net/project/fizsh/fizsh-1.0.8.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/fizsh/fizsh-1.0.8.tar.gz"
     sha256 "3d17933c4773532209f9771221ec1dbb33d11fa4e0fbccc506a38d1b4f2359c7"
   end
 

--- a/Library/Formula/flac123.rb
+++ b/Library/Formula/flac123.rb
@@ -1,7 +1,7 @@
 class Flac123 < Formula
   desc "Command-line program for playing FLAC audio files"
   homepage "http://flac-tools.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/flac-tools/flac123/flac123-0.0.12-release.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/flac-tools/flac123/flac123-0.0.12-release.tar.gz"
   sha256 "1976efd54a918eadd3cb10b34c77cee009e21ae56274148afa01edf32654e47d"
 
   bottle do

--- a/Library/Formula/flactag.rb
+++ b/Library/Formula/flactag.rb
@@ -1,7 +1,7 @@
 class Flactag < Formula
   desc "Tag single album FLAC files with MusicBrainz CUE sheets"
   homepage "http://flactag.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/flactag/v2.0.4/flactag-2.0.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/flactag/v2.0.4/flactag-2.0.4.tar.gz"
   sha256 "c96718ac3ed3a0af494a1970ff64a606bfa54ac78854c5d1c7c19586177335b2"
   revision 1
 

--- a/Library/Formula/flake.rb
+++ b/Library/Formula/flake.rb
@@ -1,7 +1,7 @@
 class Flake < Formula
   desc "FLAC audio encoder"
   homepage "http://flake-enc.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/flake-enc/flake/0.11/flake-0.11.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/flake-enc/flake/0.11/flake-0.11.tar.bz2"
   sha256 "8dd249888005c2949cb4564f02b6badb34b2a0f408a7ec7ab01e11ceca1b7f19"
 
   def install

--- a/Library/Formula/flawfinder.rb
+++ b/Library/Formula/flawfinder.rb
@@ -2,7 +2,7 @@ class Flawfinder < Formula
   desc "Examines code and reports possible security weaknesses"
   homepage "http://www.dwheeler.com/flawfinder/"
   url "http://www.dwheeler.com/flawfinder/flawfinder-1.31.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/flawfinder/flawfinder-1.31.tar.gz"
+  mirror "https://prdownloads.sourceforge.net/project/flawfinder/flawfinder-1.31.tar.gz"
   sha256 "bca7256fdf71d778eb59c9d61fc22b95792b997cc632b222baf79cfc04887c30"
 
   head "git://git.code.sf.net/p/flawfinder/code"

--- a/Library/Formula/fluid-synth.rb
+++ b/Library/Formula/fluid-synth.rb
@@ -1,7 +1,7 @@
 class FluidSynth < Formula
   desc "Real-time software synthesizer based on the SoundFont 2 specs"
   homepage "http://www.fluidsynth.org"
-  url "https://downloads.sourceforge.net/project/fluidsynth/fluidsynth-1.1.6/fluidsynth-1.1.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/fluidsynth/fluidsynth-1.1.6/fluidsynth-1.1.6.tar.gz"
   sha256 "50853391d9ebeda9b4db787efb23f98b1e26b7296dd2bb5d0d96b5bccee2171c"
 
   bottle do

--- a/Library/Formula/fop.rb
+++ b/Library/Formula/fop.rb
@@ -13,7 +13,7 @@ class Fop < Formula
   end
 
   resource "hyph" do
-    url "https://downloads.sourceforge.net/project/offo/offo-hyphenation-utf8/0.1/offo-hyphenation-fop-stable-utf8.zip"
+    url "https://prdownloads.sourceforge.net/project/offo/offo-hyphenation-utf8/0.1/offo-hyphenation-fop-stable-utf8.zip"
     sha256 "0b4e074635605b47a7b82892d68e90b6ba90fd2af83142d05878d75762510128"
   end
 

--- a/Library/Formula/fpc.rb
+++ b/Library/Formula/fpc.rb
@@ -1,7 +1,7 @@
 class Fpc < Formula
   desc "Free Pascal: multi-architecture Pascal compiler"
   homepage "http://www.freepascal.org/"
-  url "https://downloads.sourceforge.net/project/freepascal/Source/2.6.4/fpc-2.6.4.source.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/freepascal/Source/2.6.4/fpc-2.6.4.source.tar.gz"
   sha256 "c16f2e6e0274c7afc0f1d2dded22d0fec98fe329b1d5b2f011af1655f3a1cc29"
 
   bottle do
@@ -12,7 +12,7 @@ class Fpc < Formula
   end
 
   resource "bootstrap" do
-    url "https://downloads.sourceforge.net/project/freepascal/Bootstrap/2.6.4/universal-macosx-10.5-ppcuniversal.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/freepascal/Bootstrap/2.6.4/universal-macosx-10.5-ppcuniversal.tar.bz2"
     sha256 "e7243e83e6a04de147ebab7530754ec92cd1fbabbc9b6b00a3f90a796312f3e9"
   end
 

--- a/Library/Formula/freeimage.rb
+++ b/Library/Formula/freeimage.rb
@@ -9,7 +9,7 @@ end
 class Freeimage < Formula
   desc "Library for FreeImage, a dependency-free graphics library"
   homepage "https://sourceforge.net/projects/freeimage"
-  url "https://downloads.sourceforge.net/project/freeimage/Source%20Distribution/3.17.0/FreeImage3170.zip",
+  url "https://prdownloads.sourceforge.net/project/freeimage/Source%20Distribution/3.17.0/FreeImage3170.zip",
     :using => FreeimageHttpDownloadStrategy
   version "3.17.0"
   sha256 "fbfc65e39b3d4e2cb108c4ffa8c41fd02c07d4d436c594fff8dab1a6d5297f89"

--- a/Library/Formula/ftgl.rb
+++ b/Library/Formula/ftgl.rb
@@ -1,7 +1,7 @@
 class Ftgl < Formula
   desc "Freetype / OpenGL bridge"
   homepage "http://sourceforge.net/projects/ftgl/"
-  url "https://downloads.sourceforge.net/project/ftgl/FTGL%20Source/2.1.3~rc5/ftgl-2.1.3-rc5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ftgl/FTGL%20Source/2.1.3~rc5/ftgl-2.1.3-rc5.tar.gz"
   sha256 "5458d62122454869572d39f8aa85745fc05d5518001bcefa63bd6cbb8d26565b"
 
   depends_on "freetype"

--- a/Library/Formula/ftimes.rb
+++ b/Library/Formula/ftimes.rb
@@ -1,7 +1,7 @@
 class Ftimes < Formula
   desc "System baselining and evidence collection tool"
   homepage "http://ftimes.sourceforge.net/FTimes/index.shtml"
-  url "https://downloads.sourceforge.net/project/ftimes/ftimes/3.11.0/ftimes-3.11.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/ftimes/ftimes/3.11.0/ftimes-3.11.0.tgz"
   sha256 "70178e80c4ea7a8ce65404dd85a4bf5958a78f6a60c48f1fd06f78741c200f64"
   revision 1
 

--- a/Library/Formula/ftjam.rb
+++ b/Library/Formula/ftjam.rb
@@ -1,7 +1,7 @@
 class Ftjam < Formula
   desc "Build tool that can be used as a replacement for Make"
   homepage "http://www.freetype.org/jam/"
-  url "https://downloads.sourceforge.net/project/freetype/ftjam/2.5.2/ftjam-2.5.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/freetype/ftjam/2.5.2/ftjam-2.5.2.tar.bz2"
   sha256 "e89773500a92912de918e9febffabe4b6bce79d69af194435f4e032b8a6d66a3"
 
   conflicts_with "jam", :because => "both install a `jam` binary"

--- a/Library/Formula/gabedit.rb
+++ b/Library/Formula/gabedit.rb
@@ -1,7 +1,7 @@
 class Gabedit < Formula
   desc "GUI to computational chemistry packages like Gamess-US, Gaussian, etc."
   homepage "http://gabedit.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gabedit/gabedit/Gabedit248/GabeditSrc248.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gabedit/gabedit/Gabedit248/GabeditSrc248.tar.gz"
   version "2.4.8"
   sha256 "38d6437a18280387b46fd136f2201a73b33e45abde13fa802c64806b6b64e4d3"
   revision 1

--- a/Library/Formula/gaffitter.rb
+++ b/Library/Formula/gaffitter.rb
@@ -1,7 +1,7 @@
 class Gaffitter < Formula
   desc "Efficiently fit files/folders to fixed size volumes (like DVDs)"
   homepage "http://gaffitter.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gaffitter/gaffitter/1.0.0/gaffitter-1.0.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gaffitter/gaffitter/1.0.0/gaffitter-1.0.0.tar.gz"
   sha256 "c85d33bdc6c0875a7144b540a7cce3e78e7c23d2ead0489327625549c3ab23ee"
 
   bottle do

--- a/Library/Formula/ganglia.rb
+++ b/Library/Formula/ganglia.rb
@@ -1,7 +1,7 @@
 class Ganglia < Formula
   desc "Ganglia monitoring client"
   homepage "http://ganglia.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ganglia/ganglia%20monitoring%20core/3.7.1/ganglia-3.7.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ganglia/ganglia%20monitoring%20core/3.7.1/ganglia-3.7.1.tar.gz"
   sha256 "e735a6218986a0ff77c737e5888426b103196c12dc2d679494ca9a4269ca69a3"
 
   bottle do

--- a/Library/Formula/gauche.rb
+++ b/Library/Formula/gauche.rb
@@ -1,7 +1,7 @@
 class Gauche < Formula
   desc "R5RS Scheme implementation, developed to be a handy script interpreter"
   homepage "http://practical-scheme.net/gauche/"
-  url "https://downloads.sourceforge.net/gauche/Gauche/Gauche-0.9.4.tgz"
+  url "https://prdownloads.sourceforge.net/gauche/Gauche/Gauche-0.9.4.tgz"
   sha256 "7b18bcd70beaced1e004594be46c8cff95795318f6f5830dd2a8a700410fc149"
 
   bottle do

--- a/Library/Formula/gaul.rb
+++ b/Library/Formula/gaul.rb
@@ -1,7 +1,7 @@
 class Gaul < Formula
   desc "Genetic Algorithm Utility Library"
   homepage "http://gaul.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gaul/gaul-devel/0.1850-0/gaul-devel-0.1850-0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gaul/gaul-devel/0.1850-0/gaul-devel-0.1850-0.tar.gz"
   sha256 "7aabb5c1c218911054164c3fca4f5c5f0b9c8d9bab8b2273f48a3ff573da6570"
 
   def install

--- a/Library/Formula/gdal.rb
+++ b/Library/Formula/gdal.rb
@@ -100,7 +100,7 @@ class Gdal < Formula
   end
 
   resource "numpy" do
-    url "https://downloads.sourceforge.net/project/numpy/NumPy/1.8.1/numpy-1.8.1.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/numpy/NumPy/1.8.1/numpy-1.8.1.tar.gz"
     sha256 "3d722fc3ac922a34c50183683e828052cd9bb7e9134a95098441297d7ea1c7a9"
   end
 

--- a/Library/Formula/gdmap.rb
+++ b/Library/Formula/gdmap.rb
@@ -1,7 +1,7 @@
 class Gdmap < Formula
   desc "Tool to inspect the used space of folders"
   homepage "https://sourceforge.net/projects/gdmap/"
-  url "https://downloads.sourceforge.net/project/gdmap/gdmap/0.8.1/gdmap-0.8.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gdmap/gdmap/0.8.1/gdmap-0.8.1.tar.gz"
   sha256 "a200c98004b349443f853bf611e49941403fce46f2335850913f85c710a2285b"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/genders.rb
+++ b/Library/Formula/genders.rb
@@ -1,7 +1,7 @@
 class Genders < Formula
   desc "Static cluster configuration database for cluster management"
   homepage "https://computing.llnl.gov/linux/genders.html"
-  url "https://downloads.sourceforge.net/project/genders/genders/1.20-1/genders-1.20.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/genders/genders/1.20-1/genders-1.20.tar.gz"
   sha256 "374ef2833ad53ea9ca4ccbabd7a66d77ab0b46785e299c0e64f95577eed96ac9"
 
   option "with-non-shortened-hostnames", "Allow non shortened hostnames that can include dots e.g. www.google.com"

--- a/Library/Formula/geogit.rb
+++ b/Library/Formula/geogit.rb
@@ -1,7 +1,7 @@
 class Geogit < Formula
   desc "Distributed version control for geospatial data"
   homepage "http://www.geogit.org"
-  url "https://downloads.sourceforge.net/project/geogit/geogit-0.10.0/geogit-cli-app-0.10.0.zip"
+  url "https://prdownloads.sourceforge.net/project/geogit/geogit-0.10.0/geogit-cli-app-0.10.0.zip"
   sha256 "b1256a2375aa38b5ba22a83d53f9befd3a7495fea5312884810744a43db77720"
 
   def install

--- a/Library/Formula/geoserver.rb
+++ b/Library/Formula/geoserver.rb
@@ -1,7 +1,7 @@
 class Geoserver < Formula
   desc "Java server to share and edit geospatial data"
   homepage "http://geoserver.org/"
-  url "https://downloads.sourceforge.net/project/geoserver/GeoServer/2.7.1.1/geoserver-2.7.1.1-bin.zip"
+  url "https://prdownloads.sourceforge.net/project/geoserver/GeoServer/2.7.1.1/geoserver-2.7.1.1-bin.zip"
   sha256 "4c584ae1e586736533e3a4bd9969eb0d180ec683cf79f2aff8512075b742da60"
 
   def install

--- a/Library/Formula/ghostscript.rb
+++ b/Library/Formula/ghostscript.rb
@@ -9,7 +9,7 @@ class Ghostscript < Formula
     # http://djvu.sourceforge.net/gsdjvu.html
     # Can't get 1.8 to compile, but feel free to open PR if you can.
     resource "djvu" do
-      url "https://downloads.sourceforge.net/project/djvu/GSDjVu/1.6/gsdjvu-1.6.tar.gz"
+      url "https://prdownloads.sourceforge.net/project/djvu/GSDjVu/1.6/gsdjvu-1.6.tar.gz"
       sha256 "6236b14b79345eda87cce9ba22387e166e7614cca2ca86b1c6f0d611c26005df"
     end
   end
@@ -44,7 +44,7 @@ class Ghostscript < Formula
 
   # https://sourceforge.net/projects/gs-fonts/
   resource "fonts" do
-    url "https://downloads.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/ghostscript-fonts-std-8.11.tar.gz"
     sha256 "0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401"
   end
 

--- a/Library/Formula/gibbslda.rb
+++ b/Library/Formula/gibbslda.rb
@@ -1,7 +1,7 @@
 class Gibbslda < Formula
   desc "Library wrapping imlib2's context API"
   homepage "http://gibbslda.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gibbslda/GibbsLDA%2B%2B/0.2/GibbsLDA%2B%2B-0.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gibbslda/GibbsLDA%2B%2B/0.2/GibbsLDA%2B%2B-0.2.tar.gz"
   sha256 "4ca7b51bd2f098534f2fdf82c3f861f5d8bf92e29a6b7fbdc50c3c2baeb070ae"
 
   bottle do

--- a/Library/Formula/giflib.rb
+++ b/Library/Formula/giflib.rb
@@ -1,7 +1,7 @@
 class Giflib < Formula
   desc "GIF library using patented LZW algorithm"
   homepage "http://giflib.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.2.3.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.2.3.tar.bz2"
   sha256 "0ac8d56726f77c8bc9648c93bbb4d6185d32b15ba7bdb702415990f96f3cb766"
 
   bottle do

--- a/Library/Formula/gitslave.rb
+++ b/Library/Formula/gitslave.rb
@@ -1,7 +1,7 @@
 class Gitslave < Formula
   desc "Create group of related repos with one as superproject"
   homepage "http://gitslave.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/gitslave/gitslave-2.0.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gitslave/gitslave-2.0.2.tar.gz"
   sha256 "8aa3dcb1b50418cc9cee9bee86bb4b279c1c5a34b7adc846697205057d4826f0"
 
   def install

--- a/Library/Formula/glew.rb
+++ b/Library/Formula/glew.rb
@@ -1,7 +1,7 @@
 class Glew < Formula
   desc "OpenGL Extension Wrangler Library"
   homepage "http://glew.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/glew/glew/1.12.0/glew-1.12.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/glew/glew/1.12.0/glew-1.12.0.tgz"
   sha256 "af58103f4824b443e7fa4ed3af593b8edac6f3a7be3b30911edbc7344f48e4bf"
 
   bottle do

--- a/Library/Formula/glui.rb
+++ b/Library/Formula/glui.rb
@@ -1,7 +1,7 @@
 class Glui < Formula
   desc "C++ user interface library"
   homepage "http://glui.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/glui/Source/2.36/glui-2.36.tgz"
+  url "https://prdownloads.sourceforge.net/project/glui/Source/2.36/glui-2.36.tgz"
   sha256 "c1ef5e83cf338e225ce849f948170cd681c99661a5c2158b4074515926702787"
 
   # Fix compiler warnings in glui.h. Reported upstream:

--- a/Library/Formula/gmtl.rb
+++ b/Library/Formula/gmtl.rb
@@ -3,7 +3,7 @@ class Gmtl < Formula
   homepage "http://ggt.sourceforge.net/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/ggt/Generic%20Math%20Template%20Library/0.6.1/gmtl-0.6.1.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/ggt/Generic%20Math%20Template%20Library/0.6.1/gmtl-0.6.1.tar.gz"
     sha256 "f7d8e6958d96a326cb732a9d3692a3ff3fd7df240eb1d0921a7c5c77e37fc434"
 
     # Build assumes that Python is a framework, which isn't always true. See:

--- a/Library/Formula/gnuplot.rb
+++ b/Library/Formula/gnuplot.rb
@@ -1,7 +1,7 @@
 class Gnuplot < Formula
   desc "Command-driven, interactive function plotting"
   homepage "http://www.gnuplot.info"
-  url "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.0.1/gnuplot-5.0.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gnuplot/gnuplot/5.0.1/gnuplot-5.0.1.tar.gz"
   sha256 "7cbc557e71df581ea520123fb439dea5f073adcc9010a2885dc80d4ed28b3c47"
   revision 2
 

--- a/Library/Formula/gphoto2.rb
+++ b/Library/Formula/gphoto2.rb
@@ -1,7 +1,7 @@
 class Gphoto2 < Formula
   desc "Command-line interface to libgphoto2"
   homepage "http://gphoto.org/"
-  url "http://downloads.sourceforge.net/project/gphoto/gphoto/2.5.1/gphoto2-2.5.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/gphoto/gphoto/2.5.1/gphoto2-2.5.1.tar.bz2"
   sha1 "c363adfb5d0f21c03bc5dc27daf19e9e409832ec"
   revision 2
 

--- a/Library/Formula/gplcver.rb
+++ b/Library/Formula/gplcver.rb
@@ -1,7 +1,7 @@
 class Gplcver < Formula
   desc "Pragmatic C Software GPL Cver 2001"
   homepage "http://gplcver.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gplcver/gplcver/2.12a/gplcver-2.12a.src.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/gplcver/gplcver/2.12a/gplcver-2.12a.src.tar.bz2"
   sha256 "f7d94677677f10c2d1e366eda2d01a652ef5f30d167660905c100f52f1a46e75"
 
   def install

--- a/Library/Formula/gpsim.rb
+++ b/Library/Formula/gpsim.rb
@@ -1,7 +1,7 @@
 class Gpsim < Formula
   desc "Simulator for Microchip's PIC microcontrollers"
   homepage "http://gpsim.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gpsim/gpsim/0.28.0/gpsim-0.28.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gpsim/gpsim/0.28.0/gpsim-0.28.1.tar.gz"
   sha256 "d8d41fb530630e6df31db89a0ca630038395aed4d07c48859655468ed25658ed"
 
   head "svn://svn.code.sf.net/p/gpsim/code/trunk"

--- a/Library/Formula/gptfdisk.rb
+++ b/Library/Formula/gptfdisk.rb
@@ -1,7 +1,7 @@
 class Gptfdisk < Formula
   desc "Text-mode partitioning tools"
   homepage "http://www.rodsbooks.com/gdisk/"
-  url "https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.0/gptfdisk-1.0.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gptfdisk/gptfdisk/1.0.0/gptfdisk-1.0.0.tar.gz"
   sha256 "5b66956743a799fc0471cdb032665c1391e82f9c5b3f1d7d726d29fe2ba01d6c"
   revision 1
 

--- a/Library/Formula/gptsync.rb
+++ b/Library/Formula/gptsync.rb
@@ -1,7 +1,7 @@
 class Gptsync < Formula
   desc "GPT and MBR partition tables synchronization tool"
   homepage "http://refit.sourceforge.net/"
-  url "https://downloads.sourceforge.net/refit/refit-src-0.14.tar.gz"
+  url "https://prdownloads.sourceforge.net/refit/refit-src-0.14.tar.gz"
   sha256 "c4b0803683c9f8a1de0b9f65d2b5a25a69100dcc608d58dca1611a8134cde081"
 
   def install

--- a/Library/Formula/gputils.rb
+++ b/Library/Formula/gputils.rb
@@ -1,7 +1,7 @@
 class Gputils < Formula
   desc "GNU PIC Utilities"
   homepage "http://gputils.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gputils/gputils/1.4.0/gputils-1.4.0-1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gputils/gputils/1.4.0/gputils-1.4.0-1.tar.gz"
   sha256 "d0ce93b6bcf266b8dfa0d0d589d5626a04b950a4e450ff27ef62534243ac7edb"
 
   bottle do

--- a/Library/Formula/gqlplus.rb
+++ b/Library/Formula/gqlplus.rb
@@ -1,7 +1,7 @@
 class Gqlplus < Formula
   desc "Drop-in replacement for sqlplus, an Oracle SQL client"
   homepage "http://gqlplus.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gqlplus/gqlplus/1.15/gqlplus-1.15.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gqlplus/gqlplus/1.15/gqlplus-1.15.tar.gz"
   sha256 "9a539cdcf952b4acd2ae2d940772366bf6c9ee0fb51846c02d3c7dc1df3056d5"
   revision 1
 

--- a/Library/Formula/gqview.rb
+++ b/Library/Formula/gqview.rb
@@ -1,7 +1,7 @@
 class Gqview < Formula
   desc "GQview image browser"
   homepage "http://gqview.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/gqview/gqview/2.0.4/gqview-2.0.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gqview/gqview/2.0.4/gqview-2.0.4.tar.gz"
   sha256 "97e3b7ce5f17a315c56d6eefd7b3a60b40cc3d18858ca194c7e7262acce383cb"
   revision 1
 

--- a/Library/Formula/graphicsmagick.rb
+++ b/Library/Formula/graphicsmagick.rb
@@ -1,7 +1,7 @@
 class Graphicsmagick < Formula
   desc "Image processing tools collection"
   homepage "http://www.graphicsmagick.org/"
-  url "https://downloads.sourceforge.net/project/graphicsmagick/graphicsmagick-history/1.3/GraphicsMagick-1.3.21.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/graphicsmagick/graphicsmagick-history/1.3/GraphicsMagick-1.3.21.tar.gz"
   sha256 "84ddfa0c1b5bf47db8d7d2937d4ac2fdce5e45acfd7d8a5e6a2387162312c394"
   head "http://hg.code.sf.net/p/graphicsmagick/code", :using => :hg
   revision 1

--- a/Library/Formula/graphite2.rb
+++ b/Library/Formula/graphite2.rb
@@ -1,7 +1,7 @@
 class Graphite2 < Formula
   desc "Smart font renderer for non-Roman scripts"
   homepage "https://scripts.sil.org/cms/scripts/page.php?site_id=projects&item_id=graphite_home"
-  url "https://downloads.sourceforge.net/project/silgraphite/graphite2/graphite2-1.3.2.tgz"
+  url "https://prdownloads.sourceforge.net/project/silgraphite/graphite2/graphite2-1.3.2.tgz"
   sha256 "97af064ff07828f8724b5a9c27d63e2df5aef69a742f0f67cc3f68c3f15d3850"
 
   bottle do

--- a/Library/Formula/gringo.rb
+++ b/Library/Formula/gringo.rb
@@ -1,7 +1,7 @@
 class Gringo < Formula
   desc "Grounder to translate user-provided logic programs"
   homepage "http://potassco.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/potassco/gringo/4.5.2/gringo-4.5.2-source.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/potassco/gringo/4.5.2/gringo-4.5.2-source.tar.gz"
   sha256 "36d86321c54499cabf498dac0923b39e43c7a248919224a11c2d15e4ecec9d65"
 
   bottle do

--- a/Library/Formula/grsync.rb
+++ b/Library/Formula/grsync.rb
@@ -1,7 +1,7 @@
 class Grsync < Formula
   desc "GUI for rsync"
   homepage "http://www.opbyte.it/grsync/"
-  url "https://downloads.sourceforge.net/project/grsync/grsync-1.2.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/grsync/grsync-1.2.5.tar.gz"
   sha256 "4f1443154f7c85ca7b0e93d5fea438e2709776005e7cfc97da89f4899b1c12e5"
   revision 1
 

--- a/Library/Formula/gtkdatabox.rb
+++ b/Library/Formula/gtkdatabox.rb
@@ -1,7 +1,7 @@
 class Gtkdatabox < Formula
   desc "Widget for live display of large amounts of changing data"
   homepage "https://sourceforge.net/projects/gtkdatabox/"
-  url "https://downloads.sourceforge.net/project/gtkdatabox/gtkdatabox/0.9.2.0/gtkdatabox-0.9.2.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gtkdatabox/gtkdatabox/0.9.2.0/gtkdatabox-0.9.2.0.tar.gz"
   sha256 "745a6843e8f790504a86ad1b8642e1a9e595d75586215e0d2cb2f0bf0a324040"
   revision 1
 

--- a/Library/Formula/gtkextra.rb
+++ b/Library/Formula/gtkextra.rb
@@ -1,7 +1,7 @@
 class Gtkextra < Formula
   desc "Widgets for creating GUIs for GTK+"
   homepage "http://gtkextra.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gtkextra/3.1/gtkextra-3.1.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gtkextra/3.1/gtkextra-3.1.5.tar.gz"
   sha256 "967115bddfa48878f43baf0b90cefcd46d6bc5b25b5f8069730e1ffe3873d52d"
 
   bottle do

--- a/Library/Formula/gtmess.rb
+++ b/Library/Formula/gtmess.rb
@@ -1,7 +1,7 @@
 class Gtmess < Formula
   desc "Console MSN messenger client"
   homepage "http://gtmess.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gtmess/gtmess/0.97/gtmess-0.97.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gtmess/gtmess/0.97/gtmess-0.97.tar.gz"
   sha256 "606379bb06fa70196e5336cbd421a69d7ebb4b27f93aa1dfd23a6420b3c6f5c6"
   revision 1
 

--- a/Library/Formula/gts.rb
+++ b/Library/Formula/gts.rb
@@ -1,7 +1,7 @@
 class Gts < Formula
   desc "GNU triangulated surface library"
   homepage "http://gts.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/gts/gts/0.7.6/gts-0.7.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/gts/gts/0.7.6/gts-0.7.6.tar.gz"
   sha256 "059c3e13e3e3b796d775ec9f96abdce8f2b3b5144df8514eda0cc12e13e8b81e"
 
   option :universal

--- a/Library/Formula/h264bitstream.rb
+++ b/Library/Formula/h264bitstream.rb
@@ -1,7 +1,7 @@
 class H264bitstream < Formula
   desc "Library for reading and writing H264 video streams"
   homepage "http://h264bitstream.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/h264bitstream/h264bitstream/0.1.9/h264bitstream-0.1.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/h264bitstream/h264bitstream/0.1.9/h264bitstream-0.1.9.tar.gz"
   sha256 "a18dee311adf6533931f702853b39058b1b7d0e484d91b33c6ba6442567d4764"
 
   def install

--- a/Library/Formula/harbour.rb
+++ b/Library/Formula/harbour.rb
@@ -1,7 +1,7 @@
 class Harbour < Formula
   desc "Portable, xBase-compatible programming language and environment"
   homepage "https://harbour.github.io"
-  url "https://downloads.sourceforge.net/harbour-project/source/3.0.0/harbour-3.0.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/harbour-project/source/3.0.0/harbour-3.0.0.tar.bz2"
   sha256 "4e99c0c96c681b40c7e586be18523e33db24baea68eb4e394989a3b7a6b5eaad"
 
   bottle do

--- a/Library/Formula/hilite.rb
+++ b/Library/Formula/hilite.rb
@@ -1,7 +1,7 @@
 class Hilite < Formula
   desc "CLI tool that runs a command and highlights STDERR output"
   homepage "http://sourceforge.net/projects/hilite/"
-  url "https://downloads.sourceforge.net/project/hilite/hilite/1.5/hilite.c"
+  url "https://prdownloads.sourceforge.net/project/hilite/hilite/1.5/hilite.c"
   sha256 "e15bdff2605e8d23832d6828a62194ca26dedab691c9d75df2877468c2f6aaeb"
 
   def install

--- a/Library/Formula/ht.rb
+++ b/Library/Formula/ht.rb
@@ -1,7 +1,7 @@
 class Ht < Formula
   desc "Viewer/editor/analyzer for executables"
   homepage "http://hte.sf.net/"
-  url "https://downloads.sourceforge.net/project/hte/ht-source/ht-2.1.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/hte/ht-source/ht-2.1.0.tar.bz2"
   sha256 "31f5e8e2ca7f85d40bb18ef518bf1a105a6f602918a0755bc649f3f407b75d70"
 
   bottle do

--- a/Library/Formula/htmlcleaner.rb
+++ b/Library/Formula/htmlcleaner.rb
@@ -1,7 +1,7 @@
 class Htmlcleaner < Formula
   desc "HTML parser written in Java"
   homepage "http://htmlcleaner.sourceforge.net/index.php"
-  url "https://downloads.sourceforge.net/project/htmlcleaner/htmlcleaner/htmlcleaner%20v2.10/htmlcleaner-2.10.zip"
+  url "https://prdownloads.sourceforge.net/project/htmlcleaner/htmlcleaner/htmlcleaner%20v2.10/htmlcleaner-2.10.zip"
   sha256 "904b6d11b97c3363de9ab0eeb966fa015c2afe2733786e671d9d79a34078ad32"
 
   def install

--- a/Library/Formula/htmlcxx.rb
+++ b/Library/Formula/htmlcxx.rb
@@ -1,7 +1,7 @@
 class Htmlcxx < Formula
   desc "Non-validating CSS1 and HTML parser for C++"
   homepage "http://htmlcxx.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/htmlcxx/htmlcxx/0.85/htmlcxx-0.85.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/htmlcxx/htmlcxx/0.85/htmlcxx-0.85.tar.gz"
   sha256 "ab02a0c4addc82f82d564f7d163fe0cc726179d9045381c288f5b8295996bae5"
 
   # Don't try to use internal GCC headers; rely on standards-compliant header

--- a/Library/Formula/hunspell.rb
+++ b/Library/Formula/hunspell.rb
@@ -1,7 +1,7 @@
 class Hunspell < Formula
   desc "Spell checker and morphological analyzer"
   homepage "http://hunspell.sourceforge.net/"
-  url "https://downloads.sourceforge.net/hunspell/hunspell-1.3.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/hunspell/hunspell-1.3.3.tar.gz"
   sha256 "a7b2c0de0e2ce17426821dc1ac8eb115029959b3ada9d80a81739fa19373246c"
   revision 1
 

--- a/Library/Formula/iat.rb
+++ b/Library/Formula/iat.rb
@@ -1,7 +1,7 @@
 class Iat < Formula
   desc "Converts many CD-ROM image formats to ISO9660"
   homepage "http://iat.berlios.de/"
-  url "https://downloads.sourceforge.net/project/iat.berlios/iat-0.1.7.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/iat.berlios/iat-0.1.7.tar.bz2"
   sha256 "fb72c42f4be18107ec1bff8448bd6fac2a3926a574d4950a4d5120f0012d62ca"
 
   def install

--- a/Library/Formula/icu4c.rb
+++ b/Library/Formula/icu4c.rb
@@ -2,7 +2,7 @@ class Icu4c < Formula
   desc "C/C++ and Java libraries for Unicode and globalization"
   homepage "http://site.icu-project.org/"
   head "https://github.com/unicode-org/icu.git"
-  url "https://downloads.sourceforge.net/project/icu/ICU4C/55.1/icu4c-55_1-src.tgz"
+  url "https://prdownloads.sourceforge.net/project/icu/ICU4C/55.1/icu4c-55_1-src.tgz"
   mirror "https://ftp.osuosl.org/pub/blfs/conglomeration/icu/icu4c-55_1-src.tgz"
   version "55.1"
   sha256 "e16b22cbefdd354bec114541f7849a12f8fc2015320ca5282ee4fd787571457b"

--- a/Library/Formula/id3lib.rb
+++ b/Library/Formula/id3lib.rb
@@ -4,7 +4,7 @@ class Id3lib < Formula
   revision 1
 
   stable do
-    url "https://downloads.sourceforge.net/project/id3lib/id3lib/3.8.3/id3lib-3.8.3.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/id3lib/id3lib/3.8.3/id3lib-3.8.3.tar.gz"
     sha256 "2749cc3c0cd7280b299518b1ddf5a5bcfe2d1100614519b68702230e26c7d079"
 
     patch do

--- a/Library/Formula/id3v2.rb
+++ b/Library/Formula/id3v2.rb
@@ -1,7 +1,7 @@
 class Id3v2 < Formula
   desc "ID3v2 editing tool"
   homepage "http://id3v2.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/id3v2/id3v2/0.1.12/id3v2-0.1.12.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/id3v2/id3v2/0.1.12/id3v2-0.1.12.tar.gz"
   sha256 "8105fad3189dbb0e4cb381862b4fa18744233c3bbe6def6f81ff64f5101722bf"
 
   depends_on "id3lib"

--- a/Library/Formula/imagesnap.rb
+++ b/Library/Formula/imagesnap.rb
@@ -1,7 +1,7 @@
 class Imagesnap < Formula
   desc "Tool to capture still images from an iSight or other video source"
   homepage "http://iharder.sourceforge.net/current/macosx/imagesnap/"
-  url "https://downloads.sourceforge.net/project/iharder/imagesnap/ImageSnap-v0.2.5.tgz"
+  url "https://prdownloads.sourceforge.net/project/iharder/imagesnap/ImageSnap-v0.2.5.tgz"
   sha256 "2516edd6e8fe35c075f0a6517b9fb8ba9af296f8f29b9e349566b9ba6f729615"
 
   bottle do

--- a/Library/Formula/imlib2.rb
+++ b/Library/Formula/imlib2.rb
@@ -1,7 +1,7 @@
 class Imlib2 < Formula
   desc "Image loading and rendering library"
   homepage "http://sourceforge.net/projects/enlightenment/files/"
-  url "https://downloads.sourceforge.net/project/enlightenment/imlib2-src/1.4.7/imlib2-1.4.7.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/enlightenment/imlib2-src/1.4.7/imlib2-1.4.7.tar.bz2"
   sha256 "35d733ce23ad7d338cff009095d37e656cb8a7a53717d53793a38320f9924701"
   revision 2
 

--- a/Library/Formula/iperf.rb
+++ b/Library/Formula/iperf.rb
@@ -1,7 +1,7 @@
 class Iperf < Formula
   desc "Tool to measure maximum TCP and UDP bandwidth"
   homepage "http://iperf.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/iperf/iperf-2.0.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/iperf/iperf-2.0.5.tar.gz"
   sha256 "636b4eff0431cea80667ea85a67ce4c68698760a9837e1e9d13096d20362265b"
 
   def install

--- a/Library/Formula/ipmitool.rb
+++ b/Library/Formula/ipmitool.rb
@@ -1,7 +1,7 @@
 class Ipmitool < Formula
   desc "Utility for IPMI control with kernel driver or LAN interface"
   homepage "http://ipmitool.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ipmitool/ipmitool/1.8.15/ipmitool-1.8.15.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/ipmitool/ipmitool/1.8.15/ipmitool-1.8.15.tar.bz2"
   sha256 "4acd2df5f8740fef5c032cebee0113ec4d3bbef04a6f4dbfaf7fcc7f3eb08c40"
 
   depends_on "openssl"

--- a/Library/Formula/ipmiutil.rb
+++ b/Library/Formula/ipmiutil.rb
@@ -1,7 +1,7 @@
 class Ipmiutil < Formula
   desc "IPMI server management utility"
   homepage "http://ipmiutil.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ipmiutil/ipmiutil-2.9.5.tar.gz"
   sha256 "eb00f0582ee75e1f8d371e398d546ddd7639595b9a0a1f27a84cc6ecb038dbe6"
 
   bottle do

--- a/Library/Formula/ircd-hybrid.rb
+++ b/Library/Formula/ircd-hybrid.rb
@@ -1,7 +1,7 @@
 class IrcdHybrid < Formula
   desc "High-performance secure IRC server"
   homepage "http://www.ircd-hybrid.org/"
-  url "https://downloads.sourceforge.net/project/ircd-hybrid/ircd-hybrid/ircd-hybrid-8.2.8/ircd-hybrid-8.2.8.tgz"
+  url "https://prdownloads.sourceforge.net/project/ircd-hybrid/ircd-hybrid/ircd-hybrid-8.2.8/ircd-hybrid-8.2.8.tgz"
   sha256 "651031ca86c829535ef91ff8a344c36cd5d79d2c6fb4a1c10bbd12a3b8fb2f9f"
 
   bottle do

--- a/Library/Formula/irrlicht.rb
+++ b/Library/Formula/irrlicht.rb
@@ -2,7 +2,7 @@ class Irrlicht < Formula
   desc "Realtime 3D engine"
   homepage "http://irrlicht.sourceforge.net/"
   head "https://irrlicht.svn.sourceforge.net/svnroot/irrlicht/trunk"
-  url "https://downloads.sourceforge.net/irrlicht/irrlicht-1.8.1.zip"
+  url "https://prdownloads.sourceforge.net/irrlicht/irrlicht-1.8.1.zip"
   sha256 "814bb90116d5429449ba1d169e2cbff881c473b7eada4c2447132bc4f4a6e97b"
 
   # may be removed when https://sourceforge.net/p/irrlicht/patches/297/ applied

--- a/Library/Formula/isync.rb
+++ b/Library/Formula/isync.rb
@@ -1,7 +1,7 @@
 class Isync < Formula
   desc "Synchronize a maildir with an IMAP server"
   homepage "http://isync.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/isync/isync/1.2.0/isync-1.2.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/isync/isync/1.2.0/isync-1.2.0.tar.gz"
   sha256 "833878de1647d403cb56984757cc416094ee037c5388a0f1d1f74084f6e60e59"
 
   bottle do

--- a/Library/Formula/itpp.rb
+++ b/Library/Formula/itpp.rb
@@ -2,7 +2,7 @@ class Itpp < Formula
   desc "Library of math, signal, and communication classes and functions"
   homepage "http://itpp.sourceforge.net"
   head "http://git.code.sf.net/p/itpp/git"
-  url "https://downloads.sourceforge.net/project/itpp/itpp/4.3.1/itpp-4.3.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/itpp/itpp/4.3.1/itpp-4.3.1.tar.bz2"
   sha256 "50717621c5dfb5ed22f8492f8af32b17776e6e06641dfe3a3a8f82c8d353b877"
 
   depends_on "cmake" => :build

--- a/Library/Formula/jags.rb
+++ b/Library/Formula/jags.rb
@@ -1,7 +1,7 @@
 class Jags < Formula
   desc "Just Another Gibbs Sampler for Bayesian MCMC simulation"
   homepage "http://mcmc-jags.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mcmc-jags/JAGS/3.x/Source/JAGS-3.4.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mcmc-jags/JAGS/3.x/Source/JAGS-3.4.0.tar.gz"
   sha256 "2beaa9a2672c2c95efc55ffa4c8b597a872f20232373daebd17ad539d3d7d82b"
   bottle do
     cellar :any

--- a/Library/Formula/jasmin.rb
+++ b/Library/Formula/jasmin.rb
@@ -1,7 +1,7 @@
 class Jasmin < Formula
   desc "Assembler for the Java Virtual Machine"
   homepage "http://jasmin.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/jasmin/jasmin/jasmin-2.4/jasmin-2.4.zip"
+  url "https://prdownloads.sourceforge.net/project/jasmin/jasmin/jasmin-2.4/jasmin-2.4.zip"
   sha256 "eaa10c68cec68206fd102e9ec7113739eccd790108a1b95a6e8c3e93f20e449d"
 
   bottle do

--- a/Library/Formula/joe.rb
+++ b/Library/Formula/joe.rb
@@ -1,7 +1,7 @@
 class Joe < Formula
   desc "Joe's Own Editor (JOE)"
   homepage "http://joe-editor.sourceforge.net/index.html"
-  url "https://downloads.sourceforge.net/project/joe-editor/JOE%20sources/joe-4.0/joe-4.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/joe-editor/JOE%20sources/joe-4.0/joe-4.0.tar.gz"
   sha256 "c556adff77fd97bf1b86198de6cb82e0b92cda18579c4fef6c83b608d2ed2915"
 
   bottle do

--- a/Library/Formula/jp2a.rb
+++ b/Library/Formula/jp2a.rb
@@ -1,7 +1,7 @@
 class Jp2a < Formula
   desc "Convert JPG images to ASCII"
   homepage "http://csl.sublevel3.org/jp2a/"
-  url "https://downloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/jp2a/jp2a/1.0.6/jp2a-1.0.6.tar.gz"
   sha256 "0930ac8a9545c8a8a65dd30ff80b1ae0d3b603f2ef83b04226da0475c7ccce1c"
   revision 1
 

--- a/Library/Formula/jpeg-turbo.rb
+++ b/Library/Formula/jpeg-turbo.rb
@@ -1,7 +1,7 @@
 class JpegTurbo < Formula
   desc "JPEG image codec that aids compression and decompression"
   homepage "http://www.libjpeg-turbo.org/"
-  url "https://downloads.sourceforge.net/project/libjpeg-turbo/1.4.1/libjpeg-turbo-1.4.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libjpeg-turbo/1.4.1/libjpeg-turbo-1.4.1.tar.gz"
   sha256 "4bf5bad4ce85625bffbbd9912211e06790e00fb982b77724af7211034efafb08"
 
   bottle do

--- a/Library/Formula/judy.rb
+++ b/Library/Formula/judy.rb
@@ -1,7 +1,7 @@
 class Judy < Formula
   desc "C library that implements a sparse dynamic array"
   homepage "http://judy.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/judy/judy/Judy-1.0.5/Judy-1.0.5.tar.gz"
   sha256 "d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb"
 
   def install

--- a/Library/Formula/kbtin.rb
+++ b/Library/Formula/kbtin.rb
@@ -1,7 +1,7 @@
 class Kbtin < Formula
   desc "Heavily extended clone of TinTin++"
   homepage "http://kbtin.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/kbtin/kbtin/1.0.14/kbtin-1.0.14.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/kbtin/kbtin/1.0.14/kbtin-1.0.14.tar.xz"
   sha256 "7b495e04d894f5958336756055800cec148ae5a7336c0a2b26dd2084c37d1f5c"
   revision 1
 

--- a/Library/Formula/kdiff3.rb
+++ b/Library/Formula/kdiff3.rb
@@ -1,7 +1,7 @@
 class Kdiff3 < Formula
   desc "Compare and merge 2 or 3 files or directories"
   homepage "http://kdiff3.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.98/kdiff3-0.9.98.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/kdiff3/kdiff3/0.9.98/kdiff3-0.9.98.tar.gz"
   sha256 "802c1ababa02b403a5dca15955c01592997116a24909745016931537210fd668"
 
   depends_on "qt"

--- a/Library/Formula/ktoblzcheck.rb
+++ b/Library/Formula/ktoblzcheck.rb
@@ -1,7 +1,7 @@
 class Ktoblzcheck < Formula
   desc "Library for German banks"
   homepage "http://ktoblzcheck.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ktoblzcheck/ktoblzcheck-1.48.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ktoblzcheck/ktoblzcheck-1.48.tar.gz"
   sha256 "0f4e66d3a880355b1afc88870d224755e078dfaf192242d9c6acb8853f5bcf58"
 
   bottle do

--- a/Library/Formula/lame.rb
+++ b/Library/Formula/lame.rb
@@ -1,7 +1,7 @@
 class Lame < Formula
   desc "Lame Aint an MP3 Encoder (LAME)"
   homepage "http://lame.sourceforge.net/"
-  url "https://downloads.sourceforge.net/sourceforge/lame/lame-3.99.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/sourceforge/lame/lame-3.99.5.tar.gz"
   sha256 "24346b4158e4af3bd9f2e194bb23eb473c75fb7377011523353196b19b9a23ff"
 
   bottle do

--- a/Library/Formula/lasi.rb
+++ b/Library/Formula/lasi.rb
@@ -1,7 +1,7 @@
 class Lasi < Formula
   desc "C++ stream output interface for creating Postscript documents"
   homepage "http://www.unifont.org/lasi/"
-  url "https://downloads.sourceforge.net/project/lasi/lasi/1.1.2%20Source/libLASi-1.1.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lasi/lasi/1.1.2%20Source/libLASi-1.1.2.tar.gz"
   sha256 "448c6e52263a1e88ac2a157f775c393aa8b6cd3f17d81fc51e718f18fdff5121"
 
   head "https://lasi.svn.sourceforge.net/svnroot/lasi/trunk"

--- a/Library/Formula/latex2rtf.rb
+++ b/Library/Formula/latex2rtf.rb
@@ -1,7 +1,7 @@
 class Latex2rtf < Formula
   desc "Translate LaTeX to RTF"
   homepage "http://latex2rtf.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/latex2rtf/latex2rtf-unix/2.3.8/latex2rtf-2.3.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/latex2rtf/latex2rtf-unix/2.3.8/latex2rtf-2.3.8.tar.gz"
   sha256 "5484530de16e96ce76aedf969c464656a5f8834e748849d9009049e26f8c4143"
 
   def install

--- a/Library/Formula/lcdproc.rb
+++ b/Library/Formula/lcdproc.rb
@@ -1,7 +1,7 @@
 class Lcdproc < Formula
   desc "Display real-time system information on a LCD"
   homepage "http://www.lcdproc.org/"
-  url "https://downloads.sourceforge.net/project/lcdproc/lcdproc/0.5.6/lcdproc-0.5.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lcdproc/lcdproc/0.5.6/lcdproc-0.5.6.tar.gz"
   sha256 "bd2f43c30ff43b30f43110abe6b4a5bc8e0267cb9f57fa97cc5e5ef9488b984a"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/lci.rb
+++ b/Library/Formula/lci.rb
@@ -1,7 +1,7 @@
 class Lci < Formula
   desc "Interpreter for the lambda calculus"
   homepage "http://lci.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/lci/lci/0.6/lci-0.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lci/lci/0.6/lci-0.6.tar.gz"
   sha256 "204f1ca5e2f56247d71ab320246811c220ed511bf08c9cb7f305cf180a93948e"
 
   conflicts_with "lolcode", :because => "both install `lci` binaries"

--- a/Library/Formula/lcov.rb
+++ b/Library/Formula/lcov.rb
@@ -1,7 +1,7 @@
 class Lcov < Formula
   desc "Graphical front-end for GCC's coverage testing tool (gcov)"
   homepage "http://ltp.sourceforge.net/coverage/lcov.php"
-  url "https://downloads.sourceforge.net/ltp/lcov-1.11.tar.gz"
+  url "https://prdownloads.sourceforge.net/ltp/lcov-1.11.tar.gz"
   sha256 "c282de8d678ecbfda32ce4b5c85fc02f77c2a39a062f068bd8e774d29ddc9bf8"
 
   head "https://github.com/linux-test-project/lcov.git"

--- a/Library/Formula/leafnode.rb
+++ b/Library/Formula/leafnode.rb
@@ -1,7 +1,7 @@
 class Leafnode < Formula
   desc "Leafnode is a store and forward NNTP proxy"
   homepage "http://sourceforge.net/projects/leafnode/"
-  url "https://downloads.sourceforge.net/project/leafnode/leafnode/1.11.10/leafnode-1.11.10.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/leafnode/leafnode/1.11.10/leafnode-1.11.10.tar.bz2"
   sha256 "d75ba79961a8900b273eb74c3ad6976bf9fd64c2fa0284273e65f98190c5f2bc"
 
   depends_on "pcre"

--- a/Library/Formula/ledger.rb
+++ b/Library/Formula/ledger.rb
@@ -14,7 +14,7 @@ class Ledger < Formula
   end
 
   resource "utfcpp" do
-    url "https://downloads.sourceforge.net/project/utfcpp/utf8cpp_2x/Release%202.3.4/utf8_v2_3_4.zip"
+    url "https://prdownloads.sourceforge.net/project/utfcpp/utf8cpp_2x/Release%202.3.4/utf8_v2_3_4.zip"
     sha256 "3373cebb25d88c662a2b960c4d585daf9ae7b396031ecd786e7bb31b15d010ef"
   end
 

--- a/Library/Formula/lensfun.rb
+++ b/Library/Formula/lensfun.rb
@@ -1,7 +1,7 @@
 class Lensfun < Formula
   desc "Remove defects from digital images"
   homepage "http://lensfun.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/lensfun/0.3.1/lensfun-0.3.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lensfun/0.3.1/lensfun-0.3.1.tar.gz"
   sha256 "216c23754212e051c8b834437e46af3812533bd770c09714e8c06c9d91cdb535"
   head "http://git.code.sf.net/p/lensfun/code"
   revision 1

--- a/Library/Formula/lesspipe.rb
+++ b/Library/Formula/lesspipe.rb
@@ -1,7 +1,7 @@
 class Lesspipe < Formula
   desc "Input filter for the pager less"
   homepage "https://www-zeuthen.desy.de/~friebel/unix/lesspipe.html"
-  url "https://downloads.sourceforge.net/project/lesspipe/lesspipe/1.82/lesspipe-1.82.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lesspipe/lesspipe/1.82/lesspipe-1.82.tar.gz"
   sha256 "3fd345b15d46cc8fb0fb1d625bf8d881b0637abc34d15df45243fd4e5a8f4241"
 
   bottle do

--- a/Library/Formula/lesstif.rb
+++ b/Library/Formula/lesstif.rb
@@ -1,7 +1,7 @@
 class Lesstif < Formula
   desc "Open source implementation of OSF/Motif"
   homepage "http://lesstif.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/lesstif/lesstif/0.95.2/lesstif-0.95.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/lesstif/lesstif/0.95.2/lesstif-0.95.2.tar.bz2"
   sha256 "eb4aa38858c29a4a3bcf605cfe7d91ca41f4522d78d770f69721e6e3a4ecf7e3"
 
   bottle do

--- a/Library/Formula/libbinio.rb
+++ b/Library/Formula/libbinio.rb
@@ -1,7 +1,7 @@
 class Libbinio < Formula
   desc "Binary I/O stream class library"
   homepage "http://libbinio.sf.net"
-  url "https://downloads.sourceforge.net/project/libbinio/libbinio/1.4/libbinio-1.4.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/libbinio/libbinio/1.4/libbinio-1.4.tar.bz2"
   sha256 "4a32d3154517510a3fe4f2dc95e378dcc818a4a921fc0cb992bdc0d416a77e75"
 
   bottle do

--- a/Library/Formula/libbs2b.rb
+++ b/Library/Formula/libbs2b.rb
@@ -1,7 +1,7 @@
 class Libbs2b < Formula
   desc "Bauer stereophonic-to-binaural DSP"
   homepage "http://bs2b.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/bs2b/libbs2b/3.1.0/libbs2b-3.1.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bs2b/libbs2b/3.1.0/libbs2b-3.1.0.tar.gz"
   sha256 "6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528"
 
   bottle do

--- a/Library/Formula/libcddb.rb
+++ b/Library/Formula/libcddb.rb
@@ -1,7 +1,7 @@
 class Libcddb < Formula
   desc "CDDB server access library"
   homepage "http://libcddb.sourceforge.net/"
-  url "https://downloads.sourceforge.net/libcddb/libcddb-1.3.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/libcddb/libcddb-1.3.2.tar.bz2"
   sha256 "35ce0ee1741ea38def304ddfe84a958901413aa829698357f0bee5bb8f0a223b"
 
   bottle do

--- a/Library/Formula/libcmph.rb
+++ b/Library/Formula/libcmph.rb
@@ -1,7 +1,7 @@
 class Libcmph < Formula
   desc "C minimal perfect hashing library"
   homepage "http://cmph.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/cmph/cmph/cmph-2.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/cmph/cmph/cmph-2.0.tar.gz"
   sha256 "ad6c9a75ff3da1fb1222cac0c1d9877f4f2366c5c61c92338c942314230cba76"
 
   bottle do

--- a/Library/Formula/libcoap.rb
+++ b/Library/Formula/libcoap.rb
@@ -1,7 +1,7 @@
 class Libcoap < Formula
   desc "Lightweight application-protocol for resource-constrained devices"
   homepage "http://libcoap.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/libcoap/coap-18/libcoap-4.1.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libcoap/coap-18/libcoap-4.1.1.tar.gz"
   sha256 "20cd0f58434480aa7e97e93a66ffef4076921de9687b14bd29fbbf18621bd394"
 
   bottle do

--- a/Library/Formula/libcsv.rb
+++ b/Library/Formula/libcsv.rb
@@ -1,7 +1,7 @@
 class Libcsv < Formula
   desc "CSV library in ANSI C89"
   homepage "http://sourceforge.net/projects/libcsv/"
-  url "https://downloads.sourceforge.net/project/libcsv/libcsv/libcsv-3.0.3/libcsv-3.0.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libcsv/libcsv/libcsv-3.0.3/libcsv-3.0.3.tar.gz"
   sha256 "d9c0431cb803ceb9896ce74f683e6e5a0954e96ae1d9e4028d6e0f967bebd7e4"
 
   bottle do

--- a/Library/Formula/libdbi.rb
+++ b/Library/Formula/libdbi.rb
@@ -1,7 +1,7 @@
 class Libdbi < Formula
   desc "Database-independent abstraction layer in C, similar to DBI/DBD in Perl"
   homepage "http://libdbi.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/libdbi/libdbi/libdbi-0.9.0/libdbi-0.9.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libdbi/libdbi/libdbi-0.9.0/libdbi-0.9.0.tar.gz"
   sha256 "dafb6cdca524c628df832b6dd0bf8fabceb103248edb21762c02d3068fca4503"
 
   bottle do

--- a/Library/Formula/libdc1394.rb
+++ b/Library/Formula/libdc1394.rb
@@ -1,7 +1,7 @@
 class Libdc1394 < Formula
   desc "Provides API for IEEE 1394 cameras"
   homepage "http://damien.douxchamps.net/ieee1394/libdc1394/"
-  url "https://downloads.sourceforge.net/project/libdc1394/libdc1394-2/2.2.2/libdc1394-2.2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libdc1394/libdc1394-2/2.2.2/libdc1394-2.2.2.tar.gz"
   sha256 "ff8744a92ab67a276cfaf23fa504047c20a1ff63262aef69b4f5dbaa56a45059"
 
   bottle do

--- a/Library/Formula/libdv.rb
+++ b/Library/Formula/libdv.rb
@@ -1,7 +1,7 @@
 class Libdv < Formula
   desc "Codec for DV video encoding format"
   homepage "http://libdv.sourceforge.net"
-  url "https://downloads.sourceforge.net/libdv/libdv-1.0.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/libdv/libdv-1.0.0.tar.gz"
   sha256 "a305734033a9c25541a59e8dd1c254409953269ea7c710c39e540bd8853389ba"
 
   bottle do

--- a/Library/Formula/libexif.rb
+++ b/Library/Formula/libexif.rb
@@ -1,7 +1,7 @@
 class Libexif < Formula
   desc "EXIF parsing library"
   homepage "http://libexif.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libexif/libexif/0.6.21/libexif-0.6.21.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libexif/libexif/0.6.21/libexif-0.6.21.tar.gz"
   sha256 "edb7eb13664cf950a6edd132b75e99afe61c5effe2f16494e6d27bc404b287bf"
 
   bottle do

--- a/Library/Formula/libgetdata.rb
+++ b/Library/Formula/libgetdata.rb
@@ -1,7 +1,7 @@
 class Libgetdata < Formula
   desc "Reference implementation of the Dirfile Standards"
   homepage "http://getdata.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/getdata/getdata/0.8.6/getdata-0.8.6.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/getdata/getdata/0.8.6/getdata-0.8.6.tar.bz2"
   sha256 "e8d333b89abc5b20e2ecc3df4de26338dce8eb2f20677e0636649c6a1ef6b5b3"
 
   bottle do

--- a/Library/Formula/libicns.rb
+++ b/Library/Formula/libicns.rb
@@ -1,7 +1,7 @@
 class Libicns < Formula
   desc "Library for manipulation of the OS X .icns resource format"
   homepage "http://icns.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
   sha256 "335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"
   revision 1

--- a/Library/Formula/libid3tag.rb
+++ b/Library/Formula/libid3tag.rb
@@ -1,7 +1,7 @@
 class Libid3tag < Formula
   desc "ID3 tag manipulation library"
   homepage "https://www.underbit.com/products/mad/"
-  url "https://downloads.sourceforge.net/project/mad/libid3tag/0.15.1b/libid3tag-0.15.1b.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mad/libid3tag/0.15.1b/libid3tag-0.15.1b.tar.gz"
   sha256 "63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151"
 
   bottle do

--- a/Library/Formula/libiodbc.rb
+++ b/Library/Formula/libiodbc.rb
@@ -1,7 +1,7 @@
 class Libiodbc < Formula
   desc "Database connectivity layer based on ODBC. (alternative to unixodbc)"
   homepage "http://www.iodbc.org/dataspace/iodbc/wiki/iODBC/"
-  url "https://downloads.sourceforge.net/project/iodbc/iodbc/3.52.10/libiodbc-3.52.10.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/iodbc/iodbc/3.52.10/libiodbc-3.52.10.tar.gz"
   sha256 "1568b42b4e97f36110af661d39bfea7d94ac4ff020014574b16a7199f068e11f"
 
   bottle do

--- a/Library/Formula/libiptcdata.rb
+++ b/Library/Formula/libiptcdata.rb
@@ -1,7 +1,7 @@
 class Libiptcdata < Formula
   desc "Virtual package provided by libiptcdata0"
   homepage "http://libiptcdata.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libiptcdata/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libiptcdata/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz"
   sha256 "79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e"
 
   bottle do

--- a/Library/Formula/liblo.rb
+++ b/Library/Formula/liblo.rb
@@ -1,7 +1,7 @@
 class Liblo < Formula
   desc "Lightweight Open Sound Control implementation"
   homepage "http://liblo.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/liblo/liblo/0.28/liblo-0.28.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/liblo/liblo/0.28/liblo-0.28.tar.gz"
   sha256 "da94a9b67b93625354dd89ff7fe31e5297fc9400b6eaf7378c82ee1caf7db909"
 
   bottle do

--- a/Library/Formula/libmaa.rb
+++ b/Library/Formula/libmaa.rb
@@ -1,7 +1,7 @@
 class Libmaa < Formula
   desc "Low-level data structures including hash tables, sets, lists"
   homepage "http://www.dict.org/"
-  url "https://downloads.sourceforge.net/project/dict/libmaa/libmaa-1.3.2/libmaa-1.3.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/dict/libmaa/libmaa-1.3.2/libmaa-1.3.2.tar.gz"
   sha256 "59a5a01e3a9036bd32160ec535d25b72e579824e391fea7079e9c40b0623b1c5"
 
   bottle do

--- a/Library/Formula/libming.rb
+++ b/Library/Formula/libming.rb
@@ -1,7 +1,7 @@
 class Libming < Formula
   desc "C library for generating Macromedia Flash files"
   homepage "http://www.libming.org"
-  url "https://downloads.sourceforge.net/project/ming/Releases/ming-0.4.4.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/ming/Releases/ming-0.4.4.tar.bz2"
   sha256 "40e09d781741ac961338ed8dec7ba2ed06217de9da44dd67af6b881b95d2af7e"
   revision 1
 

--- a/Library/Formula/libmms.rb
+++ b/Library/Formula/libmms.rb
@@ -1,7 +1,7 @@
 class Libmms < Formula
   desc "Library for parsing mms:// and mmsh:// network streams"
   homepage "http://sourceforge.net/projects/libmms/"
-  url "https://downloads.sourceforge.net/project/libmms/libmms/0.6.4/libmms-0.6.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libmms/libmms/0.6.4/libmms-0.6.4.tar.gz"
   sha256 "3c05e05aebcbfcc044d9e8c2d4646cd8359be39a3f0ba8ce4e72a9094bee704f"
 
   bottle do

--- a/Library/Formula/libmodplug.rb
+++ b/Library/Formula/libmodplug.rb
@@ -1,7 +1,7 @@
 class Libmodplug < Formula
   desc "Library from the Modplug-XMMS project"
   homepage "http://modplug-xmms.sourceforge.net/"
-  url "https://downloads.sourceforge.net/modplug-xmms/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/modplug-xmms/libmodplug/0.8.8.5/libmodplug-0.8.8.5.tar.gz"
   sha256 "77462d12ee99476c8645cb5511363e3906b88b33a6b54362b4dbc0f39aa2daad"
 
   bottle do

--- a/Library/Formula/libmp3splt.rb
+++ b/Library/Formula/libmp3splt.rb
@@ -1,7 +1,7 @@
 class Libmp3splt < Formula
   desc "Utility library to split mp3, ogg, and FLAC files"
   homepage "http://mp3splt.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mp3splt/libmp3splt/0.9.2/libmp3splt-0.9.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mp3splt/libmp3splt/0.9.2/libmp3splt-0.9.2.tar.gz"
   sha256 "30eed64fce58cb379b7cc6a0d8e545579cb99d0f0f31eb00b9acc8aaa1b035dc"
 
   bottle do

--- a/Library/Formula/libmtp.rb
+++ b/Library/Formula/libmtp.rb
@@ -1,7 +1,7 @@
 class Libmtp < Formula
   desc "Implementation of Microsoft's Media Transfer Protocol (MTP)"
   homepage "http://libmtp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libmtp/libmtp/1.1.9/libmtp-1.1.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libmtp/libmtp/1.1.9/libmtp-1.1.9.tar.gz"
   sha256 "23f1d3c0b54107388bf2824d56415e9e087c980c86e5d179865652c022b6b189"
 
   bottle do

--- a/Library/Formula/libnet.rb
+++ b/Library/Formula/libnet.rb
@@ -1,7 +1,7 @@
 class Libnet < Formula
   desc "C library for creating IP packets"
   homepage "https://github.com/sam-github/libnet"
-  url "https://downloads.sourceforge.net/project/libnet-dev/libnet-1.1.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libnet-dev/libnet-1.1.6.tar.gz"
   sha256 "d392bb5825c4b6b672fc93a0268433c86dc964e1500c279dc6d0711ea6ec467a"
 
   bottle do

--- a/Library/Formula/libnids.rb
+++ b/Library/Formula/libnids.rb
@@ -1,7 +1,7 @@
 class Libnids < Formula
   desc "Implements E-component of network intrusion detection system"
   homepage "http://libnids.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libnids/libnids/1.24/libnids-1.24.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libnids/libnids/1.24/libnids-1.24.tar.gz"
   sha256 "314b4793e0902fbf1fdb7fb659af37a3c1306ed1aad5d1c84de6c931b351d359"
 
   bottle do

--- a/Library/Formula/liboauth.rb
+++ b/Library/Formula/liboauth.rb
@@ -1,7 +1,7 @@
 class Liboauth < Formula
   desc "C library for the OAuth Core RFC 5849 standard"
   homepage "http://liboauth.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/liboauth/liboauth-1.0.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/liboauth/liboauth-1.0.3.tar.gz"
   sha256 "0df60157b052f0e774ade8a8bac59d6e8d4b464058cc55f9208d72e41156811f"
   revision 1
 

--- a/Library/Formula/libodbc++.rb
+++ b/Library/Formula/libodbc++.rb
@@ -1,7 +1,7 @@
 class Libodbcxx < Formula
   desc "C++ development environment for SQL database access"
   homepage "http://libodbcxx.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/libodbcxx/libodbc++/0.2.5/libodbc++-0.2.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libodbcxx/libodbc++/0.2.5/libodbc++-0.2.5.tar.gz"
   sha256 "0731a475b4693514e6a99121441a40305df3fe1dce3756df20c7b6758aa53b57"
 
   bottle do

--- a/Library/Formula/libodfgen.rb
+++ b/Library/Formula/libodfgen.rb
@@ -2,7 +2,7 @@ class Libodfgen < Formula
   desc "ODF export library for projects using librevenge"
   homepage "http://sourceforge.net/p/libwpd/wiki/libodfgen/"
   url "http://dev-www.libreoffice.org/src/libodfgen-0.1.4.tar.bz2"
-  mirror "https://downloads.sourceforge.net/project/libwpd/libodfgen/libodfgen-0.1.4/libodfgen-0.1.4.tar.bz2"
+  mirror "https://prdownloads.sourceforge.net/project/libwpd/libodfgen/libodfgen-0.1.4/libodfgen-0.1.4.tar.bz2"
   sha256 "f74999d2c93ac0cc077a0a9c36340daff29dc772992160ae81dd010345f72b80"
 
   bottle do

--- a/Library/Formula/libofx.rb
+++ b/Library/Formula/libofx.rb
@@ -1,7 +1,7 @@
 class Libofx < Formula
   desc "Library to support OFX command responses"
   homepage "http://libofx.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/libofx/libofx/0.9.9/libofx-0.9.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libofx/libofx/0.9.9/libofx-0.9.9.tar.gz"
   sha256 "94ef88c5cdc3e307e473fa2a55d4a05da802ee2feb65c85c63b9019c83747b23"
 
   bottle do

--- a/Library/Formula/libopendkim.rb
+++ b/Library/Formula/libopendkim.rb
@@ -1,7 +1,7 @@
 class Libopendkim < Formula
   desc "Implementation of Domain Keys Identified Mail authentication"
   homepage "http://opendkim.org"
-  url "https://downloads.sourceforge.net/project/opendkim/opendkim-2.10.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/opendkim/opendkim-2.10.3.tar.gz"
   sha256 "43a0ba57bf942095fe159d0748d8933c6b1dd1117caf0273fa9a0003215e681b"
 
   bottle do

--- a/Library/Formula/libp11.rb
+++ b/Library/Formula/libp11.rb
@@ -1,7 +1,7 @@
 class Libp11 < Formula
   desc "PKCS#11 wrapper library in C"
   homepage "https://github.com/OpenSC/libp11/wiki"
-  url "https://downloads.sourceforge.net/project/opensc/libp11/libp11-0.2.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/opensc/libp11/libp11-0.2.8.tar.gz"
   sha256 "a4121015503ade98074b5e2a2517fc8a139f8b28aed10021db2bb77283f40691"
   revision 1
 

--- a/Library/Formula/libpano.rb
+++ b/Library/Formula/libpano.rb
@@ -1,7 +1,7 @@
 class Libpano < Formula
   desc "Build panoramic images from a set of overlapping images"
   homepage "http://panotools.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.19/libpano13-2.9.19.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/panotools/libpano13/libpano13-2.9.19/libpano13-2.9.19.tar.gz"
   version "13-2.9.19"
   sha256 "037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8"
   bottle do

--- a/Library/Formula/libpng.rb
+++ b/Library/Formula/libpng.rb
@@ -1,7 +1,7 @@
 class Libpng < Formula
   desc "Library for manipulating PNG images"
   homepage "http://www.libpng.org/pub/png/libpng.html"
-  url "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.40/libpng-1.6.40.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/libpng/libpng16/1.6.40/libpng-1.6.40.tar.xz"
   sha256 "535b479b2467ff231a3ec6d92a525906fb8ef27978be4f66dbe05d3f3a01b3a1"
 
   head do

--- a/Library/Formula/libqalculate.rb
+++ b/Library/Formula/libqalculate.rb
@@ -1,7 +1,7 @@
 class Libqalculate < Formula
   desc "Library for Qalculate! program"
   homepage "http://qalculate.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/qalculate/libqalculate/libqalculate-0.9.7/libqalculate-0.9.7.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/qalculate/libqalculate/libqalculate-0.9.7/libqalculate-0.9.7.tar.gz"
   sha256 "9a6d97ce3339d104358294242c3ecd5e312446721e93499ff70acc1604607955"
   revision 1
 

--- a/Library/Formula/libquicktime.rb
+++ b/Library/Formula/libquicktime.rb
@@ -1,7 +1,7 @@
 class Libquicktime < Formula
   desc "Library for reading and writing quicktime files"
   homepage "http://libquicktime.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libquicktime/libquicktime/1.2.4/libquicktime-1.2.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libquicktime/libquicktime/1.2.4/libquicktime-1.2.4.tar.gz"
   sha256 "1c53359c33b31347b4d7b00d3611463fe5e942cae3ec0fefe0d2fd413fd47368"
   revision 2
 

--- a/Library/Formula/libquvi.rb
+++ b/Library/Formula/libquvi.rb
@@ -1,7 +1,7 @@
 class Libquvi < Formula
   desc "C library to parse flash media stream properties"
   homepage "http://quvi.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi/libquvi-0.4.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/quvi/0.4/libquvi/libquvi-0.4.1.tar.bz2"
   sha256 "f5a2fb0571634483e8a957910f44e739f5a72eb9a1900bd10b453c49b8d5f49d"
   revision 1
 
@@ -18,7 +18,7 @@ class Libquvi < Formula
   depends_on "lua"
 
   resource "scripts" do
-    url "https://downloads.sourceforge.net/project/quvi/0.4/libquvi-scripts/libquvi-scripts-0.4.14.tar.xz"
+    url "https://prdownloads.sourceforge.net/project/quvi/0.4/libquvi-scripts/libquvi-scripts-0.4.14.tar.xz"
     sha256 "b8d17d53895685031cd271cf23e33b545ad38cad1c3bddcf7784571382674c65"
   end
 

--- a/Library/Formula/libreadline-java.rb
+++ b/Library/Formula/libreadline-java.rb
@@ -1,7 +1,7 @@
 class LibreadlineJava < Formula
   desc "Port of GNU readline for Java"
   homepage "http://java-readline.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/java-readline/java-readline/0.8.0/libreadline-java-0.8.0-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/java-readline/java-readline/0.8.0/libreadline-java-0.8.0-src.tar.gz"
   sha256 "cdcfd9910bfe2dca4cd08b2462ec05efee7395e9b9c3efcb51e85fa70548c890"
   revision 1
 

--- a/Library/Formula/librevenge.rb
+++ b/Library/Formula/librevenge.rb
@@ -2,7 +2,7 @@ class Librevenge < Formula
   desc "Base library for writing document import filters"
   homepage "http://sourceforge.net/p/libwpd/wiki/librevenge/"
   url "http://dev-www.libreoffice.org/src/librevenge-0.0.2.tar.bz2"
-  mirror "https://downloads.sourceforge.net/project/libwpd/librevenge/librevenge-0.0.2/librevenge-0.0.2.tar.bz2"
+  mirror "https://prdownloads.sourceforge.net/project/libwpd/librevenge/librevenge-0.0.2/librevenge-0.0.2.tar.bz2"
   sha256 "dedd6fe1f643fc2f254f2ad3719547084bd86bcc482104b995caf3b828368b18"
 
   bottle do

--- a/Library/Formula/librsync.rb
+++ b/Library/Formula/librsync.rb
@@ -1,7 +1,7 @@
 class Librsync < Formula
   desc "Library that implements the rsync remote-delta algorithm"
   homepage "http://librsync.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/librsync/librsync/0.9.7/librsync-0.9.7.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/librsync/librsync/0.9.7/librsync-0.9.7.tar.gz"
   sha256 "6633e4605662763a03bb6388529cbdfd3b11a9ec55b8845351c1bd9a92bc41d6"
 
   bottle do

--- a/Library/Formula/libsmf.rb
+++ b/Library/Formula/libsmf.rb
@@ -1,7 +1,7 @@
 class Libsmf < Formula
   desc "C library for handling SMF ('*.mid') files"
   homepage "http://sourceforge.net/projects/libsmf/"
-  url "https://downloads.sourceforge.net/project/libsmf/libsmf/1.3/libsmf-1.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libsmf/libsmf/1.3/libsmf-1.3.tar.gz"
   sha256 "d3549f15de94ac8905ad365639ac6a2689cb1b51fdfa02d77fa6640001b18099"
 
   bottle do

--- a/Library/Formula/libsoxr.rb
+++ b/Library/Formula/libsoxr.rb
@@ -1,7 +1,7 @@
 class Libsoxr < Formula
   desc "High quality, one-dimensional sample-rate conversion library"
   homepage "http://sourceforge.net/projects/soxr/"
-  url "https://downloads.sourceforge.net/project/soxr/soxr-0.1.1-Source.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/soxr/soxr-0.1.1-Source.tar.xz"
   mirror "https://mirrors.kernel.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.1.orig.tar.xz"
   sha256 "dcc16868d1a157079316f84233afcc2b52dd0bd541dd8439dc25bceb306faac2"
 

--- a/Library/Formula/libspiro.rb
+++ b/Library/Formula/libspiro.rb
@@ -1,7 +1,7 @@
 class Libspiro < Formula
   desc "Library to simplify the drawing of curves"
   homepage "https://github.com/fontforge/libspiro"
-  url "https://downloads.sourceforge.net/project/libspiro/libspiro/20071029/libspiro_src-20071029.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/libspiro/libspiro/20071029/libspiro_src-20071029.tar.bz2"
   sha256 "1efeb1527bd48f8787281e8be1d0e8ff2e584d4c1994a0bc2f6859be2ffad4cf"
 
   bottle do

--- a/Library/Formula/libspnav.rb
+++ b/Library/Formula/libspnav.rb
@@ -1,7 +1,7 @@
 class Libspnav < Formula
   desc "Client library for connecting to 3Dconnexion's 3D input devices"
   homepage "http://spacenav.sourceforge.net/index.html"
-  url "https://downloads.sourceforge.net/project/spacenav/spacenav%20library%20%28SDK%29/libspnav%200.2.3/libspnav-0.2.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/spacenav/spacenav%20library%20%28SDK%29/libspnav%200.2.3/libspnav-0.2.3.tar.gz"
   sha256 "7ae4d7bb7f6a5dda28b487891e01accc856311440f582299760dace6ee5f1f93"
 
   bottle do

--- a/Library/Formula/libstxxl.rb
+++ b/Library/Formula/libstxxl.rb
@@ -1,7 +1,7 @@
 class Libstxxl < Formula
   desc "C++ implementation of STL for extra large data sets"
   homepage "http://stxxl.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/stxxl/stxxl/1.4.1/stxxl-1.4.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/stxxl/stxxl/1.4.1/stxxl-1.4.1.tar.gz"
   sha256 "92789d60cd6eca5c37536235eefae06ad3714781ab5e7eec7794b1c10ace67ac"
 
   bottle do

--- a/Library/Formula/libupnp.rb
+++ b/Library/Formula/libupnp.rb
@@ -1,7 +1,7 @@
 class Libupnp < Formula
   desc "Portable UPnP development kit"
   homepage "http://pupnp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pupnp/pupnp/libUPnP%201.6.19/libupnp-1.6.19.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/pupnp/pupnp/libUPnP%201.6.19/libupnp-1.6.19.tar.bz2"
   sha256 "b3142b39601243b50532eec90f4a27dba85eb86f58d4b849ac94edeb29d9b22a"
 
   bottle do

--- a/Library/Formula/libusb-compat.rb
+++ b/Library/Formula/libusb-compat.rb
@@ -1,7 +1,7 @@
 class LibusbCompat < Formula
   desc "Library for USB device access"
   homepage "http://www.libusb.org/"
-  url "https://downloads.sourceforge.net/project/libusb/libusb-compat-0.1/libusb-compat-0.1.5/libusb-compat-0.1.5.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/libusb/libusb-compat-0.1/libusb-compat-0.1.5/libusb-compat-0.1.5.tar.bz2"
   sha256 "404ef4b6b324be79ac1bfb3d839eac860fbc929e6acb1ef88793a6ea328bc55a"
 
   bottle do

--- a/Library/Formula/libusb.rb
+++ b/Library/Formula/libusb.rb
@@ -1,7 +1,7 @@
 class Libusb < Formula
   desc "Library for USB device access"
   homepage "http://libusb.info"
-  url "https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.20/libusb-1.0.20.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.20/libusb-1.0.20.tar.bz2"
   sha256 "cb057190ba0a961768224e4dc6883104c6f945b2bf2ef90d7da39e7c1834f7ff"
 
   bottle do

--- a/Library/Formula/libvo-aacenc.rb
+++ b/Library/Formula/libvo-aacenc.rb
@@ -1,7 +1,7 @@
 class LibvoAacenc < Formula
   desc "VisualOn AAC encoder library"
   homepage "http://opencore-amr.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/opencore-amr/vo-aacenc/vo-aacenc-0.1.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/opencore-amr/vo-aacenc/vo-aacenc-0.1.3.tar.gz"
   sha256 "e51a7477a359f18df7c4f82d195dab4e14e7414cbd48cf79cc195fc446850f36"
 
   bottle do

--- a/Library/Formula/libwbxml.rb
+++ b/Library/Formula/libwbxml.rb
@@ -1,7 +1,7 @@
 class Libwbxml < Formula
   desc "Library and tools to parse and encode WBXML documents"
   homepage "https://libwbxml.opensync.org/"
-  url "https://downloads.sourceforge.net/project/libwbxml/libwbxml/0.11.2/libwbxml-0.11.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/libwbxml/libwbxml/0.11.2/libwbxml-0.11.2.tar.bz2"
   sha256 "5f642027ece0225d80ef21979a57cf59b1027d46cb8dbd5ff4b87662eec2557d"
 
   bottle do

--- a/Library/Formula/libwmf.rb
+++ b/Library/Formula/libwmf.rb
@@ -1,7 +1,7 @@
 class Libwmf < Formula
   desc "Library for converting WMF (Window Metafile Format) files"
   homepage "http://wvware.sourceforge.net/libwmf.html"
-  url "https://downloads.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/wvware/libwmf/0.2.8.4/libwmf-0.2.8.4.tar.gz"
   sha256 "5b345c69220545d003ad52bfd035d5d6f4f075e65204114a9e875e84895a7cf8"
   revision 2
 

--- a/Library/Formula/libxmp-lite.rb
+++ b/Library/Formula/libxmp-lite.rb
@@ -1,7 +1,7 @@
 class LibxmpLite < Formula
   desc "Lite libxmp"
   homepage "http://xmp.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/xmp/libxmp/4.3.5/libxmp-lite-4.3.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xmp/libxmp/4.3.5/libxmp-lite-4.3.5.tar.gz"
   sha256 "e3ce0f3099432afefa2459c8de37958ff95daeb231ef97b7df10a58fa1e416da"
 
   def install

--- a/Library/Formula/libxmp.rb
+++ b/Library/Formula/libxmp.rb
@@ -1,7 +1,7 @@
 class Libxmp < Formula
   desc "C library for playback of module music (MOD, S3M, IT, etc)"
   homepage "http://xmp.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/xmp/libxmp/4.3.9/libxmp-4.3.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xmp/libxmp/4.3.9/libxmp-4.3.9.tar.gz"
   sha256 "8acdcc7c4b97558b36279ec26fd03d3c34b4fed20e06a84fa0ce667816c78a95"
 
   bottle do

--- a/Library/Formula/libzzip.rb
+++ b/Library/Formula/libzzip.rb
@@ -1,7 +1,7 @@
 class Libzzip < Formula
   desc "Library providing read access on ZIP-archives"
   homepage "http://sourceforge.net/projects/zziplib/"
-  url "https://downloads.sourceforge.net/project/zziplib/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/zziplib/zziplib13/0.13.62/zziplib-0.13.62.tar.bz2"
   sha256 "a1b8033f1a1fd6385f4820b01ee32d8eca818409235d22caf5119e0078c7525b"
 
   bottle do

--- a/Library/Formula/lifelines.rb
+++ b/Library/Formula/lifelines.rb
@@ -1,7 +1,7 @@
 class Lifelines < Formula
   desc "Text-based genealogy software"
   homepage "http://lifelines.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/lifelines/lifelines/3.0.62/lifelines-3.0.62.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lifelines/lifelines/3.0.62/lifelines-3.0.62.tar.gz"
   sha256 "2f00441ac0ed64aab8f76834c055e2b95600ed4c6f5845b9f6e5284ac58a9a52"
 
   def install

--- a/Library/Formula/little-cms.rb
+++ b/Library/Formula/little-cms.rb
@@ -1,7 +1,7 @@
 class LittleCms < Formula
   desc "Version 1 of the Little CMS library"
   homepage "http://www.littlecms.com/"
-  url "https://downloads.sourceforge.net/project/lcms/lcms/1.19/lcms-1.19.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lcms/lcms/1.19/lcms-1.19.tar.gz"
   sha256 "80ae32cb9f568af4dc7ee4d3c05a4c31fc513fc3e31730fed0ce7378237273a9"
   revision 1
 

--- a/Library/Formula/little-cms2.rb
+++ b/Library/Formula/little-cms2.rb
@@ -1,7 +1,7 @@
 class LittleCms2 < Formula
   desc "Color management engine supporting ICC profiles"
   homepage "http://www.littlecms.com/"
-  url "https://downloads.sourceforge.net/project/lcms/lcms/2.7/lcms2-2.7.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lcms/lcms/2.7/lcms2-2.7.tar.gz"
   sha256 "4524234ae7de185e6b6da5d31d6875085b2198bc63b1211f7dde6e2d197d6a53"
   revision 1
 

--- a/Library/Formula/log4c.rb
+++ b/Library/Formula/log4c.rb
@@ -1,7 +1,7 @@
 class Log4c < Formula
   desc "Logging Framework for C"
   homepage "http://log4c.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/log4c/log4c/1.2.4/log4c-1.2.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/log4c/log4c/1.2.4/log4c-1.2.4.tar.gz"
   sha256 "5991020192f52cc40fa852fbf6bbf5bd5db5d5d00aa9905c67f6f0eadeed48ea"
 
   head ":pserver:anonymous:@log4c.cvs.sourceforge.net:/cvsroot/log4c", :using => :cvs

--- a/Library/Formula/log4cplus.rb
+++ b/Library/Formula/log4cplus.rb
@@ -1,7 +1,7 @@
 class Log4cplus < Formula
   desc "Logging Framework for C++"
   homepage "http://log4cplus.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/log4cplus/log4cplus-stable/1.1.2/log4cplus-1.1.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/log4cplus/log4cplus-stable/1.1.2/log4cplus-1.1.2.tar.bz2"
   sha256 "c46d56c96873dcb525791b5ea639d1415e74b1de99d51b657336cb6ebb72ed93"
 
   option :cxx11

--- a/Library/Formula/log4cpp.rb
+++ b/Library/Formula/log4cpp.rb
@@ -1,7 +1,7 @@
 class Log4cpp < Formula
   desc "Configurable logging for C++"
   homepage "http://log4cpp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.1.tar.gz"
   sha256 "35abf332630a6809c969276b1d60b90c81a95daf24c86cfd7866ffef72f9bed0"
 
   def install

--- a/Library/Formula/lpc21isp.rb
+++ b/Library/Formula/lpc21isp.rb
@@ -1,7 +1,7 @@
 class Lpc21isp < Formula
   desc "In-circuit programming (ISP) tool for several NXP microcontrollers"
   homepage "http://lpc21isp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/lpc21isp/lpc21isp/1.97/lpc21isp_197.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lpc21isp/lpc21isp/1.97/lpc21isp_197.tar.gz"
   sha256 "9f7d80382e4b70bfa4200233466f29f73a36fea7dc604e32f05b9aa69ef591dc"
   version "1.97"
 

--- a/Library/Formula/lsdvd.rb
+++ b/Library/Formula/lsdvd.rb
@@ -1,7 +1,7 @@
 class Lsdvd < Formula
   desc "Read the content info of a DVD"
   homepage "http://sourceforge.net/projects/lsdvd"
-  url "https://downloads.sourceforge.net/project/lsdvd/lsdvd/0.16%20-%20I%20hate%20James%20Blunt/lsdvd-0.16.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/lsdvd/lsdvd/0.16%20-%20I%20hate%20James%20Blunt/lsdvd-0.16.tar.gz"
   sha256 "04ae3e2d823ed427e31d57f3677d28ec36bdf3bf984d35f7bdfab030d89b20f1"
 
   depends_on "libdvdread"

--- a/Library/Formula/luabind.rb
+++ b/Library/Formula/luabind.rb
@@ -1,7 +1,7 @@
 class Luabind < Formula
   desc "Library for bindings between C++ and Lua"
   homepage "http://www.rasterbar.com/products/luabind.html"
-  url "https://downloads.sourceforge.net/project/luabind/luabind/0.9.1/luabind-0.9.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/luabind/luabind/0.9.1/luabind-0.9.1.tar.gz"
   sha256 "80de5e04918678dd8e6dac3b22a34b3247f74bf744c719bae21faaa49649aaae"
   bottle do
     cellar :any

--- a/Library/Formula/luciddb.rb
+++ b/Library/Formula/luciddb.rb
@@ -1,7 +1,7 @@
 class Luciddb < Formula
   desc "DBMS optimized for business intelligence"
   homepage "http://www.luciddb.org/"
-  url "https://downloads.sourceforge.net/project/luciddb/luciddb/luciddb-0.9.4/luciddb-bin-macos32-0.9.4.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/luciddb/luciddb/luciddb-0.9.4/luciddb-bin-macos32-0.9.4.tar.bz2"
   sha256 "fe6caa93d63a97e412e2bc478e1a1bd99c2aa736b1dcfea665cbab94b8da8593"
 
   def shim_script(target)

--- a/Library/Formula/lxsplit.rb
+++ b/Library/Formula/lxsplit.rb
@@ -1,7 +1,7 @@
 class Lxsplit < Formula
   desc "Tool for splitting or joining files"
   homepage "http://lxsplit.sourceforge.net/"
-  url "https://downloads.sourceforge.net/lxsplit/lxsplit-0.2.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/lxsplit/lxsplit-0.2.4.tar.gz"
   sha256 "858fa939803b2eba97ccc5ec57011c4f4b613ff299abbdc51e2f921016845056"
 
   def install

--- a/Library/Formula/mac-robber.rb
+++ b/Library/Formula/mac-robber.rb
@@ -1,7 +1,7 @@
 class MacRobber < Formula
   desc "Digital investigation tool"
   homepage "http://www.sleuthkit.org/mac-robber/"
-  url "https://downloads.sourceforge.net/project/mac-robber/mac-robber/1.02/mac-robber-1.02.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mac-robber/mac-robber/1.02/mac-robber-1.02.tar.gz"
   sha256 "5895d332ec8d87e15f21441c61545b7f68830a2ee2c967d381773bd08504806d"
 
   def install

--- a/Library/Formula/mad.rb
+++ b/Library/Formula/mad.rb
@@ -1,7 +1,7 @@
 class Mad < Formula
   desc "MPEG audio decoder"
   homepage "http://www.underbit.com/products/mad/"
-  url "https://downloads.sourceforge.net/project/mad/libmad/0.15.1b/libmad-0.15.1b.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mad/libmad/0.15.1b/libmad-0.15.1b.tar.gz"
   sha256 "bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690"
 
   bottle do

--- a/Library/Formula/madplay.rb
+++ b/Library/Formula/madplay.rb
@@ -1,7 +1,7 @@
 class Madplay < Formula
   desc "MPEG Audio Decoder"
   homepage "http://www.underbit.com/products/mad/"
-  url "https://downloads.sourceforge.net/project/mad/madplay/0.15.2b/madplay-0.15.2b.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mad/madplay/0.15.2b/madplay-0.15.2b.tar.gz"
   sha256 "5a79c7516ff7560dffc6a14399a389432bc619c905b13d3b73da22fa65acede0"
 
   depends_on "mad"

--- a/Library/Formula/mailcheck.rb
+++ b/Library/Formula/mailcheck.rb
@@ -1,7 +1,7 @@
 class Mailcheck < Formula
   desc "Check multiple mailboxes/maildirs for mail"
   homepage "http://mailcheck.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mailcheck/mailcheck/1.91.2/mailcheck_1.91.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mailcheck/mailcheck/1.91.2/mailcheck_1.91.2.tar.gz"
   sha256 "6ca6da5c9f8cc2361d4b64226c7d9486ff0962602c321fc85b724babbbfa0a5c"
 
   def install

--- a/Library/Formula/mairix.rb
+++ b/Library/Formula/mairix.rb
@@ -1,7 +1,7 @@
 class Mairix < Formula
   desc "Email index and search tool"
   homepage "http://www.rpcurnow.force9.co.uk/mairix/"
-  url "https://downloads.sourceforge.net/project/mairix/mairix/0.23/mairix-0.23.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mairix/mairix/0.23/mairix-0.23.tar.gz"
   sha256 "804e235b183c3350071a28cdda8eb465bcf447092a8206f40486191875bdf2fb"
 
   head "https://github.com/rc0/mairix.git"

--- a/Library/Formula/makensis.rb
+++ b/Library/Formula/makensis.rb
@@ -1,7 +1,7 @@
 class Makensis < Formula
   desc "System to create Windows installers"
   homepage "http://nsis.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/nsis/NSIS%202/2.46/nsis-2.46-src.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/nsis/NSIS%202/2.46/nsis-2.46-src.tar.bz2"
   sha256 "f5f9e5e22505e44b25aea14fe17871c1ed324c1f3cc7a753ef591f76c9e8a1ae"
 
   depends_on "scons" => :build
@@ -12,7 +12,7 @@ class Makensis < Formula
   patch :DATA
 
   resource "nsis" do
-    url "https://downloads.sourceforge.net/project/nsis/NSIS%202/2.46/nsis-2.46.zip"
+    url "https://prdownloads.sourceforge.net/project/nsis/NSIS%202/2.46/nsis-2.46.zip"
     sha256 "ced6561f8aed81c8f3d6bc5a33684e03ca36a618110c0a849880c703337f26cc"
   end
 

--- a/Library/Formula/makepp.rb
+++ b/Library/Formula/makepp.rb
@@ -1,7 +1,7 @@
 class Makepp < Formula
   desc "Drop-in replacement for GNU make"
   homepage "http://makepp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/makepp/2.0/makepp-2.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/makepp/2.0/makepp-2.0.tgz"
   sha256 "d1b64c6f259ed50dfe0c66abedeb059e5043fc02ca500b2702863d96cdc15a19"
 
   def install

--- a/Library/Formula/mboxgrep.rb
+++ b/Library/Formula/mboxgrep.rb
@@ -1,7 +1,7 @@
 class Mboxgrep < Formula
   desc "Scan a mailbox for messages matching a regular expression"
   homepage "http://www.mboxgrep.org"
-  url "https://downloads.sourceforge.net/project/mboxgrep/mboxgrep/0.7.9/mboxgrep-0.7.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mboxgrep/mboxgrep/0.7.9/mboxgrep-0.7.9.tar.gz"
   sha256 "78d375a05c3520fad4bca88509d4da0dbe9fba31f36790bd20880e212acd99d7"
 
   depends_on "pcre"

--- a/Library/Formula/mcpp.rb
+++ b/Library/Formula/mcpp.rb
@@ -1,7 +1,7 @@
 class Mcpp < Formula
   desc "Alternative C/C++ preprocessor"
   homepage "http://mcpp.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mcpp/mcpp/V.2.7.2/mcpp-2.7.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mcpp/mcpp/V.2.7.2/mcpp-2.7.2.tar.gz"
   sha256 "3b9b4421888519876c4fc68ade324a3bbd81ceeb7092ecdbbc2055099fcb8864"
 
   # stpcpy is a macro on OS X; trying to define it as an extern is invalid.

--- a/Library/Formula/mcrypt.rb
+++ b/Library/Formula/mcrypt.rb
@@ -1,7 +1,7 @@
 class Mcrypt < Formula
   desc "Replacement for the old crypt package and crypt(1) command"
   homepage "http://mcrypt.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mcrypt/MCrypt/2.6.8/mcrypt-2.6.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mcrypt/MCrypt/2.6.8/mcrypt-2.6.8.tar.gz"
   sha256 "5145aa844e54cca89ddab6fb7dd9e5952811d8d787c4f4bf27eb261e6c182098"
 
   bottle do
@@ -17,7 +17,7 @@ class Mcrypt < Formula
   depends_on "mhash"
 
   resource "libmcrypt" do
-    url "https://downloads.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/mcrypt/Libmcrypt/2.5.8/libmcrypt-2.5.8.tar.gz"
     sha256 "e4eb6c074bbab168ac47b947c195ff8cef9d51a211cdd18ca9c9ef34d27a373e"
   end
 

--- a/Library/Formula/mecab-ipadic.rb
+++ b/Library/Formula/mecab-ipadic.rb
@@ -1,7 +1,7 @@
 class MecabIpadic < Formula
   desc "IPA dictionary compiled for MeCab"
   homepage "http://mecab.googlecode.com/svn/trunk/mecab/doc/index.html"
-  url "https://downloads.sourceforge.net/project/mecab/mecab-ipadic/2.7.0-20070801/mecab-ipadic-2.7.0-20070801.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mecab/mecab-ipadic/2.7.0-20070801/mecab-ipadic-2.7.0-20070801.tar.gz"
   sha256 "b62f527d881c504576baed9c6ef6561554658b175ce6ae0096a60307e49e3523"
 
   bottle do

--- a/Library/Formula/mecab-jumandic.rb
+++ b/Library/Formula/mecab-jumandic.rb
@@ -1,7 +1,7 @@
 class MecabJumandic < Formula
   desc "See mecab"
   homepage "http://mecab.googlecode.com/svn/trunk/mecab/doc/index.html"
-  url "https://downloads.sourceforge.net/project/mecab/mecab-jumandic/5.1-20070304/mecab-jumandic-5.1-20070304.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mecab/mecab-jumandic/5.1-20070304/mecab-jumandic-5.1-20070304.tar.gz"
   sha256 "042614dcc04afc68f1cfa2a32f353dc31b06f0674ebab3bfa8e67472709fe657"
 
   bottle do

--- a/Library/Formula/mergelog.rb
+++ b/Library/Formula/mergelog.rb
@@ -1,7 +1,7 @@
 class Mergelog < Formula
   desc "Merges httpd logs from web servers behind round-robin DNS"
   homepage "http://mergelog.sourceforge.net/"
-  url "https://downloads.sourceforge.net/mergelog/mergelog-4.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/mergelog/mergelog-4.5.tar.gz"
   sha256 "fd97c5b9ae88fbbf57d3be8d81c479e0df081ed9c4a0ada48b1ab8248a82676d"
 
   def install

--- a/Library/Formula/mhash.rb
+++ b/Library/Formula/mhash.rb
@@ -1,7 +1,7 @@
 class Mhash < Formula
   desc "Uniform interface to a large number of hash algorithms"
   homepage "http://mhash.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mhash/mhash/0.9.9.9/mhash-0.9.9.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mhash/mhash/0.9.9.9/mhash-0.9.9.9.tar.gz"
   sha256 "3dcad09a63b6f1f634e64168dd398e9feb9925560f9b671ce52283a79604d13e"
 
   bottle do

--- a/Library/Formula/minidjvu.rb
+++ b/Library/Formula/minidjvu.rb
@@ -1,7 +1,7 @@
 class Minidjvu < Formula
   desc "DjVu multipage encoder, single page encoder/decoder"
   homepage "http://minidjvu.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/minidjvu/minidjvu/0.8/minidjvu-0.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/minidjvu/minidjvu/0.8/minidjvu-0.8.tar.gz"
   sha256 "e9c892e0272ee4e560eaa2dbd16b40719b9797a1fa2749efeb6622f388dfb74a"
 
   depends_on "autoconf" => :build

--- a/Library/Formula/minidlna.rb
+++ b/Library/Formula/minidlna.rb
@@ -1,7 +1,7 @@
 class Minidlna < Formula
   desc "Media server software, compliant with DLNA/UPnP-AV clients"
   homepage "http://sourceforge.net/projects/minidlna/"
-  url "https://downloads.sourceforge.net/project/minidlna/minidlna/1.1.5/minidlna-1.1.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/minidlna/minidlna/1.1.5/minidlna-1.1.5.tar.gz"
   sha256 "8477ad0416bb2af5cd8da6dde6c07ffe1a413492b7fe40a362bc8587be15ab9b"
   revision 1
 

--- a/Library/Formula/mitie.rb
+++ b/Library/Formula/mitie.rb
@@ -19,7 +19,7 @@ class Mitie < Formula
   option "without-models", "Don't download the v0.2 models (~415MB)"
 
   resource "models-english" do
-    url "https://downloads.sourceforge.net/project/mitie/binaries/MITIE-models-v0.2.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/mitie/binaries/MITIE-models-v0.2.tar.bz2"
     sha256 "dc073eaef980e65d68d18c7193d94b9b727beb254a0c2978f39918f158d91b31"
   end
 

--- a/Library/Formula/mjpegtools.rb
+++ b/Library/Formula/mjpegtools.rb
@@ -1,7 +1,7 @@
 class Mjpegtools < Formula
   desc "Record and playback videos and perform simple edits"
   homepage "http://mjpeg.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mjpeg/mjpegtools/2.1.0/mjpegtools-2.1.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mjpeg/mjpegtools/2.1.0/mjpegtools-2.1.0.tar.gz"
   sha256 "864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
   revision 1
 

--- a/Library/Formula/mkclean.rb
+++ b/Library/Formula/mkclean.rb
@@ -1,7 +1,7 @@
 class Mkclean < Formula
   desc "Optimizes Matroska and WebM files"
   homepage "http://www.matroska.org/downloads/mkclean.html"
-  url "https://downloads.sourceforge.net/project/matroska/mkclean/mkclean-0.8.7.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/matroska/mkclean/mkclean-0.8.7.tar.bz2"
   sha256 "88713065a172d1ab7fd34c8854a42f6bf8d0e794957265340328a2f692ad46d9"
 
   # Fixes compile error with XCode-4.3+, a hardcoded /Developer.  Reported as:

--- a/Library/Formula/mkvalidator.rb
+++ b/Library/Formula/mkvalidator.rb
@@ -1,7 +1,7 @@
 class Mkvalidator < Formula
   desc "Tool to verify Matroska and WebM files for spec conformance"
   homepage "http://www.matroska.org/downloads/mkvalidator.html"
-  url "https://downloads.sourceforge.net/project/matroska/mkvalidator/mkvalidator-0.5.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/matroska/mkvalidator/mkvalidator-0.5.0.tar.bz2"
   sha256 "c3e72e5b49d32174415b9273ea8d52380e09ac63c8dc7db684104021c711c104"
 
   bottle do

--- a/Library/Formula/mldonkey.rb
+++ b/Library/Formula/mldonkey.rb
@@ -1,7 +1,7 @@
 class Mldonkey < Formula
   desc "OCaml/GTK client for the eDonkey P2P network"
   homepage "http://mldonkey.sourceforge.net/Main_Page"
-  url "https://downloads.sourceforge.net/project/mldonkey/mldonkey/3.1.5/mldonkey-3.1.5.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/mldonkey/mldonkey/3.1.5/mldonkey-3.1.5.tar.bz2"
   sha256 "74f9d4bcc72356aa28d0812767ef5b9daa03efc5d1ddabf56447dc04969911cb"
 
   bottle do

--- a/Library/Formula/mlt.rb
+++ b/Library/Formula/mlt.rb
@@ -1,7 +1,7 @@
 class Mlt < Formula
   desc "Author, manage, and run multitrack audio/video compositions"
   homepage "http://www.mltframework.org/"
-  url "https://downloads.sourceforge.net/mlt/mlt/mlt-0.9.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/mlt/mlt/mlt-0.9.6.tar.gz"
   sha256 "ab999992828a03dadbf62f6a131aada776cfd7afe63a94d994877fdba31a3000"
 
   bottle do

--- a/Library/Formula/modules.rb
+++ b/Library/Formula/modules.rb
@@ -1,7 +1,7 @@
 class Modules < Formula
   desc "Dynamic modification of a user's environment via modulefiles"
   homepage "http://modules.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/modules/Modules/modules-3.2.10/modules-3.2.10.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/modules/Modules/modules-3.2.10/modules-3.2.10.tar.bz2"
   sha256 "e8403492a8d57ace6485813ad6cdaafe0a735b7d93b9435553a8d11d3fdd29a2"
 
   depends_on :x11 => :optional

--- a/Library/Formula/mp3blaster.rb
+++ b/Library/Formula/mp3blaster.rb
@@ -1,7 +1,7 @@
 class Mp3blaster < Formula
   desc "Text-based mp3 player"
   homepage "http://mp3blaster.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mp3blaster/mp3blaster/mp3blaster-3.2.5/mp3blaster-3.2.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mp3blaster/mp3blaster/mp3blaster-3.2.5/mp3blaster-3.2.5.tar.gz"
   sha256 "129115742c77362cc3508eb7782702cfb44af2463a5453e8d19ea68abccedc29"
 
   depends_on "sdl"

--- a/Library/Formula/mp3gain.rb
+++ b/Library/Formula/mp3gain.rb
@@ -1,7 +1,7 @@
 class Mp3gain < Formula
   desc "Lossless mp3 normalizer with statistical analysis"
   homepage "http://mp3gain.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mp3gain/mp3gain/1.5.2/mp3gain-1_5_2_r2-src.zip"
+  url "https://prdownloads.sourceforge.net/project/mp3gain/mp3gain/1.5.2/mp3gain-1_5_2_r2-src.zip"
   version "1.5.2"
   sha256 "3378d32c8333c14f57622802f6a92b725f36ee45a6b181657b595b1b5d64260f"
 

--- a/Library/Formula/mp3splt.rb
+++ b/Library/Formula/mp3splt.rb
@@ -1,7 +1,7 @@
 class Mp3splt < Formula
   desc "Command-line interface to split MP3 and Ogg Vorbis files"
   homepage "http://mp3splt.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mp3splt/mp3splt/2.6.2/mp3splt-2.6.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mp3splt/mp3splt/2.6.2/mp3splt-2.6.2.tar.gz"
   sha256 "3ec32b10ddd8bb11af987b8cd1c76382c48d265d0ffda53041d9aceb1f103baa"
 
   bottle do

--- a/Library/Formula/mp3val.rb
+++ b/Library/Formula/mp3val.rb
@@ -1,7 +1,7 @@
 class Mp3val < Formula
   desc "Program for MPEG audio stream validation"
   homepage "http://mp3val.sourceforge.net/"
-  url "https://downloads.sourceforge.net/mp3val/mp3val-0.1.8-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/mp3val/mp3val-0.1.8-src.tar.gz"
   sha256 "95a16efe3c352bb31d23d68ee5cb8bb8ebd9868d3dcf0d84c96864f80c31c39f"
 
   bottle do

--- a/Library/Formula/mp3wrap.rb
+++ b/Library/Formula/mp3wrap.rb
@@ -1,7 +1,7 @@
 class Mp3wrap < Formula
   desc "Wrap two or more mp3 files in a single large file"
   homepage "http://mp3wrap.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mp3wrap/mp3wrap/mp3wrap%200.5/mp3wrap-0.5-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mp3wrap/mp3wrap/mp3wrap%200.5/mp3wrap-0.5-src.tar.gz"
   sha256 "1b4644f6b7099dcab88b08521d59d6f730fa211b5faf1f88bd03bf61fedc04e7"
 
   bottle do

--- a/Library/Formula/mpg321.rb
+++ b/Library/Formula/mpg321.rb
@@ -1,7 +1,7 @@
 class Mpg321 < Formula
   desc "Command-line MP3 player"
   homepage "http://mpg321.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mpg321/mpg321/0.3.2/mpg321_0.3.2.orig.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mpg321/mpg321/0.3.2/mpg321_0.3.2.orig.tar.gz"
   sha256 "056fcc03e3f5c5021ec74bb5053d32c4a3b89b4086478dcf81adae650eac284e"
 
   depends_on "mad"

--- a/Library/Formula/mpgtx.rb
+++ b/Library/Formula/mpgtx.rb
@@ -1,7 +1,7 @@
 class Mpgtx < Formula
   desc "Toolbox to manipulate MPEG files"
   homepage "http://mpgtx.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/mpgtx/mpgtx/1.3.1/mpgtx-1.3.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mpgtx/mpgtx/1.3.1/mpgtx-1.3.1.tar.gz"
   sha256 "8815e73e98b862f12ba1ef5eaaf49407cf211c1f668c5ee325bf04af27f8e377"
 
   def install

--- a/Library/Formula/msdl.rb
+++ b/Library/Formula/msdl.rb
@@ -1,7 +1,7 @@
 class Msdl < Formula
   desc "Downloader for various streaming protocols"
   homepage "http://msdl.sourceforge.net"
-  url "https://downloads.sourceforge.net/msdl/msdl-1.2.7-r2.tar.gz"
+  url "https://prdownloads.sourceforge.net/msdl/msdl-1.2.7-r2.tar.gz"
   version "1.2.7-r2"
   sha256 "0297e87bafcab885491b44f71476f5d5bfc648557e7d4ef36961d44dd430a3a1"
 

--- a/Library/Formula/mspdebug.rb
+++ b/Library/Formula/mspdebug.rb
@@ -1,7 +1,7 @@
 class Mspdebug < Formula
   desc "Debugger for use with MSP430 MCUs"
   homepage "http://mspdebug.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mspdebug/mspdebug-0.22.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/mspdebug/mspdebug-0.22.tar.gz"
   sha256 "9a0550f3c7911bcc4e3231fff652c8f14763eb6a945609ce715db7164bf76c55"
 
   depends_on "libusb-compat"

--- a/Library/Formula/mussh.rb
+++ b/Library/Formula/mussh.rb
@@ -1,7 +1,7 @@
 class Mussh < Formula
   desc "Multi-host SSH wrapper"
   homepage "http://mussh.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/mussh/mussh/1.0/mussh-1.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/mussh/mussh/1.0/mussh-1.0.tgz"
   sha256 "6ba883cfaacc3f54c2643e8790556ff7b17da73c9e0d4e18346a51791fedd267"
 
   def install

--- a/Library/Formula/nagios.rb
+++ b/Library/Formula/nagios.rb
@@ -1,7 +1,7 @@
 class Nagios < Formula
   desc "Network monitoring and management system"
   homepage "http://www.nagios.org/"
-  url "https://downloads.sourceforge.net/project/nagios/nagios-4.x/nagios-4.0.6/nagios-4.0.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/nagios/nagios-4.x/nagios-4.0.6/nagios-4.0.6.tar.gz"
   sha256 "d400190c771eb90e0ba16351f6358fa7e22e42a7be986f2066db63518a14397b"
 
   depends_on "gd"

--- a/Library/Formula/nant.rb
+++ b/Library/Formula/nant.rb
@@ -1,7 +1,7 @@
 class Nant < Formula
   desc ".NET build tool"
   homepage "http://nant.sourceforge.net/"
-  url "https://downloads.sourceforge.net/nant/nant/nant-0.92-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/nant/nant/nant-0.92-src.tar.gz"
   sha256 "72d4d585267ed7f03e1aa75087d96f4f8d49ee976c32d974c5ab1fef4d4f8305"
 
   bottle do

--- a/Library/Formula/naturaldocs.rb
+++ b/Library/Formula/naturaldocs.rb
@@ -1,7 +1,7 @@
 class Naturaldocs < Formula
   desc "Extensible, multi-language documentation generator"
   homepage "http://www.naturaldocs.org/"
-  url "https://downloads.sourceforge.net/project/naturaldocs/Stable%20Releases/1.52/NaturalDocs-1.52.zip"
+  url "https://prdownloads.sourceforge.net/project/naturaldocs/Stable%20Releases/1.52/NaturalDocs-1.52.zip"
   sha256 "3f13c99e15778afe6c5555084a083f856e93567b31b08acd1fd81afb10082681"
 
   def install

--- a/Library/Formula/nesc.rb
+++ b/Library/Formula/nesc.rb
@@ -1,7 +1,7 @@
 class Nesc < Formula
   desc "Programming language for deeply networked systems"
   homepage "http://nescc.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/nescc/nescc/v1.3.4/nesc-1.3.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/nescc/nescc/v1.3.4/nesc-1.3.4.tar.gz"
   sha256 "870f06797bc945523918d6318386f0b717d799f9c90adce645da246caa959558"
 
   def install

--- a/Library/Formula/net-snmp.rb
+++ b/Library/Formula/net-snmp.rb
@@ -1,7 +1,7 @@
 class NetSnmp < Formula
   desc "Implements SNMP v1, v2c, and v3, using IPv4 and IPv6"
   homepage "http://www.net-snmp.org/"
-  url "https://downloads.sourceforge.net/project/net-snmp/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/net-snmp/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz"
   sha256 "12ef89613c7707dc96d13335f153c1921efc9d61d3708ef09f3fc4a7014fb4f0"
 
   bottle do

--- a/Library/Formula/netcat.rb
+++ b/Library/Formula/netcat.rb
@@ -1,7 +1,7 @@
 class Netcat < Formula
   desc "Utility for managing network connections"
   homepage "http://netcat.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/netcat/netcat/0.7.1/netcat-0.7.1.tar.bz2"
   sha256 "b55af0bbdf5acc02d1eb6ab18da2acd77a400bafd074489003f3df09676332bb"
 
   bottle do

--- a/Library/Formula/nfdump.rb
+++ b/Library/Formula/nfdump.rb
@@ -1,7 +1,7 @@
 class Nfdump < Formula
   desc "Tools to collect and process netflow data on the command line"
   homepage "http://nfdump.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/nfdump/stable/nfdump-1.6.13/nfdump-1.6.13.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/nfdump/stable/nfdump-1.6.13/nfdump-1.6.13.tar.gz"
   sha256 "251533c316c9fe595312f477cdb051e9c667517f49fb7ac5b432495730e45693"
 
   bottle do

--- a/Library/Formula/ngrep.rb
+++ b/Library/Formula/ngrep.rb
@@ -1,7 +1,7 @@
 class Ngrep < Formula
   desc "network grep"
   homepage "http://ngrep.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ngrep/ngrep/1.45/ngrep-1.45.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/ngrep/ngrep/1.45/ngrep-1.45.tar.bz2"
   sha256 "aea6dd337da8781847c75b3b5b876e4de9c58520e0d77310679a979fc6402fa7"
   revision 1
 

--- a/Library/Formula/nrpe.rb
+++ b/Library/Formula/nrpe.rb
@@ -1,7 +1,7 @@
 class Nrpe < Formula
   desc "Nagios remote plugin executor"
   homepage "https://www.nagios.org/"
-  url "https://downloads.sourceforge.net/project/nagios/nrpe-2.x/nrpe-2.15/nrpe-2.15.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/nagios/nrpe-2.x/nrpe-2.15/nrpe-2.15.tar.gz"
   sha256 "66383b7d367de25ba031d37762d83e2b55de010c573009c6f58270b137131072"
   revision 1
 

--- a/Library/Formula/ocamlsdl.rb
+++ b/Library/Formula/ocamlsdl.rb
@@ -1,7 +1,7 @@
 class Ocamlsdl < Formula
   desc "OCaml interface with the SDL C library"
   homepage "http://ocamlsdl.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ocamlsdl/OCamlSDL/ocamlsdl-0.9.1/ocamlsdl-0.9.1.tar.gz"
   sha256 "abfb295b263dc11e97fffdd88ea1a28b46df8cc2b196777093e4fe7f509e4f8f"
   revision 1
 

--- a/Library/Formula/omniorb.rb
+++ b/Library/Formula/omniorb.rb
@@ -1,7 +1,7 @@
 class Omniorb < Formula
   desc "IOR and naming service utilities for omniORB"
   homepage "http://omniorb.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/omniorb/omniORB/omniORB-4.2.0/omniORB-4.2.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/omniorb/omniORB/omniORB-4.2.0/omniORB-4.2.0.tar.bz2"
   sha256 "74c273fc997c2881b128feb52182dbe067acfecc4cf37475f43c104338eba8bc"
 
   bottle do
@@ -13,7 +13,7 @@ class Omniorb < Formula
   depends_on "pkg-config" => :build
 
   resource "bindings" do
-    url "https://downloads.sourceforge.net/project/omniorb/omniORBpy/omniORBpy-4.2.0/omniORBpy-4.2.0.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/omniorb/omniORBpy/omniORBpy-4.2.0/omniORBpy-4.2.0.tar.bz2"
     sha256 "c82b3bafacbb93cfaace41765219155f2b24eb3781369bba0581feb1dc50fe5e"
   end
 

--- a/Library/Formula/onepass.rb
+++ b/Library/Formula/onepass.rb
@@ -23,7 +23,7 @@ class Onepass < Formula
   # https://github.com/swig/swig/issues/344
   # https://github.com/martinpaljak/M2Crypto/issues/60
   resource "swig304" do
-    url "https://downloads.sourceforge.net/project/swig/swig/swig-3.0.4/swig-3.0.4.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/swig/swig/swig-3.0.4/swig-3.0.4.tar.gz"
     sha256 "410ffa80ef5535244b500933d70c1b65206333b546ca5a6c89373afb65413795"
   end
 

--- a/Library/Formula/open-babel.rb
+++ b/Library/Formula/open-babel.rb
@@ -3,7 +3,7 @@ class OpenBabel < Formula
   homepage "http://www.openbabel.org"
 
   stable do
-    url "https://downloads.sourceforge.net/project/openbabel/openbabel/2.3.2/openbabel-2.3.2.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/openbabel/openbabel/2.3.2/openbabel-2.3.2.tar.gz"
     sha256 "4eaca26679aa6cc85ebf96af19191472ac63ca442c36b0427b369c3a25705188"
 
     # Patch to support libc++ in OS X 10.9+, backport of upstream commit c3abbddae78e654df9322ad1020ff79dd6332946

--- a/Library/Formula/open-ocd.rb
+++ b/Library/Formula/open-ocd.rb
@@ -1,7 +1,7 @@
 class OpenOcd < Formula
   desc "On-chip debugging, in-system programming and boundary-scan testing"
   homepage "http://sourceforge.net/projects/openocd/"
-  url "https://downloads.sourceforge.net/project/openocd/openocd/0.9.0/openocd-0.9.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/openocd/openocd/0.9.0/openocd-0.9.0.tar.bz2"
   sha256 "837042ac9a156b9363cbffa1fcdaf463bfb83a49331addf52e63119642b5f443"
 
   bottle do

--- a/Library/Formula/open-sp.rb
+++ b/Library/Formula/open-sp.rb
@@ -1,7 +1,7 @@
 class OpenSp < Formula
   desc "SGML parser"
   homepage "http://openjade.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/openjade/opensp/1.5.2/OpenSP-1.5.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/openjade/opensp/1.5.2/OpenSP-1.5.2.tar.gz"
   sha256 "57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce"
 
   bottle do

--- a/Library/Formula/opencore-amr.rb
+++ b/Library/Formula/opencore-amr.rb
@@ -1,7 +1,7 @@
 class OpencoreAmr < Formula
   desc "Audio codecs extracted from Android open source project"
   homepage "http://opencore-amr.sourceforge.net/"
-  url "https://downloads.sourceforge.net/opencore-amr/opencore-amr-0.1.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/opencore-amr/opencore-amr-0.1.3.tar.gz"
   sha256 "106bf811c1f36444d7671d8fd2589f8b2e0cca58a2c764da62ffc4a070595385"
 
   def install

--- a/Library/Formula/opensc.rb
+++ b/Library/Formula/opensc.rb
@@ -1,7 +1,7 @@
 class Opensc < Formula
   desc "Tools and libraries for smart cards"
   homepage "https://github.com/OpenSC/OpenSC/wiki"
-  url "https://downloads.sourceforge.net/project/opensc/OpenSC/opensc-0.15.0/opensc-0.15.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/opensc/OpenSC/opensc-0.15.0/opensc-0.15.0.tar.gz"
   sha256 "399b2107a69e3f67e4e76dc2dbd951dbced8e534b1e0f919e176aea9b85970d7"
   head "https://github.com/OpenSC/OpenSC.git"
 

--- a/Library/Formula/openslp.rb
+++ b/Library/Formula/openslp.rb
@@ -1,7 +1,7 @@
 class Openslp < Formula
   desc "Implementation of Service Location Protocol"
   homepage "http://www.openslp.org"
-  url "https://downloads.sourceforge.net/project/openslp/2.0.0/2.0.0%20Release/openslp-2.0.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/openslp/2.0.0/2.0.0%20Release/openslp-2.0.0.tar.gz"
   sha256 "924337a2a8e5be043ebaea2a78365c7427ac6e9cee24610a0780808b2ba7579b"
 
   def install

--- a/Library/Formula/ophcrack.rb
+++ b/Library/Formula/ophcrack.rb
@@ -1,7 +1,7 @@
 class Ophcrack < Formula
   desc "Microsoft Windows password cracker using rainbow tables"
   homepage "http://ophcrack.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ophcrack/ophcrack/3.6.0/ophcrack-3.6.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/ophcrack/ophcrack/3.6.0/ophcrack-3.6.0.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/o/ophcrack/ophcrack_3.6.0.orig.tar.bz2"
   sha256 "79219baa03afd7e52bc6d365dd5a445bc73dfac2e88216e7b050ad7749191893"
   revision 1

--- a/Library/Formula/optipng.rb
+++ b/Library/Formula/optipng.rb
@@ -2,7 +2,7 @@ class Optipng < Formula
   desc "PNG file optimizer"
   homepage "http://optipng.sourceforge.net/"
   head "http://hg.code.sf.net/p/optipng/mercurial", :using => :hg
-  url "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.5/optipng-0.7.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.5/optipng-0.7.5.tar.gz"
   sha256 "74e54b798b012dff8993fb8d90185ca83f18cfa4935f4a93b0bcfc33c849619d"
 
   # Fix compilation on 10.10

--- a/Library/Formula/orfeo.rb
+++ b/Library/Formula/orfeo.rb
@@ -1,7 +1,7 @@
 class Orfeo < Formula
   desc "Library of image processing algorithms"
   homepage "http://www.orfeo-toolbox.org/otb/"
-  url "https://downloads.sourceforge.net/project/orfeo-toolbox/OTB/OTB-3.20/OTB-3.20.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/orfeo-toolbox/OTB/OTB-3.20/OTB-3.20.0.tgz"
   sha256 "7c405756887842fbdfd6eb99a1fdc3c940817290a99c188414e5af45702d1b9d"
 
   depends_on "cmake" => :build

--- a/Library/Formula/owfs.rb
+++ b/Library/Formula/owfs.rb
@@ -1,7 +1,7 @@
 class Owfs < Formula
   desc "Monitor and control physical environment using Dallas/Maxim 1-wire system"
   homepage "http://owfs.org/"
-  url "https://downloads.sourceforge.net/project/owfs/owfs/3.1p0/owfs-3.1p0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/owfs/owfs/3.1p0/owfs-3.1p0.tar.gz"
   version "3.1p0"
   sha256 "62fca1b3e908cd4515c9eb499bf2b05020bbbea4a5b73611ddc6f205adec7a54"
 

--- a/Library/Formula/paps.rb
+++ b/Library/Formula/paps.rb
@@ -1,7 +1,7 @@
 class Paps < Formula
   desc "Pango to PostScript converter"
   homepage "http://paps.sourceforge.net/"
-  url "https://downloads.sourceforge.net/paps/paps-0.6.8.tar.gz"
+  url "https://prdownloads.sourceforge.net/paps/paps-0.6.8.tar.gz"
   sha256 "db214c4ea7ecde2f7986b869f6249864d3ff364e6f210c15aa2824bcbd850a20"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/par2.rb
+++ b/Library/Formula/par2.rb
@@ -1,7 +1,7 @@
 class Par2 < Formula
   desc "Parchive: Parity Archive Volume Set for data recovery"
   homepage "http://parchive.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/parchive/par2cmdline/0.4/par2cmdline-0.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/parchive/par2cmdline/0.4/par2cmdline-0.4.tar.gz"
   sha256 "9e32b7dbcf7bca8249f98824757d4868714156fe2276516504cd26f736e9f677"
 
   bottle do

--- a/Library/Formula/pcal.rb
+++ b/Library/Formula/pcal.rb
@@ -1,7 +1,7 @@
 class Pcal < Formula
   desc "Generate Postscript calendars without X"
   homepage "http://pcal.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pcal/pcal/pcal-4.11.0/pcal-4.11.0.tgz"
+  url "https://prdownloads.sourceforge.net/project/pcal/pcal/pcal-4.11.0/pcal-4.11.0.tgz"
   sha256 "8406190e7912082719262b71b63ee31a98face49aa52297db96cc0c970f8d207"
 
   def install

--- a/Library/Formula/pcre.rb
+++ b/Library/Formula/pcre.rb
@@ -1,7 +1,7 @@
 class Pcre < Formula
   desc "Perl compatible regular expressions library"
   homepage "http://www.pcre.org/"
-  url "https://downloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/pcre/pcre/8.45/pcre-8.45.tar.bz2"
   sha256 "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
 
   bottle do

--- a/Library/Formula/pdfcrack.rb
+++ b/Library/Formula/pdfcrack.rb
@@ -1,7 +1,7 @@
 class Pdfcrack < Formula
   desc "PDF files password cracker"
   homepage "http://pdfcrack.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pdfcrack/pdfcrack/pdfcrack-0.14/pdfcrack-0.14.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pdfcrack/pdfcrack/pdfcrack-0.14/pdfcrack-0.14.tar.gz"
   sha256 "ac88eca576cebb40c4a63cd90542664de7d8f1b39885db5a7ac021d8b0c6a95c"
 
   def install

--- a/Library/Formula/pdftohtml.rb
+++ b/Library/Formula/pdftohtml.rb
@@ -1,7 +1,7 @@
 class Pdftohtml < Formula
   desc "PDF to HTML converter (based on xpdf)"
   homepage "http://pdftohtml.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pdftohtml/Experimental%20Versions/pdftohtml%200.40/pdftohtml-0.40a.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pdftohtml/Experimental%20Versions/pdftohtml%200.40/pdftohtml-0.40a.tar.gz"
   sha256 "277ec1c75231b0073a458b1bfa2f98b7a115f5565e53494822ec7f0bcd8d4655"
 
   conflicts_with "poppler", :because => "both install `pdftohtml` binaries"

--- a/Library/Formula/perceptualdiff.rb
+++ b/Library/Formula/perceptualdiff.rb
@@ -1,7 +1,7 @@
 class Perceptualdiff < Formula
   desc "Perceptual image comparison tool"
   homepage "http://pdiff.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pdiff/pdiff/perceptualdiff-1.1.1/perceptualdiff-1.1.1-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pdiff/pdiff/perceptualdiff-1.1.1/perceptualdiff-1.1.1-src.tar.gz"
   sha256 "ab349279a63018663930133b04852bde2f6a373cc175184b615944a10c1c7c6a"
 
   depends_on "cmake" => :build

--- a/Library/Formula/pev.rb
+++ b/Library/Formula/pev.rb
@@ -1,7 +1,7 @@
 class Pev < Formula
   desc "PE analysis toolkit"
   homepage "http://pev.sf.net/"
-  url "https://downloads.sourceforge.net/project/pev/pev-0.70/pev-0.70.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pev/pev-0.70/pev-0.70.tar.gz"
   sha256 "250396a06930d60a92e9bc86d7afb543d899ba12c007d1be5d09802a02908202"
   revision 1
 

--- a/Library/Formula/pgbadger.rb
+++ b/Library/Formula/pgbadger.rb
@@ -1,7 +1,7 @@
 class Pgbadger < Formula
   desc "Log analyzer for PostgreSQL"
   homepage "https://dalibo.github.io/pgbadger/"
-  url "https://downloads.sourceforge.net/project/pgbadger/6.4/pgbadger-6.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pgbadger/6.4/pgbadger-6.4.tar.gz"
   sha256 "a2a3b38e64c20b95d3ae395f93f41cda30492f844885a7ec5d5b2fbb090ec2f3"
 
   head "https://github.com/dalibo/pgbadger.git"

--- a/Library/Formula/pgdbf.rb
+++ b/Library/Formula/pgdbf.rb
@@ -1,7 +1,7 @@
 class Pgdbf < Formula
   desc "Converter of XBase/FoxPro tables to PostgreSQL"
   homepage "https://github.com/kstrauser/pgdbf"
-  url "https://downloads.sourceforge.net/project/pgdbf/pgdbf/0.6.2/pgdbf-0.6.2.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/pgdbf/pgdbf/0.6.2/pgdbf-0.6.2.tar.xz"
   sha256 "e46f75e9ac5f500bd12c4542b215ea09f4ebee638d41dcfd642be8e9769aa324"
 
   def install

--- a/Library/Formula/pidgin.rb
+++ b/Library/Formula/pidgin.rb
@@ -1,7 +1,7 @@
 class Pidgin < Formula
   desc "Multi-protocol chat client"
   homepage "https://pidgin.im/"
-  url "https://downloads.sourceforge.net/project/pidgin/Pidgin/2.10.11/pidgin-2.10.11.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/pidgin/Pidgin/2.10.11/pidgin-2.10.11.tar.bz2"
   sha256 "f2ae211341fc77efb9945d40e9932aa535cdf3a6c8993fe7919fca8cc1c04007"
   revision 1
 

--- a/Library/Formula/plplot.rb
+++ b/Library/Formula/plplot.rb
@@ -1,7 +1,7 @@
 class Plplot < Formula
   desc "Cross-platform software package for creating scientific plots"
   homepage "http://plplot.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/plplot/plplot/5.11.1%20Source/plplot-5.11.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/plplot/plplot/5.11.1%20Source/plplot-5.11.1.tar.gz"
   sha256 "289dff828c440121e57b70538b3f0fb4056dc47159bc1819ea444321f2ff1c4c"
 
   bottle do

--- a/Library/Formula/pms.rb
+++ b/Library/Formula/pms.rb
@@ -1,7 +1,7 @@
 class Pms < Formula
   desc "Practical Music Search, an ncurses-based MPD client"
   homepage "http://pms.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/pms/pms/0.42/pms-0.42.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/pms/pms/0.42/pms-0.42.tar.bz2"
   sha256 "96bf942b08cba10ee891a63eeccad307fd082ef3bd20be879f189e1959e775a6"
 
   bottle do

--- a/Library/Formula/pngcheck.rb
+++ b/Library/Formula/pngcheck.rb
@@ -1,7 +1,7 @@
 class Pngcheck < Formula
   desc "Print info and check PNG, JNG, and MNG files"
   homepage "http://www.libpng.org/pub/png/apps/pngcheck.html"
-  url "https://downloads.sourceforge.net/project/png-mng/pngcheck/2.3.0/pngcheck-2.3.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/png-mng/pngcheck/2.3.0/pngcheck-2.3.0.tar.gz"
   sha256 "77f0a039ac64df55fbd06af6f872fdbad4f639d009bbb5cd5cbe4db25690f35f"
   revision 1
 

--- a/Library/Formula/pngnq.rb
+++ b/Library/Formula/pngnq.rb
@@ -1,7 +1,7 @@
 class Pngnq < Formula
   desc "Tool for optimizing PNG images"
   homepage "http://pngnq.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pngnq/pngnq/1.1/pngnq-1.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pngnq/pngnq/1.1/pngnq-1.1.tar.gz"
   sha256 "c147fe0a94b32d323ef60be9fdcc9b683d1a82cd7513786229ef294310b5b6e2"
   revision 1
 

--- a/Library/Formula/podofo.rb
+++ b/Library/Formula/podofo.rb
@@ -1,7 +1,7 @@
 class Podofo < Formula
   desc "Library to work with the PDF file format"
   homepage "http://podofo.sourceforge.net"
-  url "https://downloads.sourceforge.net/podofo/podofo-0.9.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/podofo/podofo-0.9.3.tar.gz"
   sha256 "ec261e31e89dce45b1a31be61e9c6bb250532e631a02d68ec5bb849ef0a222d8"
   revision 1
 

--- a/Library/Formula/polyml.rb
+++ b/Library/Formula/polyml.rb
@@ -1,7 +1,7 @@
 class Polyml < Formula
   desc "Standard ML implementation"
   homepage "http://www.polyml.org"
-  url "https://downloads.sourceforge.net/project/polyml/polyml/5.5.2/polyml.5.5.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/polyml/polyml/5.5.2/polyml.5.5.2.tar.gz"
   sha256 "73fd2be89f7e3ff0567e27ef525ef788775d9f963d6db54069cb34d53040a682"
 
   def install

--- a/Library/Formula/portmidi.rb
+++ b/Library/Formula/portmidi.rb
@@ -1,7 +1,7 @@
 class Portmidi < Formula
   desc "Cross-platform library for real-time MIDI I/O"
   homepage "http://sourceforge.net/apps/trac/portmedia/wiki/portmidi"
-  url "https://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip"
+  url "https://prdownloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip"
   sha256 "08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f"
 
   option "with-java", "Build java based app and bindings. You need the Java SDK for this."

--- a/Library/Formula/postgres-xc.rb
+++ b/Library/Formula/postgres-xc.rb
@@ -1,7 +1,7 @@
 class PostgresXc < Formula
   desc "PostgreSQL cluster based on shared-nothing architecture"
   homepage "http://postgres-xc.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/postgres-xc/Version_1.0/pgxc-v1.0.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/postgres-xc/Version_1.0/pgxc-v1.0.3.tar.gz"
   sha256 "60ae1e42e977f78785090743161867dc838e3c8e1db0ac836dcfa23c8f1db8dd"
   revision 2
 

--- a/Library/Formula/premake.rb
+++ b/Library/Formula/premake.rb
@@ -1,7 +1,7 @@
 class Premake < Formula
   desc "Premake is a build script generator"
   homepage "http://industriousone.com/premake"
-  url "https://downloads.sourceforge.net/project/premake/Premake/4.3/premake-4.3-src.zip"
+  url "https://prdownloads.sourceforge.net/project/premake/Premake/4.3/premake-4.3-src.zip"
   sha256 "36536490f8928d8ecde135da80cd8b751ea5bebe50cabba5c0de49cd41cb2780"
 
   bottle do
@@ -12,7 +12,7 @@ class Premake < Formula
   end
 
   devel do
-    url "https://downloads.sourceforge.net/project/premake/Premake/4.4/premake-4.4-beta5-src.zip"
+    url "https://prdownloads.sourceforge.net/project/premake/Premake/4.4/premake-4.4-beta5-src.zip"
     sha256 "0fa1ed02c5229d931e87995123cdb11d44fcc8bd99bba8e8bb1bbc0aaa798161"
   end
 

--- a/Library/Formula/privoxy.rb
+++ b/Library/Formula/privoxy.rb
@@ -1,7 +1,7 @@
 class Privoxy < Formula
   desc "Advanced filtering web proxy"
   homepage "http://www.privoxy.org"
-  url "https://downloads.sourceforge.net/project/ijbswa/Sources/3.0.23%20%28stable%29/privoxy-3.0.23-stable-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ijbswa/Sources/3.0.23%20%28stable%29/privoxy-3.0.23-stable-src.tar.gz"
   sha256 "80b1a172d0518a9f95cde83d18dc62b9c7f117b9ada77bdcd3d310107f28f964"
 
   bottle do

--- a/Library/Formula/proctools.rb
+++ b/Library/Formula/proctools.rb
@@ -1,7 +1,7 @@
 class Proctools < Formula
   desc "pgrep, pkill, and pfind for OpenBSD and Darwin (OS X)"
   homepage "http://proctools.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/proctools/proctools/0.4pre1/proctools-0.4pre1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/proctools/proctools/0.4pre1/proctools-0.4pre1.tar.gz"
   version "0.4pre1"
   sha256 "4553b9c6eda959b12913bc39b6e048a8a66dad18f888f983697fece155ec5538"
 

--- a/Library/Formula/proguard.rb
+++ b/Library/Formula/proguard.rb
@@ -1,7 +1,7 @@
 class Proguard < Formula
   desc "Java class file shrinker, optimizer, and obfuscator"
   homepage "http://proguard.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/proguard/proguard/5.2/proguard5.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/proguard/proguard/5.2/proguard5.2.1.tar.gz"
   sha256 "162fb2816212c6a7a195884a01ff826920919e97f57914a5b00bdf7641fc00f6"
 
   def install

--- a/Library/Formula/proxychains-ng.rb
+++ b/Library/Formula/proxychains-ng.rb
@@ -1,7 +1,7 @@
 class ProxychainsNg < Formula
   desc "Hook preloader"
   homepage "https://sourceforge.net/projects/proxychains-ng/"
-  url "https://downloads.sourceforge.net/project/proxychains-ng/proxychains-4.10.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/proxychains-ng/proxychains-4.10.tar.bz2"
   sha256 "3784eef241f022a68a1a0c41a0c225f6edcf4c3ce3bee1cea99ba342084e1f8a"
 
   head "https://github.com/rofl0r/proxychains-ng.git"

--- a/Library/Formula/proxytunnel.rb
+++ b/Library/Formula/proxytunnel.rb
@@ -1,7 +1,7 @@
 class Proxytunnel < Formula
   desc "Create TCP tunnels through HTTPS proxies"
   homepage "http://proxytunnel.sourceforge.net/"
-  url "https://downloads.sourceforge.net/proxytunnel/proxytunnel-1.9.0.tgz"
+  url "https://prdownloads.sourceforge.net/proxytunnel/proxytunnel-1.9.0.tgz"
   sha256 "2ef5bbf8d81ddf291d71f865c5dab89affcc07c4cb4b3c3f23e1e9462721a6b9"
   revision 1
 

--- a/Library/Formula/pstoedit.rb
+++ b/Library/Formula/pstoedit.rb
@@ -1,7 +1,7 @@
 class Pstoedit < Formula
   desc "Convert PostScript and PDF files to editable vector graphics"
   homepage "http://www.pstoedit.net"
-  url "https://downloads.sourceforge.net/project/pstoedit/pstoedit/3.70/pstoedit-3.70.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pstoedit/pstoedit/3.70/pstoedit-3.70.tar.gz"
   sha256 "06b86113f7847cbcfd4e0623921a8763143bbcaef9f9098e6def650d1ff8138c"
 
   bottle do

--- a/Library/Formula/puf.rb
+++ b/Library/Formula/puf.rb
@@ -1,7 +1,7 @@
 class Puf < Formula
   desc "Parallel URL fetcher"
   homepage "http://puf.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/puf/puf/1.0.0/puf-1.0.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/puf/puf/1.0.0/puf-1.0.0.tar.gz"
   sha256 "3f1602057dc47debeb54effc2db9eadcffae266834389bdbf5ab14fc611eeaf0"
 
   def install

--- a/Library/Formula/putmail-queue.rb
+++ b/Library/Formula/putmail-queue.rb
@@ -1,7 +1,7 @@
 class PutmailQueue < Formula
   desc "Putmail queue package"
   homepage "http://putmail.sourceforge.net/home.html"
-  url "https://downloads.sourceforge.net/project/putmail/putmail-queue/0.2/putmail-queue-0.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/putmail/putmail-queue/0.2/putmail-queue-0.2.tar.bz2"
   sha256 "09349ad26345783e061bfe4ad7586fbbbc5d1cc48e45faa9ba9f667104f9447c"
 
   depends_on "putmail"

--- a/Library/Formula/putmail.rb
+++ b/Library/Formula/putmail.rb
@@ -1,7 +1,7 @@
 class Putmail < Formula
   desc "MTA or SMTP client designed to replace the sendmail command"
   homepage "http://putmail.sourceforge.net/home.html"
-  url "https://downloads.sourceforge.net/project/putmail/putmail.py/1.4/putmail.py-1.4.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/putmail/putmail.py/1.4/putmail.py-1.4.tar.bz2"
   sha256 "1f4e6f33496100ad89b8f029621fb78ab2f80258994c7cd8687fd46730df45be"
 
   def install

--- a/Library/Formula/pwgen.rb
+++ b/Library/Formula/pwgen.rb
@@ -1,7 +1,7 @@
 class Pwgen < Formula
   desc "Password generator"
   homepage "http://pwgen.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pwgen/pwgen/2.07/pwgen-2.07.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pwgen/pwgen/2.07/pwgen-2.07.tar.gz"
   sha256 "eb74593f58296c21c71cd07933e070492e9222b79cedf81d1a02ce09c0e11556"
 
   def install

--- a/Library/Formula/pyqt5.rb
+++ b/Library/Formula/pyqt5.rb
@@ -1,7 +1,7 @@
 class Pyqt5 < Formula
   desc "Python bindings for v5 of Qt"
   homepage "http://www.riverbankcomputing.co.uk/software/pyqt/download5"
-  url "https://downloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.5/PyQt-gpl-5.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pyqt/PyQt5/PyQt-5.5/PyQt-gpl-5.5.tar.gz"
   sha256 "cdd1bb55b431acdb50e9210af135428a13fb32d7b1ab86e972ac7101f6acd814"
   revision 1
 

--- a/Library/Formula/pyqwt.rb
+++ b/Library/Formula/pyqwt.rb
@@ -1,7 +1,7 @@
 class Pyqwt < Formula
   desc "Python bindings for Qwt, widgets for science and engineering"
   homepage "http://pyqwt.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/pyqwt/pyqwt5/PyQwt-5.2.0/PyQwt-5.2.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pyqwt/pyqwt5/PyQwt-5.2.0/PyQwt-5.2.0.tar.gz"
   sha256 "98a8c7e0c76d07701c11dffb77793b05f071b664a8b520d6e97054a98179e70b"
 
   bottle do

--- a/Library/Formula/qjson.rb
+++ b/Library/Formula/qjson.rb
@@ -1,7 +1,7 @@
 class Qjson < Formula
   desc "Map JSON to QVariant objects"
   homepage "http://qjson.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/qjson/qjson/0.8.1/qjson-0.8.1.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/qjson/qjson/0.8.1/qjson-0.8.1.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/q/qjson/qjson_0.8.1.orig.tar.bz2"
   sha256 "cd4db5b956247c4991a9c3e95512da257cd2a6bd011357e363d02300afc814d9"
   head "https://github.com/flavio/qjson.git"

--- a/Library/Formula/qpdf.rb
+++ b/Library/Formula/qpdf.rb
@@ -1,7 +1,7 @@
 class Qpdf < Formula
   desc "Tools for and transforming and inspecting PDF files"
   homepage "http://qpdf.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/qpdf/qpdf/5.1.3/qpdf-5.1.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/qpdf/qpdf/5.1.3/qpdf-5.1.3.tar.gz"
   sha256 "d5164bdad3afc381568dbe8e1509a4a6a911d4d077f1fc20b9866ef8fad901d3"
 
   bottle do

--- a/Library/Formula/qstat.rb
+++ b/Library/Formula/qstat.rb
@@ -1,7 +1,7 @@
 class Qstat < Formula
   desc "Query Quake servers from the command-line"
   homepage "http://qstat.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/qstat/qstat/qstat-2.11/qstat-2.11.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/qstat/qstat/qstat-2.11/qstat-2.11.tar.gz"
   sha256 "16f0c0f55567597d7f2db5136a0858c56effb4481a2c821a48cd0432ea572150"
 
   def install

--- a/Library/Formula/quazip.rb
+++ b/Library/Formula/quazip.rb
@@ -1,7 +1,7 @@
 class Quazip < Formula
   desc "C++ wrapper over Gilles Vollant's ZIP/UNZIP package"
   homepage "http://quazip.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/quazip/quazip/0.7.1/quazip-0.7.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/quazip/quazip/0.7.1/quazip-0.7.1.tar.gz"
   sha256 "78c984103555c51e6f7ef52e3a2128e2beb9896871b2cc4d4dbd4d64bff132de"
 
   bottle do

--- a/Library/Formula/queequeg.rb
+++ b/Library/Formula/queequeg.rb
@@ -1,7 +1,7 @@
 class Queequeg < Formula
   desc "English grammar checker for non-native speakers"
   homepage "http://queequeg.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/queequeg/queequeg/queequeg-0.91/queequeg-0.91.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/queequeg/queequeg/queequeg-0.91/queequeg-0.91.tar.gz"
   sha256 "44e2f2bb8b68d08b7ee95ece24cefeeea8ec6ff9150851922015b73fc8908136"
 
   bottle do

--- a/Library/Formula/quvi.rb
+++ b/Library/Formula/quvi.rb
@@ -1,7 +1,7 @@
 class Quvi < Formula
   desc "Parse video download URLs"
   homepage "http://quvi.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/quvi/0.4/quvi/quvi-0.4.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/quvi/0.4/quvi/quvi-0.4.2.tar.bz2"
   sha256 "1f4e40c14373cb3d358ae1b14a427625774fd09a366b6da0c97d94cb1ff733c3"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/qwt.rb
+++ b/Library/Formula/qwt.rb
@@ -1,7 +1,7 @@
 class Qwt < Formula
   desc "Qt Widgets for Technical Applications (v5.1)"
   homepage "http://qwt.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2"
   sha256 "2b08f18d1d3970e7c3c6096d850f17aea6b54459389731d3ce715d193e243d0c"
 
   bottle do

--- a/Library/Formula/rcssserver.rb
+++ b/Library/Formula/rcssserver.rb
@@ -1,7 +1,7 @@
 class Rcssserver < Formula
   desc "Server for RoboCup Soccer Simulator"
   homepage "http://sserver.sourceforge.net/"
-  url "https://downloads.sourceforge.net/sserver/rcssserver/15.2.2/rcssserver-15.2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/sserver/rcssserver/15.2.2/rcssserver-15.2.2.tar.gz"
   sha256 "329b3008689dac16d1f39ad8f5c8341aef283ef3750d137dcf299d1fbc30355a"
   revision 1
 
@@ -14,12 +14,12 @@ class Rcssserver < Formula
 
   stable do
     resource "rcssmonitor" do
-      url "https://downloads.sourceforge.net/sserver/rcssmonitor/15.1.1/rcssmonitor-15.1.1.tar.gz"
+      url "https://prdownloads.sourceforge.net/sserver/rcssmonitor/15.1.1/rcssmonitor-15.1.1.tar.gz"
       sha256 "51f85f65cd147f5a9018a6a2af117fc45358eb2989399343eaadd09f2184ee41"
     end
 
     resource "rcsslogplayer" do
-      url "https://downloads.sourceforge.net/sserver/rcsslogplayer/15.1.1/rcsslogplayer-15.1.1.tar.gz"
+      url "https://prdownloads.sourceforge.net/sserver/rcsslogplayer/15.1.1/rcsslogplayer-15.1.1.tar.gz"
       sha256 "216473a9300e0733f66054345b8ea0afc50ce922341ac48eb5ef03d09bb740e6"
     end
   end

--- a/Library/Formula/regina-rexx.rb
+++ b/Library/Formula/regina-rexx.rb
@@ -1,7 +1,7 @@
 class ReginaRexx < Formula
   desc "Regina REXX interpreter"
   homepage "http://regina-rexx.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/regina-rexx/regina-rexx/3.9.1/Regina-REXX-3.9.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/regina-rexx/regina-rexx/3.9.1/Regina-REXX-3.9.1.tar.gz"
   sha256 "5d13df26987e27f25e7779a2efa87a5775213beeda449a9efac59b57a5d5f3ee"
 
   bottle do

--- a/Library/Formula/remake.rb
+++ b/Library/Formula/remake.rb
@@ -1,7 +1,7 @@
 class Remake < Formula
   desc "GNU Make with improved error handling, tracing, and a debugger"
   homepage "http://bashdb.sourceforge.net/remake/"
-  url "https://downloads.sourceforge.net/project/bashdb/remake/4.1%2Bdbg-0.91/remake-4.1%2Bdbg0.91.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/bashdb/remake/4.1%2Bdbg-0.91/remake-4.1%2Bdbg0.91.tar.bz2"
   sha256 "02a1c62b47e99376701f8d99b45fffdf44e8512ecf92794fc6bf5d6779900dfb"
 
   bottle do

--- a/Library/Formula/rhash.rb
+++ b/Library/Formula/rhash.rb
@@ -1,7 +1,7 @@
 class Rhash < Formula
   desc "Utility for computing and verifying hash sums of files"
   homepage "http://rhash.anz.ru/"
-  url "https://downloads.sourceforge.net/project/rhash/rhash/1.3.3/rhash-1.3.3-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/rhash/rhash/1.3.3/rhash-1.3.3-src.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/r/rhash/rhash_1.3.3.orig.tar.gz"
   sha256 "5b520b597bd83f933d316fce1382bb90e0b0b87b559b8c9c9a197551c935315a"
 

--- a/Library/Formula/rig.rb
+++ b/Library/Formula/rig.rb
@@ -1,7 +1,7 @@
 class Rig < Formula
   desc "Provides fake name and address data"
   homepage "http://rig.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/rig/rig/1.11/rig-1.11.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/rig/rig/1.11/rig-1.11.tar.gz"
   sha256 "00bfc970d5c038c1e68bc356c6aa6f9a12995914b7d4fda69897622cb5b77ab8"
 
   def install

--- a/Library/Formula/rkflashtool.rb
+++ b/Library/Formula/rkflashtool.rb
@@ -1,7 +1,7 @@
 class Rkflashtool < Formula
   desc "Tools for flashing Rockchip devices"
   homepage "https://sourceforge.net/projects/rkflashtool/"
-  url "https://downloads.sourceforge.net/project/rkflashtool/rkflashtool-5.1/rkflashtool-5.1-src.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/rkflashtool/rkflashtool-5.1/rkflashtool-5.1-src.tar.bz2"
   sha256 "2cad0e0c116357b721a6ac98fb3a91b43fe0269cda66e75eda4adec3330b7735"
 
   head "git://git.code.sf.net/p/rkflashtool/Git"
@@ -18,7 +18,7 @@ class Rkflashtool < Formula
 
   # Add file 'version.h' that has been forgotten in the tarball
   resource "version" do
-    url "https://downloads.sourceforge.net/project/rkflashtool/rkflashtool-5.1/version.h"
+    url "https://prdownloads.sourceforge.net/project/rkflashtool/rkflashtool-5.1/version.h"
     sha256 "b7bd8e3c66170d5f6e6a68c5add677ad365e37b4121251de87ad29e7fdf06cd6"
   end
 

--- a/Library/Formula/rnv.rb
+++ b/Library/Formula/rnv.rb
@@ -1,7 +1,7 @@
 class Rnv < Formula
   desc "Implementation of Relax NG Compact Syntax validator"
   homepage "http://freshmeat.net/projects/rnv"
-  url "https://downloads.sourceforge.net/project/rnv/Sources/1.7.11/rnv-1.7.11.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/rnv/Sources/1.7.11/rnv-1.7.11.tar.bz2"
   sha256 "b2a1578773edd29ef7a828b3a392bbea61b4ca8013ce4efc3b5fbc18662c162e"
 
   depends_on "expat"

--- a/Library/Formula/rssh.rb
+++ b/Library/Formula/rssh.rb
@@ -1,7 +1,7 @@
 class Rssh < Formula
   desc "Restricted shell for use with OpenSSH"
   homepage "http://www.pizzashack.org/rssh"
-  url "https://downloads.sourceforge.net/project/rssh/rssh/2.3.4/rssh-2.3.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/rssh/rssh/2.3.4/rssh-2.3.4.tar.gz"
   sha256 "f30c6a760918a0ed39cf9e49a49a76cb309d7ef1c25a66e77a41e2b1d0b40cd9"
 
   # Submitted upstream:

--- a/Library/Formula/rtf2latex2e.rb
+++ b/Library/Formula/rtf2latex2e.rb
@@ -1,7 +1,7 @@
 class Rtf2latex2e < Formula
   desc "RTF-to-LaTeX translation"
   homepage "http://rtf2latex2e.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/rtf2latex2e/rtf2latex2e-unix/2-2/rtf2latex2e-2-2-2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/rtf2latex2e/rtf2latex2e-unix/2-2/rtf2latex2e-2-2-2.tar.gz"
   version "2.2.2"
   sha256 "eb742af22f2ae43c40ea1abc5f50215e04779e51dc9d91cac9276b98f91bb1af"
 

--- a/Library/Formula/s3cmd.rb
+++ b/Library/Formula/s3cmd.rb
@@ -1,7 +1,7 @@
 class S3cmd < Formula
   desc "Command-line tool for the Amazon S3 service"
   homepage "http://s3tools.org/s3cmd"
-  url "https://downloads.sourceforge.net/project/s3tools/s3cmd/1.5.2/s3cmd-1.5.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/s3tools/s3cmd/1.5.2/s3cmd-1.5.2.tar.gz"
   sha256 "ff8a6764e8bdd7ed48a93e51b08222bea33469d248a90b8d25315b023717b42d"
   head "https://github.com/s3tools/s3cmd.git"
 

--- a/Library/Formula/saltstack.rb
+++ b/Library/Formula/saltstack.rb
@@ -28,7 +28,7 @@ class Saltstack < Formula
   # https://github.com/swig/swig/issues/344
   # https://github.com/martinpaljak/M2Crypto/issues/60
   resource "swig304" do
-    url "https://downloads.sourceforge.net/project/swig/swig/swig-3.0.4/swig-3.0.4.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/swig/swig/swig-3.0.4/swig-3.0.4.tar.gz"
     sha256 "410ffa80ef5535244b500933d70c1b65206333b546ca5a6c89373afb65413795"
   end
 

--- a/Library/Formula/saxon-b.rb
+++ b/Library/Formula/saxon-b.rb
@@ -1,7 +1,7 @@
 class SaxonB < Formula
   desc "XSLT and XQuery processor"
   homepage "http://saxon.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/saxon/Saxon-B/9.1.0.8/saxonb9-1-0-8j.zip"
+  url "https://prdownloads.sourceforge.net/project/saxon/Saxon-B/9.1.0.8/saxonb9-1-0-8j.zip"
   version "9.1.0.8"
   sha256 "92bcdc4a0680c7866fe5828adb92c714cfe88dcf3fa0caf5bf638fcc6d9369b4"
 

--- a/Library/Formula/saxon.rb
+++ b/Library/Formula/saxon.rb
@@ -1,7 +1,7 @@
 class Saxon < Formula
   desc "XSLT and XQuery processor"
   homepage "http://saxon.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/saxon/Saxon-HE/9.6/SaxonHE9-6-0-7J.zip"
+  url "https://prdownloads.sourceforge.net/project/saxon/Saxon-HE/9.6/SaxonHE9-6-0-7J.zip"
   sha256 "0c904b886c7512a288c38474ff5f92042b7c3c1440352f5c919aa54f3811ab66"
   version "9.6.0.7"
 

--- a/Library/Formula/sbcl.rb
+++ b/Library/Formula/sbcl.rb
@@ -1,7 +1,7 @@
 class Sbcl < Formula
   desc "Steel Bank Common Lisp system"
   homepage "http://www.sbcl.org/"
-  url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.2.15/sbcl-1.2.15-source.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/sbcl/sbcl/1.2.15/sbcl-1.2.15-source.tar.bz2"
   sha256 "d95a6e8a4b658f9973825f8d44d6195a645b0d6a33d865324c0c658b8bcb1651"
 
   head "git://sbcl.git.sourceforge.net/gitroot/sbcl/sbcl.git"
@@ -27,12 +27,12 @@ class Sbcl < Formula
   # Current binary versions are listed at http://sbcl.sourceforge.net/platform-table.html
 
   resource "bootstrap64" do
-    url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.1.8/sbcl-1.1.8-x86-64-darwin-binary.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/sbcl/sbcl/1.1.8/sbcl-1.1.8-x86-64-darwin-binary.tar.bz2"
     sha256 "729054dc27d6b53bd734eac4dffeaa9e231e97bdbe4927d7a68c8f0210cad700"
   end
 
   resource "bootstrap32" do
-    url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.1.6/sbcl-1.1.6-x86-darwin-binary.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/sbcl/sbcl/1.1.6/sbcl-1.1.6-x86-darwin-binary.tar.bz2"
     sha256 "5801c60e2a875d263fccde446308b613c0253a84a61ab63569be62eb086718b3"
   end
 

--- a/Library/Formula/sblim-sfcc.rb
+++ b/Library/Formula/sblim-sfcc.rb
@@ -1,7 +1,7 @@
 class SblimSfcc < Formula
   desc "Project to enhance the manageability of GNU/Linux system"
   homepage "https://sourceforge.net/projects/sblim/"
-  url "https://downloads.sourceforge.net/project/sblim/sblim-sfcc/sblim-sfcc-2.2.8.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/sblim/sblim-sfcc/sblim-sfcc-2.2.8.tar.bz2"
   sha256 "1b8f187583bc6c6b0a63aae0165ca37892a2a3bd4bb0682cd76b56268b42c3d6"
 
   bottle do

--- a/Library/Formula/sc68.rb
+++ b/Library/Formula/sc68.rb
@@ -1,7 +1,7 @@
 class Sc68 < Formula
   desc "Play music originally designed for Atari ST and Amiga computers"
   homepage "http://sc68.atari.org/project.html"
-  url "https://downloads.sourceforge.net/project/sc68/sc68/2.2.1/sc68-2.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/sc68/sc68/2.2.1/sc68-2.2.1.tar.gz"
   sha256 "d7371f0f406dc925debf50f64df1f0700e1d29a8502bb170883fc41cc733265f"
 
   def install

--- a/Library/Formula/scale2x.rb
+++ b/Library/Formula/scale2x.rb
@@ -1,7 +1,7 @@
 class Scale2x < Formula
   desc "Real-time graphics effect"
   homepage "http://scale2x.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/scale2x/scale2x/2.4/scale2x-2.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/scale2x/scale2x/2.4/scale2x-2.4.tar.gz"
   sha256 "83599b1627988c941ee9c7965b6f26a9fd2608cd1e0073f7262a858d0f4f7078"
   revision 1
 

--- a/Library/Formula/scons.rb
+++ b/Library/Formula/scons.rb
@@ -1,7 +1,7 @@
 class Scons < Formula
   desc "Substitute for classic 'make' tool with autoconf/automake functionality"
   homepage "http://www.scons.org"
-  url "https://downloads.sourceforge.net/project/scons/scons/3.1.2/scons-3.1.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/scons/scons/3.1.2/scons-3.1.2.tar.gz"
   sha256 "7801f3f62f654528e272df780be10c0e9337e897650b62ddcee9f39fde13f8fb"
 
   bottle do

--- a/Library/Formula/scrollkeeper.rb
+++ b/Library/Formula/scrollkeeper.rb
@@ -1,7 +1,7 @@
 class Scrollkeeper < Formula
   desc "Transitional package for scrollkeeper"
   homepage "http://scrollkeeper.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/scrollkeeper/scrollkeeper/0.3.14/scrollkeeper-0.3.14.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/scrollkeeper/scrollkeeper/0.3.14/scrollkeeper-0.3.14.tar.gz"
   sha256 "4a0bd3c3a2c5eca6caf2133a504036665485d3d729a16fc60e013e1b58e7ddad"
   revision 1
 

--- a/Library/Formula/sdcc.rb
+++ b/Library/Formula/sdcc.rb
@@ -1,7 +1,7 @@
 class Sdcc < Formula
   desc "ANSI C compiler for Intel 8051, Maxim 80DS390, and Zilog Z80"
   homepage "http://sdcc.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/sdcc/sdcc/3.5.0/sdcc-src-3.5.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/sdcc/sdcc/3.5.0/sdcc-src-3.5.0.tar.bz2"
   sha256 "f82978d1614244b22e093402c0a4de1f688a07c807b2980126c964eb3df85fa9"
 
   head "https://sdcc.svn.sourceforge.net/svnroot/sdcc/trunk/sdcc/"

--- a/Library/Formula/sec.rb
+++ b/Library/Formula/sec.rb
@@ -1,7 +1,7 @@
 class Sec < Formula
   desc "Event correlation tool for event processing of various kinds"
   homepage "http://simple-evcorr.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/simple-evcorr/sec/2.7.6/sec-2.7.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/simple-evcorr/sec/2.7.6/sec-2.7.6.tar.gz"
   sha256 "3714ce9dc9c769cefc63811703905d62f45868618842d186ad6bdc522cd53ad3"
 
   def install

--- a/Library/Formula/ser2net.rb
+++ b/Library/Formula/ser2net.rb
@@ -1,7 +1,7 @@
 class Ser2net < Formula
   desc "Allow network connections to serial ports"
   homepage "http://ser2net.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/ser2net/ser2net/ser2net-2.9.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ser2net/ser2net/ser2net-2.9.1.tar.gz"
   sha256 "fdee1e69903cf409bdc6f32403a566cbc6006aa9e2a4d6f8f12b90dfd5ca0d0e"
 
   def install

--- a/Library/Formula/sfk.rb
+++ b/Library/Formula/sfk.rb
@@ -1,7 +1,7 @@
 class Sfk < Formula
   desc "Command Line Tools Collection"
   homepage "http://stahlworks.com/dev/swiss-file-knife.html"
-  url "https://downloads.sourceforge.net/project/swissfileknife/1-swissfileknife/1.7.5/sfk-1.7.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/swissfileknife/1-swissfileknife/1.7.5/sfk-1.7.5.tar.gz"
   sha256 "f15b4bd974285138d857500ddf4563d8e77146ece967867944f09edb15e745c7"
 
   bottle do

--- a/Library/Formula/shivavg.rb
+++ b/Library/Formula/shivavg.rb
@@ -1,7 +1,7 @@
 class Shivavg < Formula
   desc "OpenGL based ANSI C implementation of the OpenVG standard"
   homepage "http://sourceforge.net/projects/shivavg/"
-  url "https://downloads.sourceforge.net/project/shivavg/ShivaVG/0.2.1/ShivaVG-0.2.1.zip"
+  url "https://prdownloads.sourceforge.net/project/shivavg/ShivaVG/0.2.1/ShivaVG-0.2.1.zip"
   sha256 "9735079392829f7aaf79e02ed84dd74f5c443c39c02ff461cfdd19cfc4ae89c4"
 
   depends_on "automake" => :build

--- a/Library/Formula/shmcat.rb
+++ b/Library/Formula/shmcat.rb
@@ -1,7 +1,7 @@
 class Shmcat < Formula
   desc "Tool that dumps shared memory segments (System V and POSIX)"
   homepage "http://shmcat.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/shmcat/shmcat-1.7.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/shmcat/shmcat-1.7.tar.bz2"
   sha256 "dfe113592425373ea3d67cad5e9e44cbc27e45c75af3b308240aee9530d169cc"
 
   bottle do

--- a/Library/Formula/silc-client.rb
+++ b/Library/Formula/silc-client.rb
@@ -1,7 +1,7 @@
 class SilcClient < Formula
   desc "SILC conferencing client"
   homepage "http://silcnet.org/client.html"
-  url "https://downloads.sourceforge.net/project/silc/silc/client/sources/silc-client-1.1.11.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/silc/silc/client/sources/silc-client-1.1.11.tar.gz"
   sha256 "8cedf2f3c15322296afe094de60504bc27e349f1942713a2f322c7ef6ad5089e"
   bottle do
     sha1 "3222c80d0b58f752bab07c29679dc0585d43d067" => :yosemite

--- a/Library/Formula/sip.rb
+++ b/Library/Formula/sip.rb
@@ -1,7 +1,7 @@
 class Sip < Formula
   desc "Tool to create Python bindings for C and C++ libraries"
   homepage "http://www.riverbankcomputing.co.uk/software/sip"
-  url "https://downloads.sourceforge.net/project/pyqt/sip/sip-4.16.9/sip-4.16.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/pyqt/sip/sip-4.16.9/sip-4.16.9.tar.gz"
   sha256 "dbe173aa566e26ca0bb5bcbc1d30ef780f416267bb3b5df48149a737ea6b0555"
 
   bottle do

--- a/Library/Formula/sipsak.rb
+++ b/Library/Formula/sipsak.rb
@@ -1,7 +1,7 @@
 class Sipsak < Formula
   desc "SIP Swiss army knife"
   homepage "https://sourceforge.net/projects/sipsak.berlios/"
-  url "https://downloads.sourceforge.net/project/sipsak.berlios/sipsak-0.9.6-1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/sipsak.berlios/sipsak-0.9.6-1.tar.gz"
   version "0.9.6"
   sha256 "5064c56d482a080b6a4aea71821b78c21b59d44f6d1aa14c27429441917911a9"
 

--- a/Library/Formula/sisc-scheme.rb
+++ b/Library/Formula/sisc-scheme.rb
@@ -1,7 +1,7 @@
 class SiscScheme < Formula
   desc "Extensive Java based Scheme interpreter"
   homepage "http://sisc-scheme.org/"
-  url "https://downloads.sourceforge.net/project/sisc/SISC%20Lite/1.16.6/sisc-lite-1.16.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/sisc/SISC%20Lite/1.16.6/sisc-lite-1.16.6.tar.gz"
   sha256 "7a2f1ee46915ef885282f6df65f481b734db12cfd97c22d17b6c00df3117eea8"
 
   def install

--- a/Library/Formula/sispmctl.rb
+++ b/Library/Formula/sispmctl.rb
@@ -3,7 +3,7 @@
  class Sispmctl < Formula
    desc "Control Gembird SIS-PM programmable power outlet strips"
    homepage "http://sispmctl.sourceforge.net/"
-   url "https://downloads.sourceforge.net/project/sispmctl/sispmctl/sispmctl-3.1/sispmctl-3.1.tar.gz"
+   url "https://prdownloads.sourceforge.net/project/sispmctl/sispmctl/sispmctl-3.1/sispmctl-3.1.tar.gz"
    sha256 "e9a99cc81ef0a93f3484e5093efd14d93cc967221fcd22c151f0bea32eb91da7"
 
    depends_on "libusb-compat"

--- a/Library/Formula/sleuthkit.rb
+++ b/Library/Formula/sleuthkit.rb
@@ -3,7 +3,7 @@ class Sleuthkit < Formula
   homepage "http://www.sleuthkit.org/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/sleuthkit/sleuthkit/4.1.3/sleuthkit-4.1.3.tar.gz"
+    url "https://prdownloads.sourceforge.net/project/sleuthkit/sleuthkit/4.1.3/sleuthkit-4.1.3.tar.gz"
     sha256 "67f9d2a31a8884d58698d6122fc1a1bfa9bf238582bde2b49228ec9b899f0327"
 
     # Upstream fix for https://github.com/sleuthkit/sleuthkit/issues/345

--- a/Library/Formula/smake.rb
+++ b/Library/Formula/smake.rb
@@ -1,7 +1,7 @@
 class Smake < Formula
   desc "Portable make program with automake features"
   homepage "http://s-make.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/s-make/smake-1.2.5.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/s-make/smake-1.2.5.tar.bz2"
   sha256 "27566aa731a400c791cd95361cc755288b44ff659fa879933d4ea35d052259d4"
 
   bottle do

--- a/Library/Formula/smartmontools.rb
+++ b/Library/Formula/smartmontools.rb
@@ -1,7 +1,7 @@
 class Smartmontools < Formula
   desc "SMART hard drive monitoring"
   homepage "https://www.smartmontools.org/"
-  url "https://downloads.sourceforge.net/project/smartmontools/smartmontools/6.5/smartmontools-6.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/smartmontools/smartmontools/6.5/smartmontools-6.5.tar.gz"
   sha256 "89e8bb080130bc6ce148573ba5bb91bfe30236b64b1b5bbca26515d4b5c945bc"
 
   bottle do

--- a/Library/Formula/snap7.rb
+++ b/Library/Formula/snap7.rb
@@ -1,7 +1,7 @@
 class Snap7 < Formula
   desc "Ethernet communication suite that works natively with Siemens S7 PLCs"
   homepage "http://snap7.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/snap7/1.4.0/snap7-full-1.4.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/snap7/1.4.0/snap7-full-1.4.0.tar.gz"
   sha256 "5d2a4948a65e0ad2a52b1a7981f3c3209be0ef821f3d00756ee0584cf4b762bb"
 
   bottle do

--- a/Library/Formula/snapraid.rb
+++ b/Library/Formula/snapraid.rb
@@ -1,7 +1,7 @@
 class Snapraid < Formula
   desc "Backup program for disk arrays"
   homepage "http://snapraid.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/snapraid/snapraid-8.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/snapraid/snapraid-8.1.tar.gz"
   sha256 "6bf89a1319ac3403958cd2c98a9c6102728c0070cfa1aedd90c4561d93c54e5d"
 
   head do

--- a/Library/Formula/sofia-sip.rb
+++ b/Library/Formula/sofia-sip.rb
@@ -1,7 +1,7 @@
 class SofiaSip < Formula
   desc "SIP User-Agent library"
   homepage "http://sofia-sip.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/sofia-sip/sofia-sip/1.12.11/sofia-sip-1.12.11.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/sofia-sip/sofia-sip/1.12.11/sofia-sip-1.12.11.tar.gz"
   sha256 "2b01bc2e1826e00d1f7f57d29a2854b15fd5fe24695e47a14a735d195dd37c81"
   revision 1
 

--- a/Library/Formula/sox.rb
+++ b/Library/Formula/sox.rb
@@ -1,7 +1,7 @@
 class Sox < Formula
   desc "SOund eXchange: universal sound sample translator"
   homepage "http://sox.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.gz"
   sha256 "b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/sqliteman.rb
+++ b/Library/Formula/sqliteman.rb
@@ -1,7 +1,7 @@
 class Sqliteman < Formula
   desc "GUI tool for Sqlite3"
   homepage "http://www.sqliteman.com/"
-  url "https://downloads.sourceforge.net/project/sqliteman/sqliteman/1.2.2/sqliteman-1.2.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/sqliteman/sqliteman/1.2.2/sqliteman-1.2.2.tar.bz2"
   sha256 "2f3281f67af464c114acd0a65f05b51672e9f5b39dd52bd2570157e8f274b10f"
 
   depends_on "cmake" => :build

--- a/Library/Formula/sqsh.rb
+++ b/Library/Formula/sqsh.rb
@@ -1,7 +1,7 @@
 class Sqsh < Formula
   desc "Sybase Shell"
   homepage "https://sourceforge.net/projects/sqsh/"
-  url "https://downloads.sourceforge.net/project/sqsh/sqsh/sqsh-2.5/sqsh-2.5.16.1.tgz"
+  url "https://prdownloads.sourceforge.net/project/sqsh/sqsh/sqsh-2.5/sqsh-2.5.16.1.tgz"
   sha256 "d6641f365ace60225fc0fa48f82b9dbed77a4e506a0e497eb6889e096b8320f2"
 
   deprecated_option "enable-x" => "with-x11"

--- a/Library/Formula/squashfs.rb
+++ b/Library/Formula/squashfs.rb
@@ -1,7 +1,7 @@
 class Squashfs < Formula
   desc "Compressed read-only file system for Linux"
   homepage "http://squashfs.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz"
   sha256 "0d605512437b1eb800b4736791559295ee5f60177e102e4d4ccd0ee241a5f3f6"
 
   bottle do

--- a/Library/Formula/squirrel.rb
+++ b/Library/Formula/squirrel.rb
@@ -1,7 +1,7 @@
 class Squirrel < Formula
   desc "High level, imperative, object-oriented programming language"
   homepage "http://www.squirrel-lang.org"
-  url "https://downloads.sourceforge.net/project/squirrel/squirrel3/squirrel%203.0.7%20stable/squirrel_3_0_7_stable.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/squirrel/squirrel3/squirrel%203.0.7%20stable/squirrel_3_0_7_stable.tar.gz"
   version "3.0.7"
   sha256 "c7c2548e2d2d74116303445118e197f585a3a5e6bde06fdfe668c05b1cb43fa2"
 

--- a/Library/Formula/srecord.rb
+++ b/Library/Formula/srecord.rb
@@ -1,7 +1,7 @@
 class Srecord < Formula
   desc "Tools for manipulating EPROM load files"
   homepage "http://srecord.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/srecord/srecord/1.64/srecord-1.64.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/srecord/srecord/1.64/srecord-1.64.tar.gz"
   sha256 "49a4418733c508c03ad79a29e95acec9a2fbc4c7306131d2a8f5ef32012e67e2"
 
   depends_on "libtool" => :build

--- a/Library/Formula/ssdeep.rb
+++ b/Library/Formula/ssdeep.rb
@@ -1,7 +1,7 @@
 class Ssdeep < Formula
   desc "Recursive piecewise hashing tool"
   homepage "http://ssdeep.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ssdeep/ssdeep-2.13/ssdeep-2.13.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ssdeep/ssdeep-2.13/ssdeep-2.13.tar.gz"
   sha256 "6e4ca94457cb50ff3343d4dd585473817a461a55a666da1c5a74667924f0f8c5"
 
   bottle do

--- a/Library/Formula/sshguard.rb
+++ b/Library/Formula/sshguard.rb
@@ -1,7 +1,7 @@
 class Sshguard < Formula
   desc "Protect from brute force attacks against SSH"
   homepage "http://www.sshguard.net/"
-  url "https://downloads.sourceforge.net/project/sshguard/sshguard/1.6.1/sshguard-1.6.1.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/sshguard/sshguard/1.6.1/sshguard-1.6.1.tar.xz"
   mirror "https://dl.bintray.com/homebrew/mirror/sshguard-1.6.1.tar.xz"
   sha256 "f431899c20fa2f41fa293605af96ff97d44823b84db41c914ee60da44f1ff6c8"
 

--- a/Library/Formula/ssldump.rb
+++ b/Library/Formula/ssldump.rb
@@ -1,7 +1,7 @@
 class Ssldump < Formula
   desc "SSLv3/TLS network protocol analyzer"
   homepage "http://ssldump.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ssldump/ssldump/0.9b3/ssldump-0.9b3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ssldump/ssldump/0.9b3/ssldump-0.9b3.tar.gz"
   sha256 "6422c16718d27c270bbcfcc1272c4f9bd3c0799c351f1d6dd54fdc162afdab1e"
 
   bottle do

--- a/Library/Formula/star.rb
+++ b/Library/Formula/star.rb
@@ -1,7 +1,7 @@
 class Star < Formula
   desc "Standard tap archiver"
   homepage "http://cdrecord.org/private/star.html"
-  url "https://downloads.sourceforge.net/project/s-tar/star-1.5.3.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/s-tar/star-1.5.3.tar.bz2"
   sha256 "070342833ea83104169bf956aa880bcd088e7af7f5b1f8e3d29853b49b1a4f5b"
 
   depends_on "smake" => :build

--- a/Library/Formula/stoken.rb
+++ b/Library/Formula/stoken.rb
@@ -1,7 +1,7 @@
 class Stoken < Formula
   desc "Tokencode generator compatible with RSA SecurID 128-bit (AES)"
   homepage "http://stoken.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/stoken/stoken-0.90.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/stoken/stoken-0.90.tar.gz"
   sha256 "b83d7b95e4ad9b107ab8a5b6c26da0f233001fdfda78d8be76562437d3bd4f7d"
 
   bottle do

--- a/Library/Formula/streamripper.rb
+++ b/Library/Formula/streamripper.rb
@@ -1,7 +1,7 @@
 class Streamripper < Formula
   desc "Separate tracks via Shoutcasts title-streaming"
   homepage "http://streamripper.sourceforge.net/"
-  url "https://downloads.sourceforge.net/sourceforge/streamripper/streamripper-1.64.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/sourceforge/streamripper/streamripper-1.64.6.tar.gz"
   sha256 "c1d75f2e9c7b38fd4695be66eff4533395248132f3cc61f375196403c4d8de42"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/ta-lib.rb
+++ b/Library/Formula/ta-lib.rb
@@ -1,7 +1,7 @@
 class TaLib < Formula
   desc "Tools for market analysis"
   homepage "http://ta-lib.org/index.html"
-  url "https://downloads.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz"
   sha256 "9ff41efcb1c011a4b4b6dfc91610b06e39b1d7973ed5d4dee55029a0ac4dc651"
 
   bottle do

--- a/Library/Formula/takt.rb
+++ b/Library/Formula/takt.rb
@@ -1,7 +1,7 @@
 class Takt < Formula
   desc "text-based music programming language"
   homepage "http://takt.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/takt/takt-0.309-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/takt/takt-0.309-src.tar.gz"
   sha256 "44fca667d610fba15deb441dd44e5b87dabbe5619d7fa8a13f5c8c1f054dd509"
   revision 1
 

--- a/Library/Formula/tcl-tk.rb
+++ b/Library/Formula/tcl-tk.rb
@@ -30,7 +30,7 @@ class TclTk < Formula
   end
 
   resource "tcllib" do
-    url "https://downloads.sourceforge.net/project/tcllib/tcllib/1.21/tcllib-1.21.tar.xz"
+    url "https://prdownloads.sourceforge.net/project/tcllib/tcllib/1.21/tcllib-1.21.tar.xz"
     sha256 "10c7749e30fdd6092251930e8a1aa289b193a3b7f1abf17fee1d4fa89814762f"
   end
 

--- a/Library/Formula/tclap.rb
+++ b/Library/Formula/tclap.rb
@@ -1,7 +1,7 @@
 class Tclap < Formula
   desc "Templatized C++ command-line parser library"
   homepage "http://tclap.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/tclap/tclap-1.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tclap/tclap-1.2.1.tar.gz"
   sha256 "9f9f0fe3719e8a89d79b6ca30cf2d16620fba3db5b9610f9b51dd2cd033deebb"
 
   def install

--- a/Library/Formula/teem.rb
+++ b/Library/Formula/teem.rb
@@ -1,7 +1,7 @@
 class Teem < Formula
   desc "Libraries for scientific raster data"
   homepage "http://teem.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/teem/teem/1.11.0/teem-1.11.0-src.tar.gz"
   sha256 "a01386021dfa802b3e7b4defced2f3c8235860d500c1fa2f347483775d4c8def"
   head "https://teem.svn.sourceforge.net/svnroot/teem/teem/trunk"
 

--- a/Library/Formula/tenfourfox.rb
+++ b/Library/Formula/tenfourfox.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Tenfourfox < Formula
   homepage 'http://www.floodgap.com/software/tenfourfox/'
-  urlbase = 'https://downloads.sourceforge.net/tenfourfox/'
+  urlbase = 'https://prdownloads.sourceforge.net/tenfourfox/'
   version '32.5.0-fpr'
 
   # depends_on :arch => :ppc

--- a/Library/Formula/thrulay.rb
+++ b/Library/Formula/thrulay.rb
@@ -1,7 +1,7 @@
 class Thrulay < Formula
   desc "Measure performance of a network"
   homepage "http://sourceforge.net/projects/thrulay/"
-  url "https://downloads.sourceforge.net/project/thrulay/thrulay/0.9/thrulay-0.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/thrulay/thrulay/0.9/thrulay-0.9.tar.gz"
   sha256 "373d5613dfe371f6b4f48fc853f6c27701b2981ba4100388c9881cb802d1780d"
 
   def install

--- a/Library/Formula/timidity.rb
+++ b/Library/Formula/timidity.rb
@@ -1,7 +1,7 @@
 class Timidity < Formula
   desc "Software synthesizer"
   homepage "http://timidity.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/timidity/TiMidity++/TiMidity++-2.14.0/TiMidity++-2.14.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/timidity/TiMidity++/TiMidity++-2.14.0/TiMidity++-2.14.0.tar.bz2"
   sha256 "f97fb643f049e9c2e5ef5b034ea9eeb582f0175dce37bc5df843cc85090f6476"
 
   bottle do

--- a/Library/Formula/tintin.rb
+++ b/Library/Formula/tintin.rb
@@ -1,7 +1,7 @@
 class Tintin < Formula
   desc "MUD client"
   homepage "http://tintin.sf.net"
-  url "https://downloads.sourceforge.net/project/tintin/TinTin%2B%2B%20Source%20Code/2.01.0/tintin-2.01.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tintin/TinTin%2B%2B%20Source%20Code/2.01.0/tintin-2.01.0.tar.gz"
   sha256 "e0e35463a97ee5b33ef0b29b2c57fa8276c4e76328cb19c98a6ea92c603a9c76"
 
   depends_on "pcre"

--- a/Library/Formula/tiny-fugue.rb
+++ b/Library/Formula/tiny-fugue.rb
@@ -1,7 +1,7 @@
 class TinyFugue < Formula
   desc "Programmable MUD client"
   homepage "http://tinyfugue.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/tinyfugue/tinyfugue/5.0%20beta%208/tf-50b8.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tinyfugue/tinyfugue/5.0%20beta%208/tf-50b8.tar.gz"
   sha256 "3750a114cf947b1e3d71cecbe258cb830c39f3186c369e368d4662de9c50d989"
   version "5.0b8"
 

--- a/Library/Formula/tinyscheme.rb
+++ b/Library/Formula/tinyscheme.rb
@@ -1,7 +1,7 @@
 class Tinyscheme < Formula
   desc "Very small Scheme implementation"
   homepage "http://tinyscheme.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-1.40/tinyscheme-1.40.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-1.40/tinyscheme-1.40.tar.gz"
   sha256 "c594c84633b1dcfe832e0416cbc9f889b6bae352845e14503883119a941a12fc"
 
   bottle do

--- a/Library/Formula/tinyxml.rb
+++ b/Library/Formula/tinyxml.rb
@@ -1,7 +1,7 @@
 class Tinyxml < Formula
   desc "XML parser"
   homepage "http://www.grinninglizard.com/tinyxml/"
-  url "https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
   sha256 "15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593"
 
   bottle do

--- a/Library/Formula/tivodecode.rb
+++ b/Library/Formula/tivodecode.rb
@@ -1,7 +1,7 @@
 class Tivodecode < Formula
   desc "Convert .tivo to .mpeg"
   homepage "http://tivodecode.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/tivodecode/tivodecode/0.2pre4/tivodecode-0.2pre4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tivodecode/tivodecode/0.2pre4/tivodecode-0.2pre4.tar.gz"
   sha256 "788839cc4ad66f5b20792e166514411705e8564f9f050584c54c3f1f452e9cdf"
   version "0.2pre4"
 

--- a/Library/Formula/tkdiff.rb
+++ b/Library/Formula/tkdiff.rb
@@ -1,7 +1,7 @@
 class Tkdiff < Formula
   desc "Graphical side by side diff utility"
   homepage "http://tkdiff.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/tkdiff/tkdiff/4.2/tkdiff-4.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tkdiff/tkdiff/4.2/tkdiff-4.2.tar.gz"
   sha256 "734bb417184c10072eb64e8d274245338e41b7fdeff661b5ef30e89f3e3aa357"
 
   def install

--- a/Library/Formula/tn5250.rb
+++ b/Library/Formula/tn5250.rb
@@ -1,7 +1,7 @@
 class Tn5250 < Formula
   desc "5250 terminal and printer emulator"
   homepage "http://tn5250.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/tn5250/tn5250/0.17.4/tn5250-0.17.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tn5250/tn5250/0.17.4/tn5250-0.17.4.tar.gz"
   sha256 "354237d400dc46af887cb3ffa4ed1f2c371f5b8bee8be046a683a4ac9db4f9c5"
   revision 1
 

--- a/Library/Formula/tnote.rb
+++ b/Library/Formula/tnote.rb
@@ -1,7 +1,7 @@
 class Tnote < Formula
   desc "Small note-taking program for the terminal"
   homepage "http://tnote.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/tnote/tnote/tnote-0.2.1/tnote-0.2.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tnote/tnote/tnote-0.2.1/tnote-0.2.1.tar.gz"
   sha256 "451e0e352cb279725c5e12ad1c1377be63c7113f3fe568fb6213ede478ba6a87"
 
   depends_on :python if MacOS.version <= :snow_leopard

--- a/Library/Formula/torrentcheck.rb
+++ b/Library/Formula/torrentcheck.rb
@@ -1,7 +1,7 @@
 class Torrentcheck < Formula
   desc "Command-line torrent viewer and hash checker"
   homepage "http://torrentcheck.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/torrentcheck/torrentcheck-1.00.zip"
+  url "https://prdownloads.sourceforge.net/project/torrentcheck/torrentcheck-1.00.zip"
   sha256 "a839f9ac9669d942f83af33db96ce9902d84f85592c99b568ef0f5232ff318c5"
 
   def install

--- a/Library/Formula/treeline.rb
+++ b/Library/Formula/treeline.rb
@@ -1,7 +1,7 @@
 class Treeline < Formula
   desc "Advanced outliner and personal information manager"
   homepage "http://treeline.bellz.org/"
-  url "https://downloads.sourceforge.net/project/treeline/2.0.0/treeline-2.0.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/treeline/2.0.0/treeline-2.0.0.tar.gz"
   sha256 "71af995fca9e0eaf4e6205d72eb4ee6a979a45ea2a1f6600ed8a39bb1861d118"
   revision 1
 

--- a/Library/Formula/tta.rb
+++ b/Library/Formula/tta.rb
@@ -1,7 +1,7 @@
 class Tta < Formula
   desc "TTA lossless audio codec"
   homepage "http://www.true-audio.com"
-  url "https://downloads.sourceforge.net/project/tta/tta/libtta/libtta-2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/tta/tta/libtta/libtta-2.2.tar.gz"
   sha256 "1723424d75b3cda907ff68abf727bb9bc0c23982ea8f91ed1cc045804c1435c4"
 
   def install

--- a/Library/Formula/ttf2pt1.rb
+++ b/Library/Formula/ttf2pt1.rb
@@ -1,7 +1,7 @@
 class Ttf2pt1 < Formula
   desc "True Type Font to Postscript Type 1 converter"
   homepage "http://ttf2pt1.sourceforge.net/"
-  url "https://downloads.sourceforge.net/ttf2pt1/ttf2pt1-3.4.4.tgz"
+  url "https://prdownloads.sourceforge.net/ttf2pt1/ttf2pt1-3.4.4.tgz"
   sha256 "ae926288be910073883b5c8a3b8fc168fde52b91199fdf13e92d72328945e1d0"
 
   def install

--- a/Library/Formula/ttfautohint.rb
+++ b/Library/Formula/ttfautohint.rb
@@ -1,7 +1,7 @@
 class Ttfautohint < Formula
   desc "Automated hinting process for web fonts"
   homepage "http://www.freetype.org/ttfautohint"
-  url "https://downloads.sourceforge.net/project/freetype/ttfautohint/1.3/ttfautohint-1.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/freetype/ttfautohint/1.3/ttfautohint-1.3.tar.gz"
   sha256 "c39fa03790b2dfe711f66137cf0f0324eb19872932cef91da9c0bddf9e4ce104"
 
   head do

--- a/Library/Formula/ttylog.rb
+++ b/Library/Formula/ttylog.rb
@@ -1,7 +1,7 @@
 class Ttylog < Formula
   desc "Serial port logger: print everything from a serial device"
   homepage "http://ttylog.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ttylog/ttylog/0.25/ttylog-0.25.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ttylog/ttylog/0.25/ttylog-0.25.tar.gz"
   sha256 "80d0134ae4e29b650fff661169a6e667d22338465720ee768b2776f68aac8614"
 
   bottle do

--- a/Library/Formula/two-lame.rb
+++ b/Library/Formula/two-lame.rb
@@ -1,7 +1,7 @@
 class TwoLame < Formula
   desc "Optimized MPEG Audio Layer 2 (MP2) encoder"
   homepage "http://www.twolame.org/"
-  url "https://downloads.sourceforge.net/twolame/twolame-0.3.13.tar.gz"
+  url "https://prdownloads.sourceforge.net/twolame/twolame-0.3.13.tar.gz"
   sha256 "98f332f48951f47f23f70fd0379463aff7d7fb26f07e1e24e42ddef22cc6112a"
 
   option "frontend", "Build the twolame frontend using libsndfile"

--- a/Library/Formula/typespeed.rb
+++ b/Library/Formula/typespeed.rb
@@ -1,7 +1,7 @@
 class Typespeed < Formula
   desc "Zap words flying across the screen by typing them correctly"
   homepage "http://typespeed.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/typespeed/typespeed/0.6.5/typespeed-0.6.5.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/typespeed/typespeed/0.6.5/typespeed-0.6.5.tar.gz"
   sha256 "5c860385ceed8a60f13217cc0192c4c2b4705c3e80f9866f7d72ff306eb72961"
 
   def install

--- a/Library/Formula/udis86.rb
+++ b/Library/Formula/udis86.rb
@@ -1,7 +1,7 @@
 class Udis86 < Formula
   desc "Minimalistic disassembler library for x86"
   homepage "http://udis86.sourceforge.net"
-  url "https://downloads.sourceforge.net/udis86/udis86-1.7.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/udis86/udis86-1.7.2.tar.gz"
   sha256 "9c52ac626ac6f531e1d6828feaad7e797d0f3cce1e9f34ad4e84627022b3c2f4"
 
   option :universal

--- a/Library/Formula/ufraw.rb
+++ b/Library/Formula/ufraw.rb
@@ -1,7 +1,7 @@
 class Ufraw < Formula
   desc "Unidentified Flying RAW: RAW image processing utility"
   homepage "http://ufraw.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/ufraw/ufraw/ufraw-0.22/ufraw-0.22.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/ufraw/ufraw/ufraw-0.22/ufraw-0.22.tar.gz"
   sha256 "f7abd28ce587db2a74b4c54149bd8a2523a7ddc09bedf4f923246ff0ae09a25e"
   revision 1
 

--- a/Library/Formula/uncrustify.rb
+++ b/Library/Formula/uncrustify.rb
@@ -1,7 +1,7 @@
 class Uncrustify < Formula
   desc "Source code beautifier"
   homepage "http://uncrustify.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/uncrustify/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/uncrustify/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz"
   sha256 "1df0e5a2716e256f0a4993db12f23d10195b3030326fdf2e07f8e6421e172df9"
 
   head "https://github.com/bengardner/uncrustify.git"

--- a/Library/Formula/unfs3.rb
+++ b/Library/Formula/unfs3.rb
@@ -1,7 +1,7 @@
 class Unfs3 < Formula
   desc "User-space NFSv3 server"
   homepage "http://unfs3.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/unfs3/unfs3/0.9.22/unfs3-0.9.22.tar.gz"
   sha256 "482222cae541172c155cd5dc9c2199763a6454b0c5c0619102d8143bb19fdf1c"
 
   head do

--- a/Library/Formula/uriparser.rb
+++ b/Library/Formula/uriparser.rb
@@ -1,7 +1,7 @@
 class Uriparser < Formula
   desc "URI parsing library (strictly RFC 3986 compliant)"
   homepage "http://uriparser.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/uriparser/Sources/0.8.2/uriparser-0.8.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/uriparser/Sources/0.8.2/uriparser-0.8.2.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/u/uriparser/uriparser_0.8.2.orig.tar.bz2"
   sha256 "6d6e66b0615f65e9e2391933dab7e45eca0947160f10c6b47bc50feda93e508f"
 

--- a/Library/Formula/vde.rb
+++ b/Library/Formula/vde.rb
@@ -1,7 +1,7 @@
 class Vde < Formula
   desc "Ethernet compliant virtual network"
   homepage "http://vde.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/vde/vde2/2.3.2/vde2-2.3.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/vde/vde2/2.3.2/vde2-2.3.2.tar.gz"
   sha256 "22df546a63dac88320d35d61b7833bbbcbef13529ad009c7ce3c5cb32250af93"
 
   def install

--- a/Library/Formula/viennacl.rb
+++ b/Library/Formula/viennacl.rb
@@ -1,7 +1,7 @@
 class Viennacl < Formula
   desc "ViennaCL is a linear algebra library leveraging parallel computation."
   homepage "http://viennacl.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/viennacl/1.7.x/ViennaCL-1.7.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/viennacl/1.7.x/ViennaCL-1.7.0.tar.gz"
   sha256 "0dd062770f8cf92309b2473d5defc7a6b4c874170e350e6a7ad0f4c791c49eff"
   head "https://github.com/viennacl/viennacl-dev.git"
 

--- a/Library/Formula/vifm.rb
+++ b/Library/Formula/vifm.rb
@@ -1,7 +1,7 @@
 class Vifm < Formula
   desc "Ncurses based file manager with vi like keybindings"
   homepage "http://vifm.info/"
-  url "https://downloads.sourceforge.net/project/vifm/vifm/vifm-0.8.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/vifm/vifm/vifm-0.8.tar.bz2"
   mirror "https://github.com/vifm/vifm/releases/download/v0.8/vifm-0.8.tar.bz2"
   sha256 "69eb6b50dcf462f4233ff987f0b6a295df08a27bc42577ebef725bfe58dbdeeb"
 

--- a/Library/Formula/vimpc.rb
+++ b/Library/Formula/vimpc.rb
@@ -1,7 +1,7 @@
 class Vimpc < Formula
   desc "Ncurses based mpd client with vi like key bindings"
   homepage "http://sourceforge.net/projects/vimpc/"
-  url "https://downloads.sourceforge.net/project/vimpc/Release%200.09.1/vimpc-0.09.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/vimpc/Release%200.09.1/vimpc-0.09.1.tar.gz"
   sha256 "082fa9974e01bf563335ebf950b2f9bc129c0d05c0c15499f7827e8418306031"
 
   head do

--- a/Library/Formula/virtuoso.rb
+++ b/Library/Formula/virtuoso.rb
@@ -2,7 +2,7 @@ class Virtuoso < Formula
   desc "High-performance object-relational SQL database"
   homepage "http://virtuoso.openlinksw.com/wiki/main/"
   url "https://github.com/openlink/virtuoso-opensource/releases/download/v7.2.0.1/virtuoso-opensource-7.2.0_p1.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/virtuoso/virtuoso/7.2.0/virtuoso-opensource-7.2.0_p1.tar.gz"
+  mirror "https://prdownloads.sourceforge.net/project/virtuoso/virtuoso/7.2.0/virtuoso-opensource-7.2.0_p1.tar.gz"
   sha256 "fe0fc64c169fc59322142d4e4a90d1328f7063a07f9d9035aaf5adc9dde28302"
   version "7.2.0-1"
 

--- a/Library/Formula/vncsnapshot.rb
+++ b/Library/Formula/vncsnapshot.rb
@@ -1,7 +1,7 @@
 class Vncsnapshot < Formula
   desc "Command-line utility for taking VNC snapshots"
   homepage "http://sourceforge.net/projects/vncsnapshot/"
-  url "https://downloads.sourceforge.net/project/vncsnapshot/vncsnapshot/1.2a/vncsnapshot-1.2a-src.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/vncsnapshot/vncsnapshot/1.2a/vncsnapshot-1.2a-src.tar.gz"
   sha256 "20f5bdf6939a0454bc3b41e87e41a5f247d7efd1445f4fac360e271ddbea14ee"
   revision 1
 

--- a/Library/Formula/vpcs.rb
+++ b/Library/Formula/vpcs.rb
@@ -1,7 +1,7 @@
 class Vpcs < Formula
   desc "Virtual PC simulator for testing IP routing"
   homepage "http://vpcs.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/vpcs/0.6/vpcs-0.6-src.tbz"
+  url "https://prdownloads.sourceforge.net/project/vpcs/0.6/vpcs-0.6-src.tbz"
   sha256 "cc311b0dea9ea02ef95f26704d73e34d293caa503600a0acca202d577afd3ceb"
 
   bottle do

--- a/Library/Formula/w-calc.rb
+++ b/Library/Formula/w-calc.rb
@@ -1,5 +1,5 @@
 class WCalc < Formula
-  url "https://downloads.sourceforge.net/w-calc/wcalc-2.5.tar.bz2"
+  url "https://prdownloads.sourceforge.net/w-calc/wcalc-2.5.tar.bz2"
   bottle do
     cellar :any
     sha1 "dcd1bc693b7536d7f7707e82de4214a7327d9af3" => :yosemite

--- a/Library/Formula/w3m.rb
+++ b/Library/Formula/w3m.rb
@@ -1,7 +1,7 @@
 class W3m < Formula
   desc "Pager/text based browser"
   homepage "http://w3m.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
   sha256 "e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3"
 
   depends_on "bdw-gc"

--- a/Library/Formula/wine.rb
+++ b/Library/Formula/wine.rb
@@ -7,16 +7,16 @@ class Wine < Formula
   homepage "https://www.winehq.org/"
 
   stable do
-    url "https://downloads.sourceforge.net/project/wine/Source/wine-1.6.2.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/wine/Source/wine-1.6.2.tar.bz2"
     sha256 "f0ab9eede5a0ccacbf6e50682649f9377b9199e49cf55641f1787cf72405acbe"
 
     resource "gecko" do
-      url "https://downloads.sourceforge.net/wine/wine_gecko-2.21-x86.msi", :using => :nounzip
+      url "https://prdownloads.sourceforge.net/wine/wine_gecko-2.21-x86.msi", :using => :nounzip
       sha256 "f01fafa6d7aab995c38add77315c4cbc2f32f52d5d6a9350056f42b62d631fd8"
     end
 
     resource "mono" do
-      url "https://downloads.sourceforge.net/wine/wine-mono-0.0.8.msi", :using => :nounzip
+      url "https://prdownloads.sourceforge.net/wine/wine-mono-0.0.8.msi", :using => :nounzip
       sha256 "3dfc23bbc29015e4e538dab8b83cb825d3248a0e5cf3b3318503ee7331115402"
     end
   end
@@ -30,7 +30,7 @@ class Wine < Formula
   end
 
   devel do
-    url "https://downloads.sourceforge.net/project/wine/Source/wine-1.7.51.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/wine/Source/wine-1.7.51.tar.bz2"
     mirror "http://mirrors.ibiblio.org/wine/source/1.7/wine-1.7.51.tar.bz2"
     sha256 "397fc95b463d6ae1b65ab0477d9fe5d0871e8e2a3322bc9d984e438f2c4d0f52"
 
@@ -72,12 +72,12 @@ class Wine < Formula
   depends_on "libgsm" => :optional
 
   resource "gecko" do
-    url "https://downloads.sourceforge.net/wine/wine_gecko-2.40-x86.msi", :using => :nounzip
+    url "https://prdownloads.sourceforge.net/wine/wine_gecko-2.40-x86.msi", :using => :nounzip
     sha256 "1a29d17435a52b7663cea6f30a0771f74097962b07031947719bb7b46057d302"
   end
 
   resource "mono" do
-    url "https://downloads.sourceforge.net/wine/wine-mono-4.5.6.msi", :using => :nounzip
+    url "https://prdownloads.sourceforge.net/wine/wine-mono-4.5.6.msi", :using => :nounzip
     sha256 "ac681f737f83742d786706529eb85f4bc8d6bdddd8dcdfa9e2e336b71973bc25"
   end
 

--- a/Library/Formula/winexe.rb
+++ b/Library/Formula/winexe.rb
@@ -1,7 +1,7 @@
 class Winexe < Formula
   desc "Remote Windows-command executor"
   homepage "http://sourceforge.net/projects/winexe/"
-  url "https://downloads.sourceforge.net/project/winexe/winexe-1.00.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/winexe/winexe-1.00.tar.gz"
   sha256 "99238bd3e1c0637041c737c86a05bd73a9375abc9794dca71d2765e22d87537e"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/wput.rb
+++ b/Library/Formula/wput.rb
@@ -1,7 +1,7 @@
 class Wput < Formula
   desc "Tiny, wget-like FTP client for uploading files"
   homepage "http://wput.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/wput/wput/0.6.2/wput-0.6.2.tgz"
+  url "https://prdownloads.sourceforge.net/project/wput/wput/0.6.2/wput-0.6.2.tgz"
   sha256 "229d8bb7d045ca1f54d68de23f1bc8016690dc0027a16586712594fbc7fad8c7"
 
   # The patch is to skip inclusion of malloc.h only on OSX. Upstream:

--- a/Library/Formula/writerperfect.rb
+++ b/Library/Formula/writerperfect.rb
@@ -1,7 +1,7 @@
 class Writerperfect < Formula
   desc "Library for importing WordPerfect documents"
   homepage "http://sourceforge.net/p/libwpd/wiki/writerperfect/"
-  url "https://downloads.sourceforge.net/project/libwpd/writerperfect/writerperfect-0.9.4/writerperfect-0.9.4.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/libwpd/writerperfect/writerperfect-0.9.4/writerperfect-0.9.4.tar.xz"
   sha256 "6714bf945a657550eb84bd2f1f0b78b894f59536d8302942810134426f7a23ea"
 
   bottle do

--- a/Library/Formula/wslay.rb
+++ b/Library/Formula/wslay.rb
@@ -1,7 +1,7 @@
 class Wslay < Formula
   desc "C websocket library"
   homepage "http://wslay.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/wslay/wslay-1.0.0/wslay-1.0.0.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/wslay/wslay-1.0.0/wslay-1.0.0.tar.xz"
   sha256 "148d5272255b76034f97cf0298f606aed4908ebb4198412a321280f2319160ef"
 
   bottle do

--- a/Library/Formula/wtf.rb
+++ b/Library/Formula/wtf.rb
@@ -1,7 +1,7 @@
 class Wtf < Formula
   desc "Translate common Internet acronyms"
   homepage "http://cvsweb.netbsd.org/bsdweb.cgi/src/games/wtf/"
-  url "https://downloads.sourceforge.net/project/bsdwtf/wtf-20141212.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/bsdwtf/wtf-20141212.tar.gz"
   sha256 "31ee95558aee74f76d9e531fb2489765eb51c963b7b514cc07f8b407baf7f2a2"
 
   def install

--- a/Library/Formula/wv2.rb
+++ b/Library/Formula/wv2.rb
@@ -1,7 +1,7 @@
 class Wv2 < Formula
   desc "Programs for accessing Microsoft Word documents"
   homepage "http://wvware.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/wvware/wv2-0.4.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/wvware/wv2-0.4.2.tar.bz2"
   sha256 "9f2b6d3910cb0e29c9ff432f935a594ceec0101bca46ba2fc251aff251ee38dc"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/wxmac.rb
+++ b/Library/Formula/wxmac.rb
@@ -1,7 +1,7 @@
 class Wxmac < Formula
   desc "wxWidgets, a cross-platform C++ GUI toolkit (for OS X)"
   homepage "https://www.wxwidgets.org"
-  url "https://downloads.sourceforge.net/project/wxwindows/3.0.2/wxWidgets-3.0.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/wxwindows/3.0.2/wxWidgets-3.0.2.tar.bz2"
   sha256 "346879dc554f3ab8d6da2704f651ecb504a22e9d31c17ef5449b129ed711585d"
   revision 1
 

--- a/Library/Formula/wxpython.rb
+++ b/Library/Formula/wxpython.rb
@@ -14,7 +14,7 @@ end
 class Wxpython < Formula
   desc "Python bindings for wxWidgets"
   homepage "https://www.wxwidgets.org/"
-  url "https://downloads.sourceforge.net/project/wxpython/wxPython/3.0.2.0/wxPython-src-3.0.2.0.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/wxpython/wxPython/3.0.2.0/wxPython-src-3.0.2.0.tar.bz2"
   sha256 "d54129e5fbea4fb8091c87b2980760b72c22a386cb3b9dd2eebc928ef5e8df61"
 
   bottle do

--- a/Library/Formula/x11vnc.rb
+++ b/Library/Formula/x11vnc.rb
@@ -1,7 +1,7 @@
 class X11vnc < Formula
   desc "VNC server for real X displays"
   homepage "http://www.karlrunge.com/x11vnc/"
-  url "https://downloads.sourceforge.net/project/libvncserver/x11vnc/0.9.13/x11vnc-0.9.13.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/libvncserver/x11vnc/0.9.13/x11vnc-0.9.13.tar.gz"
   sha256 "f6829f2e629667a5284de62b080b13126a0736499fe47cdb447aedb07a59f13b"
   revision 1
 

--- a/Library/Formula/xlslib.rb
+++ b/Library/Formula/xlslib.rb
@@ -1,7 +1,7 @@
 class Xlslib < Formula
   desc "C++/C library to construct Excel .xls files in code"
   homepage "https://sourceforge.net/projects/xlslib"
-  url "https://downloads.sourceforge.net/project/xlslib/xlslib-old/xlslib-package-2.4.0.zip"
+  url "https://prdownloads.sourceforge.net/project/xlslib/xlslib-old/xlslib-package-2.4.0.zip"
   mirror "https://dl.bintray.com/homebrew/mirror/xlslib-package-2.4.0.zip"
   sha256 "acc92e31294f91d8ac8adbbfc84f7a8917f7ad649a6c97b71c9f95c25887f840"
 

--- a/Library/Formula/xmlcatmgr.rb
+++ b/Library/Formula/xmlcatmgr.rb
@@ -1,7 +1,7 @@
 class Xmlcatmgr < Formula
   desc "Manipulate SGML and XML catalogs"
   homepage "http://xmlcatmgr.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/xmlcatmgr/xmlcatmgr/2.2/xmlcatmgr-2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xmlcatmgr/xmlcatmgr/2.2/xmlcatmgr-2.2.tar.gz"
   sha256 "ea1142b6aef40fbd624fc3e2130cf10cf081b5fa88e5229c92b8f515779d6fdc"
 
   def install

--- a/Library/Formula/xmlrpc-c.rb
+++ b/Library/Formula/xmlrpc-c.rb
@@ -1,7 +1,7 @@
 class XmlrpcC < Formula
   desc "Lightweight RPC library (based on XML and HTTP)"
   homepage "http://xmlrpc-c.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/xmlrpc-c/Xmlrpc-c%20Super%20Stable/1.33.17/xmlrpc-c-1.33.17.tgz"
+  url "https://prdownloads.sourceforge.net/project/xmlrpc-c/Xmlrpc-c%20Super%20Stable/1.33.17/xmlrpc-c-1.33.17.tgz"
   sha256 "50118a3ca1114828f7cae27b7253cc25045849e487f5d0bb91d962777fc05355"
 
   bottle do

--- a/Library/Formula/xmlsh.rb
+++ b/Library/Formula/xmlsh.rb
@@ -1,7 +1,7 @@
 class Xmlsh < Formula
   desc "XML shell"
   homepage "http://www.xmlsh.org"
-  url "https://downloads.sourceforge.net/project/xmlsh/xmlsh/1.2.5/xmlsh_1_2_5.zip"
+  url "https://prdownloads.sourceforge.net/project/xmlsh/xmlsh/1.2.5/xmlsh_1_2_5.zip"
   sha256 "489df45f19a6bb586fdb5abd1f8ba9397048597895cb25def747b0118b02b1c8"
 
   def install

--- a/Library/Formula/xmlstarlet.rb
+++ b/Library/Formula/xmlstarlet.rb
@@ -1,7 +1,7 @@
 class Xmlstarlet < Formula
   desc "XML command-line utilities"
   homepage "http://xmlstar.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/xmlstar/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xmlstar/xmlstarlet/1.6.1/xmlstarlet-1.6.1.tar.gz"
   sha256 "15d838c4f3375332fd95554619179b69e4ec91418a3a5296e7c631b7ed19e7ca"
 
   def install

--- a/Library/Formula/xmltoman.rb
+++ b/Library/Formula/xmltoman.rb
@@ -1,7 +1,7 @@
 class Xmltoman < Formula
   desc "XML to manpage converter"
   homepage "http://sourceforge.net/projects/xmltoman/"
-  url "https://downloads.sourceforge.net/project/xmltoman/xmltoman/xmltoman-0.4.tar.gz/xmltoman-0.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xmltoman/xmltoman/xmltoman-0.4.tar.gz/xmltoman-0.4.tar.gz"
   sha256 "948794a316aaecd13add60e17e476beae86644d066cb60171fc6b779f2df14b0"
 
   def install

--- a/Library/Formula/xmp.rb
+++ b/Library/Formula/xmp.rb
@@ -1,7 +1,7 @@
 class Xmp < Formula
   desc "Command-line player for module music formats (MOD, S3M, IT, etc)"
   homepage "http://xmp.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/xmp/xmp/4.0.10/xmp-4.0.10.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xmp/xmp/4.0.10/xmp-4.0.10.tar.gz"
   sha256 "b6d45fef0dbdb4ad4948b9f82335cbfaf60eaec3a63cc9a0050a1e5cf7a65e3e"
 
   bottle do

--- a/Library/Formula/xplanet.rb
+++ b/Library/Formula/xplanet.rb
@@ -1,7 +1,7 @@
 class Xplanet < Formula
   desc "Create HQ wallpapers of planet Earth"
   homepage "http://xplanet.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/xplanet/xplanet/1.3.0/xplanet-1.3.0.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xplanet/xplanet/1.3.0/xplanet-1.3.0.tar.gz"
   sha256 "44fb742bb93e5661ea8b11ccabcc12896693e051f3dd5083c9227224c416b442"
   revision 3
 

--- a/Library/Formula/xqilla.rb
+++ b/Library/Formula/xqilla.rb
@@ -1,7 +1,7 @@
 class Xqilla < Formula
   desc "XQuery and XPath 2 command-line interpreter"
   homepage "http://xqilla.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/xqilla/XQilla-2.3.1.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/xqilla/XQilla-2.3.1.tar.gz"
   sha256 "5ba1c1060c7d7e1dae537d4e1388d23b278a2177c7652e33121d481907d25d68"
 
   bottle do

--- a/Library/Formula/xstow.rb
+++ b/Library/Formula/xstow.rb
@@ -1,7 +1,7 @@
 class Xstow < Formula
   desc "Extended replacement for GNU Stow"
   homepage "http://xstow.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/xstow/xstow-1.0.2.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/xstow/xstow-1.0.2.tar.bz2"
   sha256 "6f041f19a5d71667f6a9436d56f5a50646b6b8c055ef5ae0813dcecb35a3c6ef"
 
   fails_with :clang do

--- a/Library/Formula/yacas.rb
+++ b/Library/Formula/yacas.rb
@@ -1,7 +1,7 @@
 class Yacas < Formula
   desc "General purpose computer algebra system"
   homepage "http://yacas.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/yacas/yacas-source/1.3/yacas-1.3.4.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/yacas/yacas-source/1.3/yacas-1.3.4.tar.gz"
   sha256 "18482f22d6a8336e9ebfda3bec045da70db2da68ae02f32987928a3c67284233"
 
   bottle do

--- a/Library/Formula/yamdi.rb
+++ b/Library/Formula/yamdi.rb
@@ -1,7 +1,7 @@
 class Yamdi < Formula
   desc "Add metadata to Flash video"
   homepage "http://yamdi.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/yamdi/yamdi/1.9/yamdi-1.9.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/yamdi/yamdi/1.9/yamdi-1.9.tar.gz"
   sha256 "4a6630f27f6c22bcd95982bf3357747d19f40bd98297a569e9c77468b756f715"
 
   def install

--- a/Library/Formula/yconalyzer.rb
+++ b/Library/Formula/yconalyzer.rb
@@ -1,7 +1,7 @@
 class Yconalyzer < Formula
   desc "TCP traffic analyzer"
   homepage "https://sourceforge.net/projects/yconalyzer/"
-  url "https://downloads.sourceforge.net/project/yconalyzer/yconalyzer-1.0.4.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/yconalyzer/yconalyzer-1.0.4.tar.bz2"
   sha256 "3b2bd33ffa9f6de707c91deeb32d9e9a56c51e232be5002fbed7e7a6373b4d5b"
 
   bottle do

--- a/Library/Formula/yydecode.rb
+++ b/Library/Formula/yydecode.rb
@@ -1,7 +1,7 @@
 class Yydecode < Formula
   desc "Decode yEnc archives"
   homepage "http://yydecode.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/yydecode/yydecode/0.2.10/yydecode-0.2.10.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/yydecode/yydecode/0.2.10/yydecode-0.2.10.tar.gz"
   sha256 "bd4879643f6539770fd23d1a51dc6a91ba3de2823cf14d047a40c630b3c7ba66"
 
   def install

--- a/Library/Formula/zabbix.rb
+++ b/Library/Formula/zabbix.rb
@@ -1,7 +1,7 @@
 class Zabbix < Formula
   desc "Availability and monitoring solution"
   homepage "https://www.zabbix.com/"
-  url "https://downloads.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.4.6/zabbix-2.4.6.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.4.6/zabbix-2.4.6.tar.gz"
   sha256 "0ebc6a3326e506cee18826baf2940e39fca3667650f7187e4aa103bf6f7f613c"
 
   bottle do

--- a/Library/Formula/zbar.rb
+++ b/Library/Formula/zbar.rb
@@ -1,7 +1,7 @@
 class Zbar < Formula
   desc "Suite of barcodes-reading tools"
   homepage "http://zbar.sourceforge.net"
-  url "https://downloads.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/zbar/zbar/0.10/zbar-0.10.tar.bz2"
   sha256 "234efb39dbbe5cef4189cc76f37afbe3cfcfb45ae52493bfe8e191318bdbadc6"
   revision 2
 

--- a/Library/Formula/zpython.rb
+++ b/Library/Formula/zpython.rb
@@ -20,7 +20,7 @@ class Zpython < Formula
   homepage "https://bitbucket.org/ZyX_I/zsh"
 
   stable do
-    url "https://downloads.sourceforge.net/project/zsh/zsh/5.0.5/zsh-5.0.5.tar.bz2"
+    url "https://prdownloads.sourceforge.net/project/zsh/zsh/5.0.5/zsh-5.0.5.tar.bz2"
     mirror "http://www.zsh.org/pub/zsh-5.0.5.tar.bz2"
 
     # Note, non-head version is completly implemented in this lengthy patch

--- a/Library/Formula/zsh.rb
+++ b/Library/Formula/zsh.rb
@@ -1,7 +1,7 @@
 class Zsh < Formula
   desc "UNIX shell (command interpreter)"
   homepage "http://www.zsh.org/"
-  url "https://downloads.sourceforge.net/project/zsh/zsh/5.9/zsh-5.9.tar.xz"
+  url "https://prdownloads.sourceforge.net/project/zsh/zsh/5.9/zsh-5.9.tar.xz"
   mirror "http://www.zsh.org/pub/zsh-5.9.tar.xz"
   sha256 "9b8d1ecedd5b5e81fbf1918e876752a7dd948e05c1a0dba10ab863842d45acd5"
 

--- a/Library/Formula/zshdb.rb
+++ b/Library/Formula/zshdb.rb
@@ -1,7 +1,7 @@
 class Zshdb < Formula
   desc "Debugger for zsh"
   homepage "https://github.com/rocky/zshdb"
-  url "https://downloads.sourceforge.net/project/bashdb/zshdb/0.9/zshdb-0.09.tar.bz2"
+  url "https://prdownloads.sourceforge.net/project/bashdb/zshdb/0.9/zshdb-0.09.tar.bz2"
   sha256 "3ad756485a5bfd014649f4ede15187d0cf070919d2ddb15b4ded61e8990e8d4f"
 
   bottle do

--- a/Library/Formula/zssh.rb
+++ b/Library/Formula/zssh.rb
@@ -1,7 +1,7 @@
 class Zssh < Formula
   desc "Interactive file transfers over SSH"
   homepage "http://zssh.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/zssh/zssh/1.5/zssh-1.5c.tgz"
+  url "https://prdownloads.sourceforge.net/project/zssh/zssh/1.5/zssh-1.5c.tgz"
   sha256 "a2e840f82590690d27ea1ea1141af509ee34681fede897e58ae8d354701ce71b"
 
   bottle do


### PR DESCRIPTION
Saves multiple redirects on almost all formulas where the source file is fetched
after the initial redirect from prdownloads. Using downloads.sourceforge
sometimes results in many redirects.
    
The formulas in this commit are ones which 'brew fetch' was able to download from the new URL.

The following formulas were unable to download one or more source files
```
aide
arpon
avidemux
bigdata
binwalk
bittwist
bogofilter
chadwick
checkstyle
clamav
dasm
dfu-programmer
djview4
dmtx-utils
etl
fatsort
fetchmail
geographiclib
gnu-cobol
gnuradio
gsoap
gtk-gnutella
ispc
kettle
launch4j
libdmtx
libmikmod
mediatomb
mikmod
mktorrent
mpop
msmtp
ndpi
ngspice
ntopng
ocp
open-cobol
osslsigncode
plantuml
pngcrush
quantlib
quex
re2c
rgxg
rkhunter
sstp-client
synfig
synfigstudio
upx
```

Shout out to mitie which has a 415MB dataset download.

Unrelated but from the formulas which used Sourceforge, the following had patch checksum issues:

```
==> Verifying ledger--patch-064b0e64d211224455511cd7b82736bb26e444c3af3b64936bec1501ed14c547.diff checksum
Warning: Patch reports different SHA256: 064b0e64d211224455511cd7b82736bb26e444c3af3b64936bec1501ed14c547

==> Verifying ledger--patch-c1438cbf989995dd0b4bfa426578a8763544f28788ae76f9ff5d23f1b8b17add.diff checksum
Warning: Patch reports different SHA256: c1438cbf989995dd0b4bfa426578a8763544f28788ae76f9ff5d23f1b8b17add

==> Verifying luabind--patch-00476ab7d918cc118e83ced427bac48de81ae8c2d3445d6f77e556b5d8bded5f.diff checksum
Warning: Patch reports different SHA256: 00476ab7d918cc118e83ced427bac48de81ae8c2d3445d6f77e556b5d8bded5f

==> Verifying mldonkey--patch-1fb503d37eed92390eb891878a9e6d69b778bd2f1d40b9845d18aa3002f3d739.patch checksum
Warning: Patch reports different SHA256: 1fb503d37eed92390eb891878a9e6d69b778bd2f1d40b9845d18aa3002f3d739

==> Verifying nant--patch-1194a3b5c8e65d47e606f9d0f3b348fb6fe1998db929a7f711a9e172764b8075.diff checksum
Warning: Patch reports different SHA256: 1194a3b5c8e65d47e606f9d0f3b348fb6fe1998db929a7f711a9e172764b8075

==> Verifying opensc--patch-18bd9b6220bfc03768c6a7f5324e7f3981eff0bc8b8f7eb0f5159508b43d6863.diff checksum
Warning: Patch reports different SHA256: 18bd9b6220bfc03768c6a7f5324e7f3981eff0bc8b8f7eb0f5159508b43d6863

==> Verifying par2--patch-eda0a381f944b1bc9d3d78bf4526f77620bcb01de48abcb08878178e47c833f7.1 checksum
Warning: Patch reports different SHA256: eda0a381f944b1bc9d3d78bf4526f77620bcb01de48abcb08878178e47c833f7

==> Verifying par2--patch-c4820b11376c9932ece944752ddd388fb50fcbcd47aaadda073997142952d969.2 checksum
Warning: Patch reports different SHA256: c4820b11376c9932ece944752ddd388fb50fcbcd47aaadda073997142952d969
```