### PR TITLE
revert openssh 9.8p1

### DIFF
--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -1,14 +1,14 @@
 class Openssh < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools"
   homepage "https://www.openssh.com/"
-  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.8p1.tar.gz"
-  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.8p1.tar.gz"
-  version "9.8p1"
-  sha256 "dd8bd002a379b5d499dfb050dd1fa9af8029e80461f4bb6c523c49973f5a39f3"
+  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.6p1.tar.gz"
+  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.6p1.tar.gz"
+  version "9.6p1"
+  sha256 "910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c"
   license "SSH-OpenSSH"
 
   bottle do
-    sha256 "7f356510f4730d775f626df68dc1a48aeccf53de09412a628d5797c69bc863c9" => :tiger_altivec
+    sha256 "aa2b8f0ba3a79c9c162a8996bae00486077e379ce86f53d8e7d75d19fcaf831a" => :tiger_altivec
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.
@@ -28,8 +28,8 @@ class Openssh < Formula
 
     # https://github.com/apple-oss-distributions/OpenSSH/blob/main/openssh/sshd.c#L532
     patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/aa6c71920318f97370d74f2303d6aea387fb68e4/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
-      sha256 "3f06fc03bcbbf3e6ba6360ef93edd2301f73efcd8069e516245aea7c4fb21279"
+      url "https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2612fd251ac6de17bf0cc5174c3aab94c/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
+      sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
     end
 
   resource "com.openssh.sshd.sb" do


### PR DESCRIPTION
This currently doesn't work for me - I'm getting errors at runtime.

This reverts commit f3e6b1f425f2664682596efa18aea9c2d0747a50.