### PR TITLE
Add ARM cross compile toolchain

### DIFF
--- a/Library/Formula/arm-none-eabi-binutils.rb
+++ b/Library/Formula/arm-none-eabi-binutils.rb
@@ -1,0 +1,41 @@
+class ArmNoneEabiBinutils < Formula
+  desc "GNU Binutils for arm-none-eabi cross development"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.bz2"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
+  sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
+  license "GPL-3.0-or-later"
+
+  bottle do
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "zlib"
+
+  def install
+    target = "arm-none-eabi"
+    system "./configure", "--target=#{target}",
+           "--prefix=#{prefix}",
+           "--libdir=#{lib}/#{target}",
+           "--infodir=#{info}/#{target}-binutils",
+           "--with-system-zlib",
+           "--disable-nls"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test-s.s").write <<~EOS
+      .section .text
+      .globl _start
+      _start:
+          mov r1, #0
+          mov r2, #1
+          svc #0x80
+    EOS
+    system "#{bin}/arm-none-eabi-as", "-o", "test-s.o", "test-s.s"
+    assert_match "file format elf32-littlearm",
+                 shell_output("#{bin}/arm-none-eabi-objdump -a test-s.o")
+    assert_match "f()", shell_output("#{bin}/arm-none-eabi-c++filt _Z1fv")
+  end
+end


### PR DESCRIPTION
arm-none-eabi-binutils: Add a formula for binutils 2.41
Based on
https://github.com/Homebrew/homebrew-core/blob/f5c6266aaf51084a7f9e5d1917cb8f566fee0395/Formula/a/arm-none-eabi-binutils.rb without zstd support for now (needs a C11 compiler + haven't updated formula yet)

Tested on Tiger powerpc (G4/G5) with GCC 4.0.1. Intel: Leopard, Snow Leopard, El Capitan