### PR TITLE
mplayer 1.5

### DIFF
--- a/Library/Formula/mplayer.rb
+++ b/Library/Formula/mplayer.rb
@@ -1,27 +1,28 @@
 class Mplayer < Formula
   desc "UNIX movie player"
-  homepage "https://www.mplayerhq.hu/"
-  revision 1
+  homepage "https://mplayerhq.hu/"
 
   stable do
-    url "http://www.mplayerhq.hu/MPlayer/releases/MPlayer-1.2.tar.xz"
-    sha256 "ffe7f6f10adf2920707e8d6c04f0d3ed34c307efc6cd90ac46593ee8fba2e2b6"
+    url "https://mplayerhq.hu/MPlayer/releases/MPlayer-1.5.tar.xz"
+    sha256 "650cd55bb3cb44c9b39ce36dac488428559799c5f18d16d98edb2b7256cbbf85"
   end
 
   bottle do
-    sha256 "13be908b635ef84ab9a121f7e6787c20e6405bf645417e2f82f98192ea07c92e" => :el_capitan
-    sha256 "c6d4cc95a347807eacf219ed68c6dffae61b5abffae65e938f8e2d959a84c1fb" => :yosemite
-    sha256 "f9c8305916c2eb5363edc7715e499191e18eb39d6f8efd921d3a4d2881326ad9" => :mavericks
   end
 
   head do
     url "svn://svn.mplayerhq.hu/mplayer/trunk"
-    depends_on "subversion" => :build if MacOS.version <= :leopard
-
-    # When building SVN, configure prompts the user to pull FFmpeg from git.
-    # Don't do that.
-    patch :DATA
+    depends_on "subversion" => :build
   end
+
+  # Needs atomic such as sync_bool_compare_and_swap
+  fails_with :gcc_4_0
+
+  # When building SVN, configure prompts the user to pull FFmpeg from git.
+  # help with find OpenGL on Tiger
+  # https://raw.githubusercontent.com/macports/macports-ports/cb7a1cc812a77dfbcd06dcd56e646bb4497d0454/multimedia/MPlayer/files/patch-libvo-osx-objc-common-opengl-headers.diff
+  # argument 1 must be a 5-bit signed literal
+  patch :p0, :DATA
 
   option "without-osd", "Build without OSD"
 
@@ -29,18 +30,29 @@ class Mplayer < Formula
   depends_on "make" => :build if MacOS.version < :leopard
   depends_on "yasm" => :build
   depends_on "libcaca" => :optional
-
-  fails_with :clang do
-    build 211
-    cause "Inline asm errors during compile on 32bit Snow Leopard."
-  end unless MacOS.prefer_64_bit?
-
-  # ld fails with: Unknown instruction for architecture x86_64
-  fails_with :llvm
+  depends_on "pkg-config" => :build
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "fribidi"
+  depends_on "a52dec"
+  depends_on "libxml2"
+  depends_on "openssl3"
+  depends_on "giflib"
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "mad"
+  depends_on "lzo"
+  depends_on "bzip2"
+  depends_on "libmpeg2"
+  depends_on "libvorbis"
+  depends_on "libogg"
+  depends_on "theora"
+  depends_on "faad2"
+  depends_on "zlib"
 
   def install
-    # It turns out that ENV.O1 fixes link errors with llvm.
-    ENV.O1 if ENV.compiler == :llvm
+    # Build probes & sets its own optimisation
+    ENV.no_optimization
 
     # we may empty our cflags, but skipping -faltivec is bad news on Tiger
     ENV.append_to_cflags '-faltivec' if MacOS.version == :tiger
@@ -55,10 +67,15 @@ class Mplayer < Formula
       --disable-cdparanoia
       --prefix=#{prefix}
       --disable-x11
+      --enable-apple-remote
+      --enable-openssl-nondistributable
     ]
 
     args << "--enable-caca" if build.with? "libcaca"
     args << "--extra-libs-mencoder=-framework Carbon" if MacOS.version < :snow_leopard
+
+    # bytestream2_put_be16 & bytestream2_put_byte unimplemented
+    args << "--disable-encoder=sgi" if Hardware.cpu_type == :ppc
 
     system "./configure", *args
     system make_path
