### PR TITLE
gettext: assorted minor but vital improvements

### DIFF
--- a/Library/Formula/gettext.rb
+++ b/Library/Formula/gettext.rb
@@ -1,18 +1,19 @@
 class Gettext < Formula
-  desc "GNU internationalization (i18n) and localization (l10n) library"
-  homepage "https://www.gnu.org/software/gettext/"
-  url "https://ftpmirror.gnu.org/gettext/gettext-0.22.4.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/gettext/gettext-0.22.4.tar.xz"
-  sha256 "29217f1816ee2e777fa9a01f9956a14139c0c23cc1b20368f06b2888e8a34116"
+  desc 'GNU internationalization (i18n) and localization (l10n) library'
+  homepage 'https://www.gnu.org/software/gettext/'
+  url 'https://ftpmirror.gnu.org/gettext/gettext-0.22.4.tar.xz'
+  mirror 'https://ftp.gnu.org/gnu/gettext/gettext-0.22.4.tar.xz'
+  sha256 '29217f1816ee2e777fa9a01f9956a14139c0c23cc1b20368f06b2888e8a34116'
 
   bottle do
-    sha256 "c64bb31029e29599442653fe1e0f2216ae8fe144451a0541896f6e367df0018f" => :tiger_altivec
+    sha256 'c64bb31029e29599442653fe1e0f2216ae8fe144451a0541896f6e367df0018f' => :tiger_altivec
   end
 
-  keg_only :shadowed_by_osx, "OS X provides the BSD gettext library and some software gets confused if both are in the library path."
+  unless MacOS.version <= :leopard  # what Mac OS version would be correct here?
+    keg_only :shadowed_by_osx, 'OS X provides the BSD gettext library and some software gets confused if both are in the library path.'
+  end
 
   option :universal
-  option 'with-examples', 'Keep example files'
 
   # Fix lang-python-* failures when a traditional French locale
   # https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=patch;h=3c7e67be7d4dab9df362ab19f4f5fa3b9ca0836b
@@ -23,32 +24,37 @@ class Gettext < Formula
     ENV.libxml2
     ENV.universal_binary if build.universal?
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--disable-debug",
-                          "--prefix=#{prefix}",
-                          "--with-included-gettext",
-                          "--with-included-glib",
-                          "--with-included-libcroco",
-                          "--with-included-libunistring",
-                          "--with-emacs",
-                          "--with-lispdir=#{share}/emacs/site-lisp/gettext",
-                          "--disable-java",
-                          "--disable-csharp",
-                          # Don't use VCS systems to create these archives
-                          "--without-git",
-                          "--without-cvs",
-                          "--without-xz"
-    system "make"
-    system "make", "check"
+    args = %W[
+      --prefix=#{prefix}
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --disable-debug
+      --with-included-gettext
+      --with-included-glib
+      --with-included-libcroco
+      --with-included-libunistring
+      --with-emacs
+      --with-lispdir=#{share}/emacs/site-lisp/gettext
+      --disable-java
+      --disable-csharp
+      # Don't use VCS systems to create these archives
+      --without-git
+      --without-cvs
+      --without-xz
+    ]
+
+    system './configure', *args
+    make
+    make 'check'
     ENV.deparallelize # install doesn't support multiple make jobs
-    system "make", "install"
+    make 'install'
   end
 
   test do
-    system "#{bin}/gettext", "test"
+    system "#{bin}/gettext", 'test'
   end
 end
+
 __END__
 --- gettext-tools/tests/lang-python-1.orig	2023-09-18 21:10:32.000000000 +0100
 +++ gettext-tools/tests/lang-python-1	2023-11-30 23:15:43.000000000 +0000


### PR DESCRIPTION
make `keg-only` option conditional on OS version; remove unused `--with-examples` option; use the Homebrew `make` routine instead of `system "make"`