### PR TITLE
giflib 5.2.1

### DIFF
--- a/Library/Formula/giflib.rb
+++ b/Library/Formula/giflib.rb
@@ -1,41 +1,148 @@
 class Giflib < Formula
   desc "GIF library using patented LZW algorithm"
   homepage "http://giflib.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/giflib/giflib-4.x/giflib-4.2.3.tar.bz2"
-  sha256 "0ac8d56726f77c8bc9648c93bbb4d6185d32b15ba7bdb702415990f96f3cb766"
+  url "https://prdownloads.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz"
+  sha256 "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd"
 
   bottle do
     cellar :any
-    revision 1
-    sha256 "2abbeb99b0dec772fa020ec4cecd0df512813a223ab3e32bc760180367af4138" => :el_capitan
-    sha256 "3180706f4a94e7ede8c66299474ada34165b2947c262316186e424b1b9d25aba" => :yosemite
-    sha256 "74316a4dd9b94ca052b6f784c9764764d0b24dd8dc1f3f29b5681a374989979a" => :mavericks
-    sha256 "76953a4ac103ff0931f2e4f70dafe9283c9289de2dda7f800e8ca3b47b6830db" => :mountain_lion
   end
 
   option :universal
 
-  depends_on :x11 => :optional
+  # Upstream has stripped out the previous autotools-based build system and their
+  # Makefile doesn't work on macOS. See https://sourceforge.net/p/giflib/bugs/133/
+  # https://sourceforge.net/p/giflib/bugs/_discuss/thread/4e811ad29b/c323/attachment/Makefile.patch
+  patch :p0, :DATA
 
   def install
     ENV.universal_binary if build.universal?
+    ENV.enable_warnings if ENV.compiler == :gcc_4_0
 
-    args = %W[
-      --prefix=#{prefix}
-      --disable-dependency-tracking
-    ]
-
-    if build.without? "x11"
-      args << "--disable-x11" << "--without-x"
-    else
-      args << "--with-x" << "--enable-x11"
-    end
-
-    system "./configure", *args
-    system "make", "install"
+    system "make", "all"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do
-    assert_match /Size: 1x1/, shell_output("#{bin}/gifinfo #{test_fixtures("test.gif")}")
+    output = shell_output("#{bin}/giftext #{test_fixtures("test.gif")}")
+    assert_match "Screen Size - Width = 1, Height = 1", output
   end
 end
