### PR TITLE
libusb 1.0.23

### DIFF
--- a/Library/Formula/libusb.rb
+++ b/Library/Formula/libusb.rb
@@ -1,39 +1,37 @@
 class Libusb < Formula
   desc "Library for USB device access"
-  homepage "http://libusb.info"
-  url "https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.20/libusb-1.0.20.tar.bz2"
-  sha256 "cb057190ba0a961768224e4dc6883104c6f945b2bf2ef90d7da39e7c1834f7ff"
+  homepage "https://libusb.info/"
+  url "https://github.com/libusb/libusb/releases/download/v1.0.23/libusb-1.0.23.tar.bz2"
+  # sha256 "12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5"
+  sha256 "db11c06e958a82dac52cf3c65cb4dd2c3f339c8a988665110e0d24d19312ad8d"
+  license "LGPL-2.1-or-later"
 
   bottle do
-    cellar :any
-    sha256 "f04c366717f0ddeef3871f767242f50cf07aefc16f260e11e2f916fe7c17d6fd" => :el_capitan
-    sha256 "f041c11fe5402b585f2617640cd374b032fb314bebeadc2ad0202bf306bc4532" => :yosemite
-    sha256 "a156b5968853363f5465d7a281cdc536d03d77f26fd98ed7196363b0af41bbb0" => :mavericks
   end
 
   head do
-    url "https://github.com/libusb/libusb.git"
+    url "https://github.com/libusb/libusb.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  option :universal
-  option "without-runtime-logging", "Build without runtime logging functionality"
-  option "with-default-log-level-debug", "Build with default runtime log level of debug (instead of none)"
-
-  deprecated_option "no-runtime-logging" => "without-runtime-logging"
-
   def install
-    ENV.universal_binary if build.universal?
-
     args = %W[--disable-dependency-tracking --prefix=#{prefix}]
-    args << "--disable-log" if build.without? "runtime-logging"
-    args << "--enable-debug-log" if build.with? "default-log-level-debug"
 
     system "./autogen.sh" if build.head?
     system "./configure", *args
     system "make", "install"
+    (pkgshare/"examples").install Dir["examples/*"] - Dir["examples/Makefile*"]
+  end
+
+  test do
+    cp_r (pkgshare/"examples"), testpath
+    cd "examples" do
+      system ENV.cc, "listdevs.c", "-L#{lib}", "-I#{include}/libusb-1.0",
+             "-lusb-1.0", "-o", "test"
+      system "./test"
+    end
   end
 end


### PR DESCRIPTION
This is the last version to support C99. v1.0.24 onwards requires C11 support which requires stock GCC and they struggle with USB.h as there's pragmas defined which are Apple extensions. https://trac.macports.org/ticket/61868#comment:8

Tested on Tiger (G5) with GCC 4.0.1