### PR TITLE
capstone 5.0.3

### DIFF
--- a/Library/Formula/capstone.rb
+++ b/Library/Formula/capstone.rb
@@ -1,15 +1,14 @@
 class Capstone < Formula
   desc "Multi-platform, multi-architecture disassembly framework"
   homepage "https://www.capstone-engine.org/"
-  url "https://github.com/capstone-engine/capstone/archive/refs/tags/5.0.1.tar.gz"
-  sha256 "2b9c66915923fdc42e0e32e2a9d7d83d3534a45bb235e163a70047951890c01a"
+  url "https://github.com/capstone-engine/capstone/archive/refs/tags/5.0.3.tar.gz"
+  sha256 "3970c63ca1f8755f2c8e69b41432b710ff634f1b45ee4e5351defec4ec8e1753"
   license "BSD-3-Clause"
   head "https://github.com/capstone-engine/capstone.git", branch: "next"
 
   bottle do
   end
 
-  # Switch from binary constants to hex so GCC 4.x can be used
   # Fix OS detection
   patch :p0, :DATA
 
@@ -59,26 +58,6 @@ class Capstone < Formula
   end
 end
 __END__
---- arch/TriCore/TriCoreInstPrinter.c.orig	2024-02-03 00:59:37.000000000 +0000
-+++ arch/TriCore/TriCoreInstPrinter.c	2024-02-03 01:00:45.000000000 +0000
-@@ -402,7 +402,7 @@
- 		case TRICORE_LOOP_sbr:
- 			// {27b’111111111111111111111111111, disp4, 0};
- 			disp = (int32_t)MI->address +
--			       ((0b111111111111111111111111111 << 5) |
-+			       ((0x7FFFFFF << 5) |
- 				(disp << 1));
- 			break;
- 		default:
-@@ -449,7 +449,7 @@
- 	if (MCOperand_isImm(MO)) {
- 		uint32_t imm = MCOperand_getImm(MO);
- 		// {27b’111111111111111111111111111, disp4, 0};
--		imm = 0b11111111111111111111111111100000 | (imm << 1);
-+		imm = 0xFFFFFFE0 | (imm << 1);
- 
- 		printInt32Bang(O, imm);
- 		fill_imm(MI, imm);
 --- Makefile.orig	2024-02-03 01:12:02.000000000 +0000
 +++ Makefile	2024-02-03 01:18:32.000000000 +0000
 @@ -344,7 +344,7 @@

--- a/Library/Formula/capstone.rb
+++ b/Library/Formula/capstone.rb
@@ -1,36 +1,33 @@
 class Capstone < Formula
   desc "Multi-platform, multi-architecture disassembly framework"
-  homepage "http://capstone-engine.org"
-  url "http://capstone-engine.org/download/3.0.4/capstone-3.0.4.tgz"
-  sha256 "3e88abdf6899d11897f2e064619edcc731cc8e97e9d4db86495702551bb3ae7f"
+  homepage "https://www.capstone-engine.org/"
+  url "https://github.com/capstone-engine/capstone/archive/refs/tags/5.0.1.tar.gz"
+  sha256 "2b9c66915923fdc42e0e32e2a9d7d83d3534a45bb235e163a70047951890c01a"
+  license "BSD-3-Clause"
+  head "https://github.com/capstone-engine/capstone.git", branch: "next"
 
   bottle do
-    cellar :any
-    sha256 "3aa8d8b679cc5261a3fbf44b191c61480cdb34576f71b769e63d68c5e27c19b1" => :el_capitan
-    sha256 "5bbd8f7d9e0ae0d3b23c7d478fdb02476e8cee847577576d543bf98649985975" => :yosemite
-    sha256 "0cfd7478b21360ffea1aac61ec64eeae612bce247a681b0205ffd14790f8f7dc" => :mavericks
-    sha256 "585042b1452fbeda9efd07da4b8400d56d166afd5e5f1120da20975e41001e88" => :mountain_lion
   end
 
+  # Switch from binary constants to hex so GCC 4.x can be used
+  # Fix OS detection
+  patch :p0, :DATA
+
+  depends_on "make"
+
   def install
-    # Capstone's Make script ignores the prefix env and was installing
-    # in /usr/local directly. So just inreplace the prefix for less pain.
-    # https://github.com/aquynh/capstone/issues/228
-    inreplace "make.sh", "export PREFIX=/usr/local", "export PREFIX=#{prefix}"
-
+    # ENV.no_optimization
     ENV["HOMEBREW_CAPSTONE"] = "1"
+    ENV["PREFIX"] = prefix
+    ENV["MAKE"] = "gmake"
+    ENV["LIBARCHS"] = "ppc" if Hardware::CPU.type == :ppc
+    ENV["LIBARCHS"] = "i386" if Hardware::CPU.type == :intel
     system "./make.sh"
-    system "./make.sh", "install"
-
-    # As per the above inreplace, the pkgconfig file needs fixing as well.
-    inreplace lib/"pkgconfig/capstone.pc" do |s|
-      s.gsub! "/usr/lib", lib
-      s.gsub! "/usr/include/capstone", "#{include}/capstone"
-    end
+    system "gmake", "install", "PREFIX=#{prefix}"
   end
 
   test do
-    # code comes from http://www.capstone-engine.org/lang_c.html
+    # code comes from https://www.capstone-engine.org/lang_c.html
     (testpath/"test.c").write <<-EOS.undent
       #include <stdio.h>
       #include <inttypes.h>
@@ -61,3 +58,35 @@ class Capstone < Formula
     system "./test"
   end
 end
+__END__
+--- arch/TriCore/TriCoreInstPrinter.c.orig	2024-02-03 00:59:37.000000000 +0000
++++ arch/TriCore/TriCoreInstPrinter.c	2024-02-03 01:00:45.000000000 +0000
+@@ -402,7 +402,7 @@
+ 		case TRICORE_LOOP_sbr:
+ 			// {27b’111111111111111111111111111, disp4, 0};
+ 			disp = (int32_t)MI->address +
+-			       ((0b111111111111111111111111111 << 5) |
++			       ((0x7FFFFFF << 5) |
+ 				(disp << 1));
+ 			break;
+ 		default:
+@@ -449,7 +449,7 @@
+ 	if (MCOperand_isImm(MO)) {
+ 		uint32_t imm = MCOperand_getImm(MO);
+ 		// {27b’111111111111111111111111111, disp4, 0};
+-		imm = 0b11111111111111111111111111100000 | (imm << 1);
++		imm = 0xFFFFFFE0 | (imm << 1);
+ 
+ 		printInt32Bang(O, imm);
+ 		fill_imm(MI, imm);
+--- Makefile.orig	2024-02-03 01:12:02.000000000 +0000
++++ Makefile	2024-02-03 01:18:32.000000000 +0000
+@@ -344,7 +344,7 @@
+ API_MAJOR=$(shell echo `grep -e CS_API_MAJOR include/capstone/capstone.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
+ VERSION_EXT =
+ 
+-IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __apple_build_version__ | wc -l | tr -d " ")
++IS_APPLE := $(shell $(CC) -dM -E - < /dev/null 2> /dev/null | grep __APPLE__ | wc -l | tr -d " ")
+ ifeq ($(IS_APPLE),1)
+ # on MacOS, do not build in Universal format by default
+ MACOS_UNIVERSAL ?= no


### PR DESCRIPTION
Does not like build built with GCC 4.2 but happy with 4.0 & clang.

Tested v5.0.1 on Tiger (G5) & Leopard & Snow Leopard (intel) with GCC 4.0.1, El Capitan with clang
Tested v5.0.3 on Tiger (G5) with GCC 4.0.1