### PR TITLE
python major_minor_version() fix

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -3,7 +3,7 @@ require "utils.rb"
 module Language
   module Python
     def self.major_minor_version(python)
-      version = /\d\.\d/.match `#{python} --version 2>&1`
+      version = /\d\.\d\d/.match `#{python} --version 2>&1`
       return unless version
       Version.new(version.to_s)
     end


### PR DESCRIPTION
With the recent upgrade from Python 3.7 to 3.10 the minor version needs to be double digits.

Tested by installing Python 3 extensions.
Python 2 untested, marking as draft.