### PR TITLE
smartmontools 7.4

### DIFF
--- a/Library/Formula/smartmontools.rb
+++ b/Library/Formula/smartmontools.rb
@@ -1,14 +1,13 @@
 class Smartmontools < Formula
   desc "SMART hard drive monitoring"
   homepage "https://www.smartmontools.org/"
-  url "https://downloads.sourceforge.net/project/smartmontools/smartmontools/6.5/smartmontools-6.5.tar.gz"
-  sha256 "89e8bb080130bc6ce148573ba5bb91bfe30236b64b1b5bbca26515d4b5c945bc"
+  url "https://downloads.sourceforge.net/project/smartmontools/smartmontools/7.4/smartmontools-7.4.tar.gz"
+  sha256 "e9a61f641ff96ca95319edfb17948cd297d0cd3342736b2c49c99d4716fb993d"
 
   bottle do
-    sha256 "026783b59f7fbea367d6fe845db61b84ad8ecbcea7b39277503bd5548ffc3e4b" => :el_capitan
-    sha256 "1f44588d95c27cf0d0a5efc4e1aa892d00bbd3b5d55515db026c0715a6254e70" => :yosemite
-    sha256 "87e1640444ba9717a2de2530a9a981705e9752f12a276bfc4dde606ab187e5a7" => :mavericks
   end
+
+  needs :cxx11
 
   def install
     (var/"run").mkpath


### PR DESCRIPTION
Tested on Tiger powerpc (G5) with GCC 5.5 & 7.5. `smartctl -a /dev/disk0` provided the SMART info for my SATA disk. 