### PR TITLE
openfpgaloader: Add formula for v0.11.0

### DIFF
--- a/Library/Formula/openfpgaloader.rb
+++ b/Library/Formula/openfpgaloader.rb
@@ -1,8 +1,8 @@
 class Openfpgaloader < Formula
   desc "Universal utility for programming FPGA"
   homepage "https://github.com/trabucayre/openFPGALoader"
-  url "https://github.com/trabucayre/openFPGALoader/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "a463690358d2510919472c2f460039a304d016a08a45970821e667eea1c48cc8"
+  url "https://github.com/trabucayre/openFPGALoader/archive/refs/tags/v0.13.1.tar.gz"
+  sha256 "372f1942dec8a088bc7475f94ccf5a86264cb74e9154d8a162b8d4d26d3971e3"
   license "Apache-2.0"
   head "https://github.com/trabucayre/openFPGALoader.git", branch: "master"
 

--- a/Library/Formula/openfpgaloader.rb
+++ b/Library/Formula/openfpgaloader.rb
@@ -1,0 +1,31 @@
+class Openfpgaloader < Formula
+  desc "Universal utility for programming FPGA"
+  homepage "https://github.com/trabucayre/openFPGALoader"
+  url "https://github.com/trabucayre/openFPGALoader/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "a463690358d2510919472c2f460039a304d016a08a45970821e667eea1c48cc8"
+  license "Apache-2.0"
+  head "https://github.com/trabucayre/openFPGALoader.git", branch: "master"
+
+  bottle do
+  end
+
+  needs :cxx11
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libftdi"
+  depends_on "libusb"
+  depends_on "zlib"
+
+  def install
+    mkdir "build" do
+      system "cmake", "-S", "..", *std_cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    version_output = shell_output("#{bin}/openFPGALoader -V 2>&1")
+    assert_match "openFPGALoader v#{version}", version_output
+  end
+end


### PR DESCRIPTION
Based on
https://raw.githubusercontent.com/Homebrew/homebrew-core/4193b47068bd44bba3f18fb1f9f66bdc9fcef66b/Formula/o/openfpgaloader.rb

Tested detection with a Sipeed Tang Nano 9k & a Terrasic DE0-nano on Tiger powerpc (G5) + GCC 5.5.