### PR TITLE
gnutls 3.7.10

### DIFF
--- a/Library/Formula/gnutls.rb
+++ b/Library/Formula/gnutls.rb
@@ -10,6 +10,10 @@ class Gnutls < Formula
     cellar :any
   end
 
+  # Need a C11/C++11 compiler
+  fails_with :gcc_4_0
+  fails_with :gcc
+
   # Availability.h appeared in Leopard
   patch :p0, :DATA
 


### PR DESCRIPTION
p11-kit is no longer optional
Skip touching anything to do with the certificates in system supplied keychains as they'll most definitely be out of date now. Use up to date zlib instead of the system provided one.

Tested on Tiger (G5) with GCC 5.5 & GCC 7 (needs a C/C++ 11 compiler).
Should be built after PR #1031 is merged

I haven't dealt with the revision bump as previously stated in the top comment (now removed since it was about the then incoming 3.4 release)