### PR TITLE
avrdude 7.0

### DIFF
--- a/Library/Formula/avrdude.rb
+++ b/Library/Formula/avrdude.rb
@@ -12,7 +12,7 @@ class Avrdude < Formula
   fails_with :gcc
   fails_with :gcc_4_0
 
-  depends_on "libusb-compat"
+  depends_on "libusb"
   depends_on "libftdi"
   depends_on "libelf"
   depends_on "libhid" => :optional

--- a/Library/Formula/avrdude.rb
+++ b/Library/Formula/avrdude.rb
@@ -1,35 +1,23 @@
 class Avrdude < Formula
   desc "Atmel AVR MCU programmer"
   homepage "http://savannah.nongnu.org/projects/avrdude/"
-  url "http://download.savannah.gnu.org/releases/avrdude/avrdude-6.1.tar.gz"
-  mirror "http://download-mirror.savannah.gnu.org/releases/avrdude/avrdude-6.1.tar.gz"
-  sha256 "9e98baca8e57cad402aaa1c7b61c8de750ed4f6fed577f7e4935db0430783d3b"
+  url "http://download.savannah.gnu.org/releases/avrdude/avrdude-7.0.tar.gz"
+  mirror "http://download-mirror.savannah.gnu.org/releases/avrdude/avrdude-7.0.tar.gz"
+  sha256 "c0ef65d98d6040ca0b4f2b700d51463c2a1f94665441f39d15d97442dbb79b54"
 
   bottle do
-    sha1 "2d759fea880b097754defe8016e026390dbcfb31" => :mavericks
-    sha1 "83017c7fb34b0a2da5919b6b1dde9c05bf237f2a" => :mountain_lion
-    sha1 "438562a4b84b4e868cdf01b81e7543053a89a7ff" => :lion
   end
 
-  head do
-    url "svn://svn.savannah.nongnu.org/avrdude/trunk/avrdude/"
+  # Need a compiler with C11 support 
+  fails_with :gcc
+  fails_with :gcc_4_0
 
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
-
-  depends_on :macos => :snow_leopard # needs GCD/libdispatch
   depends_on "libusb-compat"
-  depends_on "libftdi0"
+  depends_on "libftdi"
   depends_on "libelf"
   depends_on "libhid" => :optional
 
   def install
-    if build.head?
-      inreplace "bootstrap", /libtoolize/, "glibtoolize"
-      system "./bootstrap"
-    end
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
v7.0 is the last autoconf'd version of avrdude, newer versions switch to cmake & require a newer version than we package. Switch to using libftdi 1.x as it is the actively developed release branch.

Tested on Tiger powerpc G4/GCC 7.5 and G5/GCC 5.5, libftid 0.20 & 1.1 and a [littlewire adapter](http://littlewire.github.io).

Requires PR #1064 #1066 