### PR TITLE
vala: Don't assist with path for libintl

### DIFF
--- a/Library/Formula/vala.rb
+++ b/Library/Formula/vala.rb
@@ -33,7 +33,7 @@ class Vala < Formula
     valac_args = [ # Build with debugging symbols.
       "-g",
       # Use Homebrew's default C compiler.
-      "--cc=#{ENV.cc} -L#{Formula["gettext"].opt_lib}",
+      "--cc=#{ENV.cc}",
       # Save generated C source code.
       "--save-temps",
       # Vala source code path.


### PR DESCRIPTION
It masks an issue with glib's `pkg-config` file which is parsed at runtime by `valac`. `glib-2.0.pc` should have the relevant parts for `-lintl`.

See PR #1029