### PR TITLE
libnghttp2: Add formula for v1.58.0

### DIFF
--- a/Library/Formula/libnghttp2.rb
+++ b/Library/Formula/libnghttp2.rb
@@ -1,0 +1,56 @@
+class Libnghttp2 < Formula
+  desc "HTTP/2 C Library"
+  homepage "https://nghttp2.org/"
+  url "https://github.com/nghttp2/nghttp2/releases/download/v1.58.0/nghttp2-1.58.0.tar.gz"
+  mirror "http://fresh-center.net/linux/www/nghttp2-1.58.0.tar.gz"
+  mirror "http://fresh-center.net/linux/www/legacy/nghttp2-1.58.0.tar.gz"
+  # this legacy mirror is for user to install from the source when https not working for them
+  # see discussions in here, https://github.com/Homebrew/homebrew-core/pull/133078#discussion_r1221941917
+  sha256 "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb"
+  license "MIT"
+
+  bottle do
+  end
+
+  head do
+    url "https://github.com/nghttp2/nghttp2.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  depends_on "pkg-config" => :build
+
+  # These used to live in `nghttp2`.
+  link_overwrite "include/nghttp2"
+  link_overwrite "lib/libnghttp2.a"
+  link_overwrite "lib/libnghttp2.dylib"
+  link_overwrite "lib/libnghttp2.14.dylib"
+  link_overwrite "lib/libnghttp2.so"
+  link_overwrite "lib/libnghttp2.so.14"
+  link_overwrite "lib/pkgconfig/libnghttp2.pc"
+
+  def install
+    system "autoreconf", "-ivf" if build.head?
+    system "./configure", "--prefix=#{prefix}", "--enable-lib-only"
+    system "make", "-C", "lib"
+    system "make", "-C", "lib", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <nghttp2/nghttp2.h>
+      #include <stdio.h>
+
+      int main() {
+        nghttp2_info *info = nghttp2_version(0);
+        printf("%s", info->version_str);
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnghttp2", "-o", "test"
+    assert_equal version.to_s, shell_output("./test")
+  end
+end


### PR DESCRIPTION
Tested on Tiger (G5) with GCC 4.0.1 as a dependency for curl.

based on
https://github.com/Homebrew/homebrew-core/blob/d60bc504f4526917b7aae5cdae51f188edcc7d8e/Formula/lib/libnghttp2.rb