### PR TITLE
qt: Fix build on Tiger

### DIFF
--- a/Library/Formula/qt.rb
+++ b/Library/Formula/qt.rb
@@ -27,7 +27,7 @@ class Qt < Formula
   # https://github.com/macports/macports-ports/blob/master/aqua/qt4-mac/files/patch-qt4-openssl111.diff
   # Fix build on macOS 10.4 and 10.5 - missing patch to qpaintengine_mac.cpp because it doesn't apply
   # https://github.com/cartr/homebrew-qt4/pull/35/files
-  # bodge for src/corelib/io/qfilesystemengine.cpp:285: error: ‘UF_HIDDEN’ was not declared in this scope
+  # UF_HIDDEN shows up in Leopard, confine to Cocoa builds.
   # QtHelp needs to link against libQtCLucene. 
   patch :p0, :DATA
 
@@ -305,24 +305,17 @@ index c51f6ad..f4bd8b8 100644
  
  const char * cfurlErrorDescription(SInt32 errorCode)
  {
---- src/corelib/io/qfilesystemengine.cpp.orig	2024-05-06 21:17:07.000000000 +0100
-+++ src/corelib/io/qfilesystemengine.cpp	2024-05-06 21:19:58.000000000 +0100
-@@ -280,6 +280,7 @@
-     // Attributes
+--- src/corelib/io/qfilesystemengine.cpp.orig	2024-05-10 22:31:54.000000000 +0100
++++ src/corelib/io/qfilesystemengine.cpp	2024-05-10 22:33:02.000000000 +0100
+@@ -281,7 +281,7 @@
      entryFlags |= QFileSystemMetaData::ExistsAttribute;
      size_ = statBuffer.st_size;
-+/*
  #if !defined(QWS) && !defined(Q_WS_QPA) && defined(Q_OS_MAC) \
-         && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
+-        && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
++        && defined(QT_MAC_USE_COCOA) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
      if (statBuffer.st_flags & UF_HIDDEN) {
-@@ -287,6 +288,7 @@
+         entryFlags |= QFileSystemMetaData::HiddenAttribute;
          knownFlagsMask |= QFileSystemMetaData::HiddenAttribute;
-     }
- #endif
-+*/
- 
-     // Times
- #ifdef Q_OS_SYMBIAN
 --- tools/assistant/tools/assistant/assistant.pro.orig	2024-05-07 16:20:22.000000000 +0100
 +++ tools/assistant/tools/assistant/assistant.pro	2024-05-07 16:21:17.000000000 +0100
 @@ -111,6 +111,7 @@


### PR DESCRIPTION
Need to build with Carbon support.
Ride the default with qt3support as it might be handy. Since it's a lengthy build, the previous option didn't work and failed on install stage. Add sqlite support so at least there is some database support by default.

draft since ~there is a bodge patch to src/corelib/io/qfilesystemengine.cpp,~ I need to enable building with OpenSSL 1.1.1, ~I haven't tested on anything beyond Tiger~.

~When it is ready to land, the PRs 529 575 577 should be reviewed to see if there's any additional bits that should be integrated.~ This PR basically introduces the changes proposed in PR 529 + fixes the issue building QtHelp & qmake on Tiger.

Skipping building with OpenSSL 1.1.1 as the patches I found were for 1.1.0 and more things need guarding off regarding to OpenSSL API usage.  Since I don't have an QT application which I could use to test with & the lengthy build time I'm going to mark this ready for review until someone comes up with an application which needs OpenSSL support.

Tested on Tiger powerpc (G5/G4/i386) with GCC 4.0.1, took 208 minutes on a 1.8Ghz iMac G5, 281 minutes a 1.33Ghz PowerBook G4, 50 minutes on a 2.0Ghz c2d Mac Mini.
Tested on Leopard powerpc (G5/i386) with GCC 4.2, took 204 minutes on a 1.8Ghz iMac G5, 87 minutes on a c2d MacBook Air.
Snow Leopard (x86_64) with GCC 4.2, took 84 minutes on a c2d MacBook Air.
El Capitan with clang, took 79 minutes on a c2d MacBook Air.