### PR TITLE
openssl 3.4.0

### DIFF
--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -32,7 +32,7 @@ class Openssl3 < Formula
     if Hardware::CPU.ppc?
       args << "darwin-ppc-cc"
     elsif Hardware::CPU.intel?
-      args << (Hardware::CPU.is_64_bit? ? "darwin64-x86_64-cc" : "darwin-i386-cc")
+      args << (Hardware::CPU.is_64_bit? && MacOS.version > :leopard ? "darwin64-x86_64-cc" : "darwin-i386-cc")
     end
     args
   end

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -20,11 +20,13 @@ class Openssl3 < Formula
   # SSLv3 & zlib are off by default with 1.1.0 but this may not
   # be obvious to everyone, so explicitly state it for now to
   # help debug inevitable breakage.
+  # makedepend slows down the build considerably.
   def configure_args
     args = %W[
       --prefix=#{prefix}
       --openssldir=#{openssldir}
       --libdir=#{lib}
+      no-makedepend
       no-ssl3
       no-ssl3-method
       no-zlib

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -31,6 +31,10 @@ class Openssl3 < Formula
       no-ssl3-method
       no-zlib
     ]
+    # as(1) on Tiger/Intel does not support specifying an alignment value for .comm directive.
+    # .comm      _OPENSSL_ia32cap_P,16,2
+    # fails with "Rest of line ignored. 1st junk character valued 44 (,)."
+    args << "no-asm" if MacOS.version == :tiger && Hardware::CPU.intel?
     # No {get,make,set}context support before Leopard
     args << "no-async" if MacOS.version == :tiger
     if Hardware::CPU.ppc?
@@ -55,6 +59,12 @@ class Openssl3 < Formula
     # crypto/asn1/a_time.c:659: error: invalid operands to binary -
     # https://github.com/openssl/openssl/commit/0176fc78d090210cd7e231a7c2c4564464509506
     ENV.append_to_cflags "-DUSE_TIMEGM" if MacOS.version == :tiger
+
+    # Match Tiger/PowerPC behaviour on Intel builds since toolchain is unable to cope
+    # ld: common symbols not allowed with MH_DYLIB output format with the -multi_module option
+    if Hardware::CPU.intel? && MacOS.version == :tiger
+      ENV.append_to_cflags "-fno-common"
+    end
 
     # This ensures where Homebrew's Perl is needed the Cellar path isn't
     # hardcoded into OpenSSL's scripts, causing them to break every Perl update.

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -1,17 +1,13 @@
 class Openssl3 < Formula
   desc "Cryptography and SSL/TLS Toolkit"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-3.2.0.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-3.2.0.tar.gz"
-  sha256 "14c826f07c7e433706fb5c69fa9e25dab95684844b4c962a2cf1bf183eb4690e"
+  url "https://www.openssl.org/source/openssl-3.2.1.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-3.2.1.tar.gz"
+  sha256 "83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"
   license "Apache-2.0"
 
   bottle do
   end
-
-  # Disable build of HWAES on PPC Macs
-  # https://github.com/openssl/openssl/pull/22860
-  patch :DATA
 
   keg_only :provided_by_osx
 
@@ -103,49 +99,3 @@ class Openssl3 < Formula
     end
   end
 end
