### PR TITLE
geoip 1.6.12

### DIFF
--- a/Library/Formula/geoip.rb
+++ b/Library/Formula/geoip.rb
@@ -33,7 +33,7 @@ class Geoip < Formula
     geoip_data.mkpath
 
     resource("database").stage do
-      system "cp", "GeoIP.dat", "#{geoip_data}/GeoIP.dat"
+      cp "GeoIP.dat", "#{geoip_data}/GeoIP.dat"
     end
   end
 


### PR DESCRIPTION
Make sure the GeoIP.dat file is installed so geoiplookup tools work.
Fix test.
Skip the legacy path migration as it is redundant now.
No need to re-autoconf any more.

Tested on Tiger powerpc (G5) with GCC 4.0.1, Snow Leopard with GCC 4.2