### PR TITLE
lftp 4.9.2

### DIFF
--- a/Library/Formula/lftp.rb
+++ b/Library/Formula/lftp.rb
@@ -1,28 +1,68 @@
 class Lftp < Formula
   desc "Sophisticated file transfer program"
   homepage "http://lftp.yar.ru/"
-  url "http://lftp.yar.ru/ftp/lftp-4.6.4.tar.xz"
-  sha256 "1e7cb674c83ace48172263f86847ed04bb6ab2f24116b11a8505f70a15e8805c"
+  url "http://lftp.yar.ru/ftp/lftp-4.9.2.tar.xz"
+  sha256 "c517c4f4f9c39bd415d7313088a2b1e313b2d386867fe40b7692b83a20f0670d"
 
   bottle do
-    sha256 "490d37a27d7b1b1ba22109bb3dfb10a21c2d32dc35fe4698e33a852ff239337e" => :el_capitan
-    sha256 "7071f8760ce3f738428cd56eee8e1ff430f59de091e4152e4d3693379ef71749" => :yosemite
-    sha256 "0ea2e54a7bafd667130b06b56200ec46975b3b30969a649826c3e1ffe2345b50" => :mavericks
-    sha256 "4cd518335114f2c29a7514439563f5e2ebe3bff5a24fec1156496f0ae93edd92" => :mountain_lion
   end
 
+  # step past a gnulib issue
+  patch :p0, :DATA
+
   depends_on "pkg-config" => :build
+  depends_on "bison"
+  depends_on "expat"
+  depends_on "libidn2"
   depends_on "readline"
-  depends_on "openssl"
+  depends_on "openssl3"
+  depends_on "zlib"
+
+  needs :cxx11
 
   def install
+    ENV.cxx11
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
-                          "--with-openssl=#{Formula["openssl"].opt_prefix}"
+                          "--with-zlib=#{Formula["zlib"].opt_prefix}",
+                          "--with-expat=#{Formula["expat"].opt_prefix}",
+                          "--with-readline=#{Formula["readline"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl3"].opt_prefix}"
     system "make", "install"
   end
 
   test do
-    system "#{bin}/lftp", "-c", "open ftp://mirrors.kernel.org; ls"
+    system "#{bin}/lftp", "-c", "open https://ftp.gnu.org/; ls"
   end
 end
+__END__
+--- lib/libc-config.h.orig	2024-05-15 23:07:30.000000000 +0100
++++ lib/libc-config.h	2024-05-15 23:09:32.000000000 +0100
+@@ -83,9 +83,11 @@
+    nonexistent files.  Make it a syntax error, since Gnulib does not
+    use __WORDSIZE now, and if Gnulib uses it later the syntax error
+    will let us know that __WORDSIZE needs configuring.  */
++/*
+ #ifndef __WORDSIZE
+ # define __WORDSIZE %%%
+ #endif
++*/
+ /* Undef the macros unconditionally defined by our copy of glibc
+    <sys/cdefs.h>, so that they do not clash with any system-defined
+    versions.  */
+--- lib/cdefs.h.orig	2024-05-15 23:09:39.000000000 +0100
++++ lib/cdefs.h	2024-05-15 23:09:55.000000000 +0100
+@@ -473,10 +473,12 @@
+ 
+ /* The #ifndef lets Gnulib avoid including these on non-glibc
+    platforms, where the includes typically do not exist.  */
++/*
+ #ifndef __WORDSIZE
+ # include <bits/wordsize.h>
+ # include <bits/long-double.h>
+ #endif
++*/
+ 
+ #if defined __LONG_DOUBLE_MATH_OPTIONAL && defined __NO_LONG_DOUBLE_MATH
+ # define __LDBL_COMPAT 1


### PR DESCRIPTION
Need bison because it mark older version found on Tiger as bad Switch to OpenSSL 3
Add dependencies which it can make use of
Fix test
Needs a C++11 compiler since it makes use of override specifier
Tested on Tiger powerpc (G5) with GCC 5.5

Resolves #1157 

Marking as draft until I find out if it affects more recent versions of OS X & how to deal with the issue (__WORDSIZE definitely isn't used in the codebase apart from in these 2 files)
