### PR TITLE
fix broken `--c++11` option

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -2,7 +2,7 @@
 module CompilerConstants
   GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7]
   GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-7])$/
-  GNU_GXX11_REGEXP = /^gcc-(4\.[8-9]|[5-7])$/
+  GNU_GXX11_REGEXP = /^gcc-(4\.[7-9]|[5-7])$/
   COMPILER_SYMBOL_MAP = {
     "gcc-4.0"  => :gcc_4_0,
     "gcc-4.2"  => :gcc,

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -2,6 +2,7 @@
 module CompilerConstants
   GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7]
   GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-7])$/
+  GNU_GXX11_REGEXP = /^gcc-(4\.[8-9]|[5-7])$/
   COMPILER_SYMBOL_MAP = {
     "gcc-4.0"  => :gcc_4_0,
     "gcc-4.2"  => :gcc,

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -1,4 +1,3 @@
-require "compilers"
 require "hardware"
 require "os/mac"
 require "extend/ENV/shared"
@@ -294,7 +293,7 @@ module Stdenv
     if compiler == :clang
       append "CXX", "-std=c++11"
       append "CXX", "-stdlib=libc++"
-    elsif compiler =~ GNU_GCC_REGEXP
+    elsif compiler =~ GNU_GXX11_REGEXP
       append "CXX", "-std=c++11"
     else
       raise "The selected compiler doesn't support C++11: #{compiler}"

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -1,3 +1,4 @@
+require "compilers"
 require "hardware"
 require "os/mac"
 require "extend/ENV/shared"
@@ -293,7 +294,7 @@ module Stdenv
     if compiler == :clang
       append "CXX", "-std=c++11"
       append "CXX", "-stdlib=libc++"
-    elsif compiler =~ /gcc-(4\.(8|9)|5)/
+    elsif compiler =~ GNU_GCC_REGEXP
       append "CXX", "-std=c++11"
     else
       raise "The selected compiler doesn't support C++11: #{compiler}"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -1,4 +1,3 @@
-require "compilers"
 require "os/mac"
 require "extend/ENV/shared"
 
@@ -294,7 +293,7 @@ module Superenv
     when "clang"
       append "HOMEBREW_CCCFG", "x", ""
       append "HOMEBREW_CCCFG", "g", ""
-    when GNU_GCC_REGEXP
+    when GNU_GXX11_REGEXP
       append "HOMEBREW_CCCFG", "x", ""
     else
       raise "The selected compiler doesn't support C++11: #{homebrew_cc}"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -1,3 +1,4 @@
+require "compilers"
 require "os/mac"
 require "extend/ENV/shared"
 
@@ -293,7 +294,7 @@ module Superenv
     when "clang"
       append "HOMEBREW_CCCFG", "x", ""
       append "HOMEBREW_CCCFG", "g", ""
-    when /gcc-(4\.(8|9)|5)/
+    when GNU_GCC_REGEXP
       append "HOMEBREW_CCCFG", "x", ""
     else
       raise "The selected compiler doesn't support C++11: #{homebrew_cc}"


### PR DESCRIPTION
(broken regexp common to ENV/std.rb and ENV/super.rb, causing C++11 test to always fail under gcc-7)