@@ -71,8 +88,8 @@ class Mplayer < Formula
 end
 
 __END__
---- a/configure
-+++ b/configure
+--- configure
++++ configure
 @@ -1532,8 +1532,6 @@
  fi
  
@@ -82,3 +99,69 @@ __END__
      if ! git clone -b $FFBRANCH --depth 1 git://source.ffmpeg.org/ffmpeg.git ffmpeg ; then
          rm -rf ffmpeg
          echo "Failed to get a FFmpeg checkout"
+--- libvo/osx_objc_common.m.orig	2017-08-13 10:10:39.000000000 -0700
++++ libvo/osx_objc_common.m	2017-08-13 10:52:06.000000000 -0700
+@@ -29,6 +29,22 @@
+ #include <CoreServices/../Frameworks/OSServices.framework/Headers/Power.h>
+ #endif
+ 
++#ifdef __APPLE__
++# ifndef __MAC_OS_X_VERSION_MIN_REQUIRED
++#  if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
++#   include <Availability.h>
++#  else
++#   include <AvailabilityMacros.h>
++#  endif
++# endif
++#endif
++
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++# include <OpenGL/gl.h>
++# include <OpenGL/glu.h>
++# include <GLUT/glut.h>
++#endif
++
+ //MPLAYER
+ #include "config.h"
+ #include "video_out.h"
+--- ffmpeg/libswscale/ppc/swscale_altivec.c.orig	2024-05-13 21:32:04.000000000 +0100
++++ ffmpeg/libswscale/ppc/swscale_altivec.c	2024-05-13 21:34:55.000000000 +0100
+@@ -107,6 +107,8 @@
+ 
+ #endif /* HAVE_BIGENDIAN */
+ 
++#define SHIFT  3
++
+ #define output_pixel(pos, val, bias, signedness) \
+     if (big_endian) { \
+         AV_WB16(pos, bias + av_clip_ ## signedness ## 16(val >> shift)); \
+@@ -149,12 +151,11 @@
+ static void yuv2plane1_float_altivec(const int32_t *src, float *dest, int dstW)
+ {
+     const int dst_u = -(uintptr_t)dest & 3;
+-    const int shift = 3;
+-    const int add = (1 << (shift - 1));
++    const int add = (1 << (SHIFT - 1));
+     const int clip = (1 << 16) - 1;
+     const float fmult = 1.0f / 65535.0f;
+     const vec_u32 vadd = (vec_u32) {add, add, add, add};
+-    const vec_u32 vshift = (vec_u32) vec_splat_u32(shift);
++    const vec_u32 vshift = (vec_u32) vec_splat_u32(SHIFT);
+     const vec_u32 vlargest = (vec_u32) {clip, clip, clip, clip};
+     const vec_f vmul = (vec_f) {fmult, fmult, fmult, fmult};
+     const vec_f vzero = (vec_f) {0, 0, 0, 0};
+@@ -182,12 +183,11 @@
+ static void yuv2plane1_float_bswap_altivec(const int32_t *src, uint32_t *dest, int dstW)
+ {
+     const int dst_u = -(uintptr_t)dest & 3;
+-    const int shift = 3;
+-    const int add = (1 << (shift - 1));
++    const int add = (1 << (SHIFT - 1));
+     const int clip = (1 << 16) - 1;
+     const float fmult = 1.0f / 65535.0f;
+     const vec_u32 vadd = (vec_u32) {add, add, add, add};
+-    const vec_u32 vshift = (vec_u32) vec_splat_u32(shift);
++    const vec_u32 vshift = (vec_u32) vec_splat_u32(SHIFT);
+     const vec_u32 vlargest = (vec_u32) {clip, clip, clip, clip};
+     const vec_f vmul = (vec_f) {fmult, fmult, fmult, fmult};
+     const vec_f vzero = (vec_f) {0, 0, 0, 0};


### PR DESCRIPTION
Resolves issue #632
Build is set to use OpenSSL which makes it undistributable as a binary due to license conflict because the gnutls option was unable to stream via HTTPS for me.

Tested on Tiger powerpc (G5) with GCC 4.2, took 16 minutes. Attempted to play mp3 locally, QuickTime movie locally & over network, MP4 h264 over network.