### PR TITLE
libtool 2.4.7

### DIFF
--- a/Library/Formula/libtool.rb
+++ b/Library/Formula/libtool.rb
@@ -4,15 +4,12 @@
 class Libtool < Formula
   desc "Generic library support script"
   homepage "https://www.gnu.org/software/libtool/"
-  url "http://ftpmirror.gnu.org/libtool/libtool-2.4.6.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz"
-  sha256 "7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f"
+  url "http://ftpmirror.gnu.org/libtool/libtool-2.4.7.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/libtool/libtool-2.4.7.tar.xz"
+  sha256 "4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d"
 
   bottle do
     cellar :any
-    sha256 "9e483f1712bc2a917f9183f80d3536f2e778dfbe9c89b82d7538354791b704e9" => :tiger_altivec
-    sha256 "312ee20c1208b8de8cb545513015460d68dff99aafed509999dc8d9826b92217" => :leopard_g3
-    sha256 "f14f7c9f863be4c820839eb403e5a994986f8c4d2d19ff60ea011adcceb2ed81" => :leopard_altivec
   end
 
   depends_on "m4" if MacOS.version < :leopard


### PR DESCRIPTION
Tested on Tiger (G5) with GCC 4.0.1.

Just as a heads up, the builds compiler name is embedded in the `glibtool` script and if that version is not installed, it breaks since `glibtool` tries to invoke that compiler. e.g `gcc-4.2`. Might be worth bottling using 4.0.1 as that will always be installed.