### PR TITLE
bdw-gc: Adjust libatomic_ops dep

### DIFF
--- a/Library/Formula/bdw-gc.rb
+++ b/Library/Formula/bdw-gc.rb
@@ -3,9 +3,9 @@ class BdwGc < Formula
   homepage "http://www.hboehm.info/gc/"
   url "https://www.hboehm.info/gc/gc_source/gc-7.6.12.tar.gz"
   sha256 "6cafac0d9365c2f8604f930aabd471145ac46ab6f771e835e57995964e845082"
+  revision 1
 
   bottle do
-    sha256 "ec6790b3da18a6f131022ee1272ec1c97b3d330af5adfcd67ff8e69152167890" => :tiger_altivec
   end
 
   head do
@@ -18,7 +18,7 @@ class BdwGc < Formula
   option :universal
 
   depends_on "pkg-config" => :build
-  depends_on "libatomic_ops" => :build
+  depends_on "libatomic_ops"
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
libatomic_ops is included in the library list of bdw-gc.pc, if it's not installed, consumer's build breaks.