### PR TITLE
fatsort 1.5.tbd

### DIFF
--- a/Library/Formula/fatsort.rb
+++ b/Library/Formula/fatsort.rb
@@ -1,8 +1,8 @@
 class Fatsort < Formula
   desc "Sorts FAT16 and FAT32 partitions"
   homepage "http://fatsort.sourceforge.net/"
-  url "https://sourceforge.net/code-snapshots/svn/f/fa/fatsort/code/fatsort-code-r522-trunk.zip"
-  sha256 "341ab8b9dc04b53d47abcb282c7cb027a2bae982e1ded3083d62aa7c260a1bde"
+  url "https://mirrors.aliyun.com/macports/distfiles/fatsort/fatsort-1.5.0.456.tar.xz"
+  sha256 "a835b47814fd30d5bad464b839e9fc404bc1a6f5a5b1f6ed760ce9744915de95"
 
   depends_on "help2man"
 

--- a/Library/Formula/fatsort.rb
+++ b/Library/Formula/fatsort.rb
@@ -1,8 +1,8 @@
 class Fatsort < Formula
   desc "Sorts FAT16 and FAT32 partitions"
   homepage "http://fatsort.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/fatsort/fatsort-1.3.365.tar.gz"
-  sha256 "77acc374b189e80e3d75d3508f3c0ca559f8030f1c220f7cfde719a4adb03f3d"
+  url "https://sourceforge.net/code-snapshots/svn/f/fa/fatsort/code/fatsort-code-r522-trunk.zip"
+  sha256 "341ab8b9dc04b53d47abcb282c7cb027a2bae982e1ded3083d62aa7c260a1bde"
 
   depends_on "help2man"
 

--- a/Library/Formula/fatsort.rb
+++ b/Library/Formula/fatsort.rb
@@ -7,7 +7,7 @@ class Fatsort < Formula
   depends_on "help2man"
 
   def install
-    system "make", "CC=#{ENV.cc}"
+    system "make", "CC=#{ENV.cc}", "LD=#{ENV.cc}"
     bin.install "src/fatsort"
     man1.install "man/fatsort.1"
   end


### PR DESCRIPTION
The support for PowerPC seems to be dropped for this useful tool. I went to sourceforge and compiled all the versions until I found the last one working on my Mac Os X Leopard and tested the install successfully.