### PR TITLE
libftdi 1.5

### DIFF
--- a/Library/Formula/libftdi.rb
+++ b/Library/Formula/libftdi.rb
@@ -1,23 +1,40 @@
 class Libftdi < Formula
   desc "Library to talk to FTDI chips"
-  homepage "http://www.intra2net.com/en/developer/libftdi"
-  url "http://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.1.tar.bz2"
-  sha256 "c0b1af1a13e2c6682a1d8041e5b164a1e0d90267cd378bb51e059bd62f821e21"
+  homepage "https://www.intra2net.com/en/developer/libftdi"
+  url "https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.5.tar.bz2"
+  sha256 "7c7091e9c86196148bd41177b4590dccb1510bfe6cea5bf7407ff194482eb049"
+  license "LGPL-2.1-only"
 
   bottle do
-    cellar :any
   end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "confuse"
   depends_on "libusb"
-  depends_on "boost" => :optional
+
+  # Patch to fix pkg-config flags issue. Homebrew/homebrew-core#71623
+  # http://developer.intra2net.com/git/?p=libftdi;a=commit;h=cdb28383402d248dbc6062f4391b038375c52385
+  patch do
+    url "http://developer.intra2net.com/git/?p=libftdi;a=patch;h=cdb28383402d248dbc6062f4391b038375c52385;hp=5c2c58e03ea999534e8cb64906c8ae8b15536c30"
+    sha256 "db4c3e558e0788db00dcec37929f7da2c4ad684791977445d8516cc3e134a3c4"
+  end
 
   def install
     ENV.enable_warnings if ENV.compiler == :gcc_4_0
     mkdir "libftdi-build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DPYTHON_BINDINGS=OFF",
+                            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
+                            "-DFTDIPP=OFF",
+                            *std_cmake_args
       system "make", "install"
+      pkgshare.install "../examples"
+      (pkgshare/"examples/bin").install Dir["examples/*"] \
+                                        - Dir["examples/{CMake*,Makefile,*.cmake}"]
     end
+  end
+
+  test do
+    system pkgshare/"examples/bin/find_all"
   end
 end


### PR DESCRIPTION
Tested on Tiger (G5) with GCC 4.0.1.
Built without C++ support since the C implementaton will build with
a C99 compiler but the C++ parts require a C++11 compiler.

Needs #1079 & #1066 