### PR TITLE
nano: Add formula for v8.0

### DIFF
--- a/Library/Formula/nano.rb
+++ b/Library/Formula/nano.rb
@@ -1,0 +1,34 @@
+class Nano < Formula
+  desc "Free (GNU) replacement for the Pico text editor"
+  homepage "https://www.nano-editor.org/"
+  url "https://www.nano-editor.org/dist/v8/nano-8.0.tar.xz"
+  sha256 "c17f43fc0e37336b33ee50a209c701d5beb808adc2d9f089ca831b40539c9ac4"
+  license "GPL-3.0-or-later"
+
+  bottle do
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "gettext"
+  depends_on "ncurses"
+  depends_on "libmagic"
+  depends_on "zlib"
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
+                          "--enable-color",
+                          "--enable-extra",
+                          "--enable-multibuffer",
+                          "--enable-nanorc",
+                          "--enable-utf8"
+    system "make", "install"
+    doc.install "doc/sample.nanorc"
+  end
+
+  test do
+    system "#{bin}/nano", "--version"
+  end
+end


### PR DESCRIPTION
Like vim formula not marked as keg_only though a version is included with OS X.

Based on
https://raw.githubusercontent.com/Homebrew/homebrew-core/017421c494107b35d3a519c93ace9c8f42235a3d/Formula/n/nano.rb

Tested on Tiger powerpc (G5) with GCC 4.0.1