### PR TITLE
mercurial 6.6

### DIFF
--- a/Library/Formula/mercurial.rb
+++ b/Library/Formula/mercurial.rb
@@ -3,15 +3,16 @@
 class Mercurial < Formula
   desc "Scalable distributed version control system"
   homepage "https://www.mercurial-scm.org/"
-  url "https://www.mercurial-scm.org/release/mercurial-6.5.2.tar.gz"
-  sha256 "afc39d7067976593c8332b8e97a12afd393b55037c5fb9c3cab1a42c7560f60a"
+  url "https://www.mercurial-scm.org/release/mercurial-6.6.tar.gz"
+  sha256 "6bfd71cba0df3b18de424216b30e2a541cca6e0104853d3334be80a2ab09a4ad"
+  license "GPL-2.0-or-later"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "16695d8cf56854e015b1467585b1d3d3315ce2e67f8d5190f0fc7c9c8e155e61" => :tiger_altivec
   end
 
   depends_on :python3
+  depends_on "gettext" => :build
 
   def install
     ENV.minimal_optimization if MacOS.version <= :snow_leopard
@@ -31,21 +32,4 @@ class Mercurial < Formula
   test do
     system "#{bin}/hg", "init"
   end
-
-  # Fix PowerPC build
-  patch :p0, :DATA
 end
-__END__
---- mercurial/thirdparty/sha1dc/lib/sha1.c.orig 2023-04-11 20:39:20.000000000 +0000
-+++ mercurial/thirdparty/sha1dc/lib/sha1.c
-@@ -102,6 +102,10 @@
-  */
- #define SHA1DC_BIGENDIAN
-
-+#elif (defined(__APPLE__) && defined(__BIG_ENDIAN__) && !defined(SHA1DC_BIGENDIAN))
-+/* older gcc compilers which are the default on Apple PPC do not define __BYTE_ORDER__ */
-+#define SHA1DC_BIGENDIAN
-+
- /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> or <os whitelist> */
- #elif defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
- /*


### PR DESCRIPTION
Add gettext as a build dep to get translations
warning: hgbuildmo: could not find msgfmt executable, no translations will be built.

Tested on Tiger (G5) with GCC 4.01