### PR TITLE
Fix imagesnap for ppc

### DIFF
--- a/Library/Formula/imagesnap.rb
+++ b/Library/Formula/imagesnap.rb
@@ -16,7 +16,7 @@ class Imagesnap < Formula
   depends_on :xcode => :build
 
   def install
-    xcodebuild "-project", "ImageSnap.xcodeproj", "SYMROOT=build", "-sdk", "macosx#{MacOS.version}"
+    xcodebuild "VALID_ARCHS=ppc ppc64 i386 x86_64", "-project", "ImageSnap.xcodeproj", "SYMROOT=build", "-sdk", "macosx#{MacOS.version}"
     bin.install "build/Release/imagesnap"
   end
 end


### PR DESCRIPTION
Imagesnap's list of valid architectures only includes i386 and x86_64. However, it compiles and works fine in PowerPC. This change adds the ppc and ppc64 architectures in the build invocation.