+__END__
+--- Makefile.orig	2019-06-24 17:08:57.000000000 +0100
++++ Makefile	2023-11-22 19:38:36.000000000 +0000
+@@ -8,7 +8,7 @@
+ #
+ OFLAGS = -O0 -g
+ OFLAGS  = -O2
+-CFLAGS  = -std=gnu99 -fPIC -Wall -Wno-format-truncation $(OFLAGS)
++CFLAGS  ?= -std=gnu99 -fPIC -Wall -Wno-format-truncation $(OFLAGS)
+ 
+ SHELL = /bin/sh
+ TAR = tar
+@@ -37,6 +37,8 @@
+ UHEADERS = getarg.h
+ UOBJECTS = $(USOURCES:.c=.o)
+ 
++UNAME:=$(shell uname)
++
+ # Some utilities are installed
+ INSTALLABLE = \
+ 	gif2rgb \
+@@ -61,27 +63,53 @@
+ 
+ LDLIBS=libgif.a -lm
+ 
+-all: libgif.so libgif.a libutil.so libutil.a $(UTILS)
++SOEXTENION	= so
++LIBGIFSO	= libgif.$(SOEXTENSION)
++LIBGIFSOMAJOR	= libgif.$(SOEXTENSION).$(LIBMAJOR)
++LIBGIFSOVER	= libgif.$(SOEXTENSION).$(LIBVER)
++LIBUTILSO	= libutil.$(SOEXTENSION)
++LIBUTILSOMAJOR	= libutil.$(SOEXTENSION).$(LIBMAJOR)
++ifeq ($(UNAME), Darwin)
++SOEXTENSION	= dylib
++LIBGIFSO        = libgif.$(SOEXTENSION)
++LIBGIFSOMAJOR   = libgif.$(LIBMAJOR).$(SOEXTENSION)
++LIBGIFSOVER	= libgif.$(LIBVER).$(SOEXTENSION)
++LIBUTILSO	= libutil.$(SOEXTENSION)
++LIBUTILSOMAJOR	= libutil.$(LIBMAJOR).$(SOEXTENSION)
++endif
++
++all: $(LIBGIFSO) libgif.a $(LIBUTILSO) libutil.a $(UTILS)
++ifeq ($(UNAME), Darwin)
++else
+ 	$(MAKE) -C doc
++endif
+ 
+ $(UTILS):: libgif.a libutil.a
+ 
+-libgif.so: $(OBJECTS) $(HEADERS)
+-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,libgif.so.$(LIBMAJOR) -o libgif.so $(OBJECTS)
++$(LIBGIFSO): $(OBJECTS) $(HEADERS)
++ifeq ($(UNAME), Darwin)
++	$(CC) $(CFLAGS) -dynamiclib -current_version $(LIBVER) $(OBJECTS) -o $(LIBGIFSO)
++else
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBGIFSOMAJOR) -o $(LIBGIFSO) $(OBJECTS)
++endif
+ 
+ libgif.a: $(OBJECTS) $(HEADERS)
+ 	$(AR) rcs libgif.a $(OBJECTS)
+ 
+-libutil.so: $(UOBJECTS) $(UHEADERS)
+-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,libutil.so.$(LIBMAJOR) -o libutil.so $(UOBJECTS)
++$(LIBUTILSO): $(UOBJECTS) $(UHEADERS)
++ifeq ($(UNAME), Darwin)
++	$(CC) $(CFLAGS) -dynamiclib -current_version $(LIBVER) $(OBJECTS) -o $(LIBUTILSO)
++else
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBUTILMAJOR) -o $(LIBUTILSO) $(UOBJECTS)
++endif
+ 
+ libutil.a: $(UOBJECTS) $(UHEADERS)
+ 	$(AR) rcs libutil.a $(UOBJECTS)
+ 
+ clean:
+-	rm -f $(UTILS) $(TARGET) libgetarg.a libgif.a libgif.so libutil.a libutil.so *.o
+-	rm -f libgif.so.$(LIBMAJOR).$(LIBMINOR).$(LIBPOINT)
+-	rm -f libgif.so.$(LIBMAJOR)
++	rm -f $(UTILS) $(TARGET) libgetarg.a libgif.a $(LIBGIFSO) libutil.a $(LIBUTILSO) *.o
++	rm -f $(LIBGIFSOVER)
++	rm -f $(LIBGIFSOMAJOR)
+ 	rm -fr doc/*.1 *.html doc/staging
+ 
+ check: all
+@@ -89,7 +117,12 @@
+ 
+ # Installation/uninstallation
+ 
++ifeq ($(UNAME), Darwin)
++install: all install-bin install-include install-lib
++else
+ install: all install-bin install-include install-lib install-man
++endif
++
+ install-bin: $(INSTALLABLE)
+ 	$(INSTALL) -d "$(DESTDIR)$(BINDIR)"
+ 	$(INSTALL) $^ "$(DESTDIR)$(BINDIR)"
+@@ -99,9 +132,9 @@
+ install-lib:
+ 	$(INSTALL) -d "$(DESTDIR)$(LIBDIR)"
+ 	$(INSTALL) -m 644 libgif.a "$(DESTDIR)$(LIBDIR)/libgif.a"
+-	$(INSTALL) -m 755 libgif.so "$(DESTDIR)$(LIBDIR)/libgif.so.$(LIBVER)"
+-	ln -sf libgif.so.$(LIBVER) "$(DESTDIR)$(LIBDIR)/libgif.so.$(LIBMAJOR)"
+-	ln -sf libgif.so.$(LIBMAJOR) "$(DESTDIR)$(LIBDIR)/libgif.so"
++	$(INSTALL) -m 755 $(LIBGIFSO) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSOVER)"
++	ln -sf $(LIBGIFSOVER) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSOMAJOR)"
++	ln -sf $(LIBGIFSOMAJOR) "$(DESTDIR)$(LIBDIR)/$(LIBGIFSO)"
+ install-man:
+ 	$(INSTALL) -d "$(DESTDIR)$(MANDIR)/man1"
+ 	$(INSTALL) -m 644 doc/*.1 "$(DESTDIR)$(MANDIR)/man1"
+@@ -112,7 +145,7 @@
+ 	rm -f "$(DESTDIR)$(INCDIR)/gif_lib.h"
+ uninstall-lib:
+ 	cd "$(DESTDIR)$(LIBDIR)" && \
+-		rm -f libgif.a libgif.so libgif.so.$(LIBMAJOR) libgif.so.$(LIBVER)
++		rm -f libgif.a $(LIBGIFSO) $(LIBGIFSOMAJOR) $(LIBGIFSOVER)
+ uninstall-man:
+ 	cd "$(DESTDIR)$(MANDIR)/man1" && rm -f $(shell cd doc >/dev/null && echo *.1)
+ 


### PR DESCRIPTION
Include patch to Makefile inline since we also need to allow CFLAGS to be overriden, otherwise build breaks with GCC 4.0 since -Wno-format-truncation is not supported.

Tested on Tiger (G5) with GCC 4.0.1.