### PR TITLE
macvim 7.4-77 bugfix

### DIFF
--- a/Library/Formula/macvim.rb
+++ b/Library/Formula/macvim.rb
@@ -17,7 +17,7 @@ class Macvim < Formula
   homepage "https://code.google.com/p/macvim/"
   url "https://github.com/macvim-dev/macvim/archive/snapshot-77.tar.gz"
   version "7.4-77"
-  sha256 "6b7f4b48ecef4a00dca17efef551884fcea1aa9897005497d31f52da7304bc5f"
+  sha256 "4696b2cd6f69093c8a619daee9a0db441ce1a124edfddd3b0b3fed3ac96f8e8d"
 
   head "https://github.com/macvim-dev/macvim.git"
 


### PR DESCRIPTION
Reference reported issue [here](https://github.com/mistydemeo/tigerbrew/issues/1189#issue-2523049346).

brew update was run prior to the attempt to install MacVim.

brew doctor doesn't report any issues.

Attempting brew install macvim results in the following error:

```bash
Error: SHA256 mismatch
Expected: 6b7f4b48ecef4a00dca17efef551884fcea1aa9897005497d31f52da7304bc5f
Actual: 4696b2cd6f69093c8a619daee9a0db441ce1a124edfddd3b0b3fed3ac96f8e8d
```

Downloading the snapshot file manually and calculating the sha256 hash reveals the correct checksum matches the actual reported by Tigerbrew.

```bash
$ sha256sum snapshot-77.tar.gz 
4696b2cd6f69093c8a619daee9a0db441ce1a124edfddd3b0b3fed3ac96f8e8d  snapshot-77.tar.gz
```