### PR TITLE
unbreak `brew test libffi`

### DIFF
--- a/Library/Formula/libffi.rb
+++ b/Library/Formula/libffi.rb
@@ -82,7 +82,7 @@ class Libffi < Formula
      }
     TEST_SCRIPT
 
-    flags = ["-L#{lib}", "-lffi", "-I#{lib}/libffi-#{version}/include"]
+    flags = %W[-L#{lib} -lffi -I#{include}]
     system ENV.cc, "-o", "closure", "closure.c", *(flags + ENV.cflags.to_s.split)
     system "./closure"
   end


### PR DESCRIPTION
For some reason, libffi's formula had a bad path specification in its test method.  This small change fixes it.