### PR TITLE
gforth: Add mirror url

### DIFF
--- a/Library/Formula/gforth.rb
+++ b/Library/Formula/gforth.rb
@@ -2,6 +2,7 @@ class Gforth < Formula
   desc "Implementation of the ANS Forth language"
   homepage "https://www.gnu.org/software/gforth/"
   url "http://www.complang.tuwien.ac.at/forth/gforth/gforth-0.7.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/gforth/gforth-0.7.3.tar.gz"
   sha256 "2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0"
 
   depends_on "libtool" => :run


### PR DESCRIPTION
Tested on Tiger (G5) with GCC 4.0.1.