### PR TITLE
gnu-cobol 3.2

### DIFF
--- a/Library/Formula/gnu-cobol.rb
+++ b/Library/Formula/gnu-cobol.rb
@@ -1,40 +1,19 @@
 class GnuCobol < Formula
   desc "Implements much of the COBOL 85 and COBOL 2002 standards"
   homepage "http://www.opencobol.org/"
-  revision 1
-
-  stable do
-    url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/1.1/gnu-cobol-1.1.tar.gz"
-    sha256 "5cd6c99b2b1c82fd0c8fffbb350aaf255d484cde43cf5d9b92de1379343b3d7e"
-
-    fails_with :clang do
-      cause <<-EOS.undent
-        Building with Clang configures GNU-COBOL to use Clang as its compiler,
-        which causes subsequent GNU-COBOL-based builds to fail.
-      EOS
-    end
-  end
-
-  devel do
-    version "2.0_nightly_r411"
-    url "https://downloads.sourceforge.net/project/open-cobol/gnu-cobol/2.0/gnu-cobol-2.0_nightly_r411.tar.gz"
-    sha256 "5d6d767bf0255fa63bc5c26493d53f4749eb0e369b81c626d156f346b3664fe7"
-  end
+  url "https://prdownloads.sourceforge.net/project/gnucobol/gnucobol/3.2/gnucobol-3.2.tar.xz"
+  sha256 "3bb48af46ced4779facf41fdc2ee60e4ccb86eaa99d010b36685315df39c2ee2"
 
   bottle do
-    revision 2
-    sha256 "2836f2bf3362ff9e9d9578a42e7207a3c29411d481279e46c723df8ac5189292" => :yosemite
-    sha256 "c24443ab3ac33ae5d8f1092cba070e62fdc5fbd4cced94fa813b5494424d8aa4" => :mavericks
-    sha256 "3be8e2c52d16b4a829f8669636d2e13f0346855899605e02cb7c6e8c47234b20" => :mountain_lion
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "berkeley-db4"
   depends_on "gmp"
-  depends_on "gcc"
+  depends_on "gettext"
 
   def install
+    # Need unsetenv(3) to return int, not void
+    ENV.append_to_cflags "-D__DARWIN_UNIX03" if MacOS.version == :tiger
     # both environment variables are needed to be set
     # the cobol compiler takes these variables for calling cc during its run
     # if the paths to gmp and bdb are not provided, the run of cobc fails
@@ -46,16 +25,6 @@ class GnuCobol < Formula
     args = ["--prefix=#{prefix}", "--infodir=#{info}"]
     args << "--with-libiconv-prefix=/usr"
     args << "--with-libintl-prefix=/usr"
-
-    if build.stable?
-      system "aclocal"
-
-      # fix referencing of libintl and libiconv for ld
-      # bug report can be found here: https://sourceforge.net/p/open-cobol/bugs/93/
-      inreplace "configure", "-R$found_dir", "-L$found_dir"
-
-      args << "--with-cc=#{ENV.cc}"
-    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Tested on Tiger (G5) with GCC 4.0.1 & GCC 5.5.
The configure script does the right thing and we don't need pass in `--with-cc`