### PR TITLE
openssl: drop makedepend build dep

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -10,7 +10,6 @@ class Openssl < Formula
 
   # Need a minimum of Perl 5.10 for Configure script and Test::More 0.96 for testsuite
   depends_on "perl" => :build
-  depends_on "makedepend" => :build
   depends_on "curl-ca-bundle"
 
   bottle do


### PR DESCRIPTION
makedepend is slow and the compiler is capable of handling dependencies.
If you have makedepend installed, you should uninstall it on Tiger as we're not guarded against using it and build will take a little longer.

Discovered when investigating why a G4 iBook running Leopard was taking less time than a G5 iMac running Tiger.

Build on iBook G4 with Leopard 39.5 minutes
Build on iMac G5 with Tiger  32.2 minutes