### PR TITLE
cython: Add formula for v3.0.11

### DIFF
--- a/Library/Formula/cython.rb
+++ b/Library/Formula/cython.rb
@@ -1,8 +1,8 @@
 class Cython < Formula
   desc "Compiler for writing C extensions for the Python language"
   homepage "https://cython.org/"
-  url "https://files.pythonhosted.org/packages/d5/f7/2fdd9205a2eedee7d9b0abbf15944a1151eb943001dbdc5233b1d1cfc34e/Cython-3.0.10.tar.gz"
-  sha256 "dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99"
+  url "https://files.pythonhosted.org/packages/84/4d/b720d6000f4ca77f030bd70f12550820f0766b568e43f11af7f7ad9061aa/cython-3.0.11.tar.gz"
+  sha256 "7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff"
   license "Apache-2.0"
 
   bottle do

--- a/Library/Formula/cython.rb
+++ b/Library/Formula/cython.rb
@@ -1,0 +1,49 @@
+class Cython < Formula
+  desc "Compiler for writing C extensions for the Python language"
+  homepage "https://cython.org/"
+  url "https://files.pythonhosted.org/packages/d5/f7/2fdd9205a2eedee7d9b0abbf15944a1151eb943001dbdc5233b1d1cfc34e/Cython-3.0.10.tar.gz"
+  sha256 "dcc96739331fb854dcf503f94607576cfe8488066c61ca50dfd55836f132de99"
+  license "Apache-2.0"
+
+  bottle do
+  end
+
+  keg_only <<~EOS
+    this formula is mainly used internally by other formulae.
+    Users are advised to use `pip` to install cython
+  EOS
+
+  depends_on "python3"
+
+  def python3
+    "python3.10"
+  end
+
+  def install
+    version = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
+
+    system python3, *Language::Python.setup_install_args(libexec)
+
+    bin.install (libexec/"bin").children
+    bin.env_script_all_files(libexec/"bin", PYTHONPATH: ENV["PYTHONPATH"])
+  end
+
+  test do
+    version = Language::Python.major_minor_version "python3"
+    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{version}/site-packages"
+
+    phrase = "You are using Homebrew"
+    (testpath/"package_manager.pyx").write "print '#{phrase}'"
+    (testpath/"setup.py").write <<~EOS
+      from distutils.core import setup
+      from Cython.Build import cythonize
+
+      setup(
+        ext_modules = cythonize("package_manager.pyx")
+      )
+    EOS
+    system python3, "setup.py", "build_ext", "--inplace"
+    assert_match phrase, shell_output("#{python3} -c 'import package_manager'")
+  end
+end


### PR DESCRIPTION
Based on
https://github.com/Homebrew/homebrew-core/blob/64ccd322494a17aa83fd3f815fc75cfed31dfacd/Formula/c/cython.rb

Tested on Tiger powerpc (G5) with GCC 4.0.1 and Python 3.10

Requires #1228