### PR TITLE
z80dasm 1.2.0

### DIFF
--- a/Library/Formula/z80dasm.rb
+++ b/Library/Formula/z80dasm.rb
@@ -1,8 +1,10 @@
 class Z80dasm < Formula
   desc "Disassembler for the Zilog Z80 microprocessor and compatibles"
-  homepage "http://www.tablix.org/~avian/blog/articles/z80dasm/"
-  url "http://www.tablix.org/~avian/z80dasm/z80dasm-1.1.3.tar.gz"
-  sha256 "1d6966bf7bddd0965421455e666872607019cfa43352188f5580304dd1039539"
+  homepage "https://web.archive.org/web/20240114192756/https://www.tablix.org/~avian/blog/articles/z80dasm/"
+  url "https://www.tablix.org/~avian/z80dasm/z80dasm-1.2.0.tar.gz"
+  mirror "https://geeklan.co.uk/files/z80dasm-1.2.0.tar.gz"
+  sha256 "8da2c4a58a3917a8229dec0da97e718f90ede84985424d74456575bf5acfeec8"
+  license "GPL-2.0-or-later"
 
   def install
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
Homepage is offline for now and the src was not on archive.org
Add a source mirror.

Tested on Tiger powerpc (G5) with GCC 4.0.1.