### PR TITLE
teensy_loader_cli 2.2

### DIFF
--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -5,7 +5,7 @@ class TeensyLoaderCli < Formula
   sha256 "103c691f412d04906c4f46038c234d3e5f78322c1b78ded102df9f900724cd54"
 
   depends_on "make"
-  depends_on "libusb"
+  depends_on "libusb-compat"
 
   # Be flexible about where libusb can be found
   patch :p0, :DATA

--- a/Library/Formula/teensy_loader_cli.rb
+++ b/Library/Formula/teensy_loader_cli.rb
@@ -1,17 +1,34 @@
 class TeensyLoaderCli < Formula
   desc "Command-line integration for Teensy USB development boards"
   homepage "https://www.pjrc.com/teensy/loader_cli.html"
-  url "https://www.pjrc.com/teensy/teensy_loader_cli.2.1.zip"
-  sha256 "dafd040d6748b52e0d4a01846d4136f3354ca27ddc36a55ed00d0a0af0902d46"
+  url "https://github.com/PaulStoffregen/teensy_loader_cli/archive/refs/tags/2.2.tar.gz"
+  sha256 "103c691f412d04906c4f46038c234d3e5f78322c1b78ded102df9f900724cd54"
+
+  depends_on "make"
+  depends_on "libusb"
+
+  # Be flexible about where libusb can be found
+  patch :p0, :DATA
 
   def install
-    ENV["OS"] = "MACOSX"
-    ENV["SDK"] = MacOS.sdk_path || "/"
-    system "make"
+    system "gmake", "USE_LIBUSB=YES", "OS=MACOSX"
     bin.install "teensy_loader_cli"
   end
 
   test do
-    assert `#{bin}/teensy_loader_cli 2>&1`.include?("<MCU> = atmega32u4 | at90usb162 | at90usb646 | at90usb1286")
+    output = shell_output("#{bin}/teensy_loader_cli 2>&1", 1)
+    assert_match "Filename must be specified", output
   end
 end
+__END__
+--- Makefile.orig	2024-04-15 22:32:01.000000000 +0100
++++ Makefile	2024-04-15 22:32:29.000000000 +0100
+@@ -27,7 +27,7 @@
+ CC ?= gcc
+ CFLAGS ?= -O2 -Wall
+ teensy_loader_cli: teensy_loader_cli.c
+-	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o teensy_loader_cli teensy_loader_cli.c -lusb -I /usr/local/include -L/usr/local/lib
++	$(CC) $(CFLAGS) -s -DUSE_LIBUSB -DMACOSX -o teensy_loader_cli teensy_loader_cli.c -lusb $(LDFLAGS)
+ 	 
+ else
+ CC ?= gcc


### PR DESCRIPTION
Tested on Tiger powerpc (G5) with GCC 4.0.1 and a Teensy 2

```
bin/teensy_loader_cli -w --mcu=TEENSY2 /tmp/teensy_loader_cli-2.2/blink_slow_Teensy2.hex -v
Teensy Loader, Command Line, Version 2.2
Read "/tmp/teensy_loader_cli-2.2/blink_slow_Teensy2.hex": 2332 bytes, 7.2% usage
Waiting for Teensy device...
 (hint: press the reset button)
Found HalfKay Bootloader
Read "/tmp/teensy_loader_cli-2.2/blink_slow_Teensy2.hex": 2332 bytes, 7.2% usage
Programming...................
Booting
```