-__END__
---- a/crypto/aes/build.info
-+++ b/crypto/aes/build.info
-@@ -38,7 +38,11 @@ IF[{- !$disabled{asm} -}]
-   $AESASM_parisc20_64=$AESASM_parisc11
-   $AESDEF_parisc20_64=$AESDEF_parisc11
- 
--  $AESASM_ppc32=aes_core.c aes_cbc.c aes-ppc.s vpaes-ppc.s aesp8-ppc.s
-+  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
-+    $AESASM_ppc32=aes_core.c aes_cbc.c aes-ppc.s vpaes-ppc.s aesp8-ppc.s
-+  ELSE
-+    $AESASM_ppc32=aes_core.c aes_cbc.c aes-ppc.s vpaes-ppc.s
-+  ENDIF
-   $AESDEF_ppc32=AES_ASM VPAES_ASM
-   $AESASM_ppc64=$AESASM_ppc32
-   $AESDEF_ppc64=$AESDEF_ppc32
-diff --git a/include/crypto/aes_platform.h b/include/crypto/aes_platform.h
-index eb280e754a6a1..a0373187c86d1 100644
---- a/include/crypto/aes_platform.h
-+++ b/include/crypto/aes_platform.h
-@@ -65,16 +65,16 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
- #   ifdef VPAES_ASM
- #    define VPAES_CAPABLE (OPENSSL_ppccap_P & PPC_ALTIVEC)
- #   endif
--#   define HWAES_CAPABLE  (OPENSSL_ppccap_P & PPC_CRYPTO207)
--#   define HWAES_set_encrypt_key aes_p8_set_encrypt_key
--#   define HWAES_set_decrypt_key aes_p8_set_decrypt_key
--#   define HWAES_encrypt aes_p8_encrypt
--#   define HWAES_decrypt aes_p8_decrypt
--#   define HWAES_cbc_encrypt aes_p8_cbc_encrypt
--#   define HWAES_ctr32_encrypt_blocks aes_p8_ctr32_encrypt_blocks
--#   define HWAES_xts_encrypt aes_p8_xts_encrypt
--#   define HWAES_xts_decrypt aes_p8_xts_decrypt
- #   if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
-+#    define HWAES_CAPABLE  (OPENSSL_ppccap_P & PPC_CRYPTO207)
-+#    define HWAES_set_encrypt_key aes_p8_set_encrypt_key
-+#    define HWAES_set_decrypt_key aes_p8_set_decrypt_key
-+#    define HWAES_encrypt aes_p8_encrypt
-+#    define HWAES_decrypt aes_p8_decrypt
-+#    define HWAES_cbc_encrypt aes_p8_cbc_encrypt
-+#    define HWAES_ctr32_encrypt_blocks aes_p8_ctr32_encrypt_blocks
-+#    define HWAES_xts_encrypt aes_p8_xts_encrypt
-+#    define HWAES_xts_decrypt aes_p8_xts_decrypt
- #    define PPC_AES_GCM_CAPABLE (OPENSSL_ppccap_P & PPC_MADD300)
- #    define AES_GCM_ENC_BYTES 128
- #    define AES_GCM_DEC_BYTES 128

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -1,9 +1,9 @@
 class Openssl3 < Formula
   desc "Cryptography and SSL/TLS Toolkit"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-3.3.1.tar.gz"
-  mirror "https://github.com/openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"
-  sha256 "777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
+  url "https://www.openssl.org/source/openssl-3.4.0.tar.gz"
+  mirror "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz"
+  sha256 "e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf"
   license "Apache-2.0"
 
   bottle do

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -1,9 +1,9 @@
 class Openssl3 < Formula
   desc "Cryptography and SSL/TLS Toolkit"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-3.2.1.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-3.2.1.tar.gz"
-  sha256 "83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39"
+  url "https://www.openssl.org/source/openssl-3.3.1.tar.gz"
+  mirror "https://github.com/openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"
+  sha256 "777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e"
   license "Apache-2.0"
 
   bottle do

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -11,6 +11,8 @@ class Openssl3 < Formula
 
   keg_only :provided_by_osx
 
+  option "with-tests", "Build and run the test suite"
+
   depends_on "curl-ca-bundle"
   depends_on "perl"
 
@@ -60,8 +62,9 @@ class Openssl3 < Formula
     openssldir.mkpath
     system "perl", "./Configure", *(configure_args)
     system "make"
-    system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
-    system "make", "test"
+    # Save time by skipping on the full HTML documentation set using the install target & only install man pages.
+    system "make", "install_sw", "install_ssldirs", "install_man_docs", "MANDIR=#{man}", "MANSUFFIX=ssl"
+    system "make", "test" if build.with?("tests") || build.bottle?
   end
 
   def openssldir


### PR DESCRIPTION
It's now possible to build on Tiger with asm support. `OPENSSL_LOCAL_CONFIG_DIR` landed in OpenSSL 1.1.0 and we've building with it untouched in `openssl.rb`, don't bother unsetting it here too.
Skip setting compiler optimisation, the build ends up setting -O3 in places.
By making the test suite run optional, and only installing manuals, build time is significantly reduced.

120minutes before (full docs, suite run) to
no test, with docs, 35.9 minutes
no test, with man, 29.3
Building no tests, no docs results in 19.5mins on 1.8Ghz G5 iMac.

224 minutes with tests & man, 44minutes no tests, with  man, on a 1.33Ghz G4 PowerBook.
50.5 minutes no tests, with man, on a 1.33Ghz iBook G4

Tested on Tiger powerpc (G4/G5) and intel (core2duo) with GCC 4.0.1, Leopard powerpc (G4) and intel (core2duo) with GCC 4.2, El Capitan with llvm