### PR TITLE
libidn2: Add formula for v2.3.4

### DIFF
--- a/Library/Formula/libidn2.rb
+++ b/Library/Formula/libidn2.rb
@@ -1,0 +1,50 @@
+class Libidn2 < Formula
+  desc "International domain name library (IDNA2008, Punycode and TR46)"
+  homepage "https://www.gnu.org/software/libidn/#libidn2"
+  url "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.4.tar.gz"
+  mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.4.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.4.tar.gz"
+  sha256 "93caba72b4e051d1f8d4f5a076ab63c99b77faee019b72b9783b267986dbb45f"
+  license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
+
+  bottle do
+    rebuild 1
+  end
+
+  head do
+    url "https://gitlab.com/libidn/libidn2.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gengetopt" => :build
+    depends_on "gettext" => :build
+    depends_on "help2man" => :build
+    depends_on "libtool" => :build
+    depends_on "ronn" => :build
+
+    # uses_from_macos "gperf" => :build
+
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "libunistring"
+  depends_on "gettext"
+
+  def install
+    args = ["--disable-silent-rules", "--with-packager=Homebrew", "--prefix=#{prefix}"]
+    args << "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}"
+
+    system "./bootstrap", "--skip-po" if build.head?
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    ENV.delete("LC_CTYPE")
+    ENV["CHARSET"] = "UTF-8"
+    output = shell_output("#{bin}/idn2 räksmörgås.se")
+    assert_equal "xn--rksmrgs-5wao1o.se", output.chomp
+    output = shell_output("#{bin}/idn2 blåbærgrød.no")
+    assert_equal "xn--blbrgrd-fxak7p.no", output.chomp
+  end
+end


### PR DESCRIPTION
Based on
https://github.com/Homebrew/homebrew-core/commit/f15b1c5e2bad1c6735da8657300010ef406e0c23

Tested on Tiger (g5) with GCC 4.0.1

This has a libunistring dependency which has a couple of issues with its tests that I haven't resolved yet (I skipped the make check stage to get the dependency installed). 