### PR TITLE
whois: Add formula for v5.5.20

### DIFF
--- a/Library/Formula/whois.rb
+++ b/Library/Formula/whois.rb
@@ -1,0 +1,45 @@
+class Whois < Formula
+  desc "Lookup tool for domain names and other internet resources"
+  homepage "https://github.com/rfc1036/whois"
+  url "https://ftp.debian.org/debian/pool/main/w/whois/whois_5.5.20.tar.xz"
+  sha256 "42085102dfad82067abe2d5d1cfca59586573dee528718559b022e762bb85cf1"
+  license "GPL-2.0-or-later"
+
+  bottle do
+  end
+
+  keg_only :provided_by_osx
+
+  depends_on "make" => :build
+  depends_on "perl" => :build
+  depends_on "pkg-config" => :build
+  depends_on "bash-completion"
+  depends_on "libidn2"
+  depends_on "libxcrypt"
+
+  # Attribute was introduced in GCC 11
+  patch :p0, :DATA
+
+  def install
+    ENV.append "LDFLAGS", "-L/usr/lib -liconv"
+    ENV.append_to_cflags "-std=gnu99"
+
+    system "gmake", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/whois", "brew.sh"
+  end
+end
+__END__
+--- utils.h.orig	2023-11-23 15:17:08.000000000 +0000
++++ utils.h	2023-11-23 15:17:23.000000000 +0000
+@@ -24,7 +24,7 @@
+ # define NONNULL
+ # define UNUSED
+ #endif
+-#if defined __GNUC__ && !defined __clang__
++#if (defined __GNUC__ && __GNUC__ >= 11) && !defined __clang__
+ # define MALLOC_FREE __attribute__((malloc(free)))
+ #else
+ # define MALLOC_FREE


### PR DESCRIPTION
Based on
https://raw.githubusercontent.com/Homebrew/homebrew-core/f04bca02643e44e5fa8b9fd5aaff131a4d1821b3/Formula/w/whois.rb

Rather that build & copy selected binaries in the original formula, we 'make install' which is where the bash-completion dependency comes in. Opted to add the dependency, rather than patch the Makefile which calls pkg-config to work out where to install bash-completions.

Requires PR #997, #998, #1024 
Tested on Tiger (G5) with GCC 4.0.1