### PR TITLE
openssh 9.9p1

### DIFF
--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -1,14 +1,13 @@
 class Openssh < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools"
   homepage "https://www.openssh.com/"
-  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.6p1.tar.gz"
-  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.6p1.tar.gz"
-  version "9.6p1"
-  sha256 "910211c07255a8c5ad654391b40ee59800710dd8119dd5362de09385aa7a777c"
+  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.9p1.tar.gz"
+  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.9p1.tar.gz"
+  version "9.9p1"
+  sha256 "b343fbcdbff87f15b1986e6e15d6d4fc9a7d36066be6b7fb507087ba8f966c02"
   license "SSH-OpenSSH"
 
   bottle do
-    sha256 "aa2b8f0ba3a79c9c162a8996bae00486077e379ce86f53d8e7d75d19fcaf831a" => :tiger_altivec
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.
@@ -18,24 +17,6 @@ class Openssh < Formula
   depends_on "ldns"
   depends_on "openssl3"
   depends_on "zlib"
-
-    # Both these patches are applied by Apple.
-    # https://github.com/apple-oss-distributions/OpenSSH/blob/main/openssh/sandbox-darwin.c#L66
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/patches/1860b0a745f1fe726900974845d1b0dd3c3398d6/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff"
-      sha256 "d886b98f99fd27e3157b02b5b57f3fb49f43fd33806195970d4567f12be66e71"
-    end
-
-    # https://github.com/apple-oss-distributions/OpenSSH/blob/main/openssh/sshd.c#L532
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2612fd251ac6de17bf0cc5174c3aab94c/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
-      sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
-    end
-
-  resource "com.openssh.sshd.sb" do
-    url "https://raw.githubusercontent.com/apple-oss-distributions/OpenSSH/OpenSSH-268.100.4/com.openssh.sshd.sb"
-    sha256 "a273f86360ea5da3910cfa4c118be931d10904267605cdd4b2055ced3a829774"
-  end
 
   def install
     args = %W[
@@ -49,12 +30,6 @@ class Openssh < Formula
       --with-zlib=#{Formula["zlib"].opt_prefix}
     ]
 
-    ENV.append "CPPFLAGS", "-D__APPLE_SANDBOX_NAMED_EXTERNAL__"
-
-    # Ensure sandbox profile prefix is correct.
-    # We introduce this issue with patching, it's not an upstream bug.
-    inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
-
     system "./configure", *args
     system "make"
     ENV.deparallelize
@@ -64,9 +39,6 @@ class Openssh < Formula
     # potential to break scripts, so recreate it for now.
     # Debian have done the same thing.
     bin.install_symlink bin/"ssh" => "slogin"
-
-    buildpath.install resource("com.openssh.sshd.sb")
-    (etc/"ssh").install "com.openssh.sshd.sb" => "org.openssh.sshd.sb"
   end
 
   test do


### PR DESCRIPTION
Drop the sandbox patches since with the further process separation changes which landed in v9.8, sshd breaks.
macOS 10+5 ships with v9.8 and the source drop also shows they are no longer applying these patches.
See OpenSSH-341 sources:
https://github.com/apple-oss-distributions/OpenSSH/tree/OpenSSH-341/

Tested on Tiger powerpc (G5) with GCC 4.0.1, Leopard powerpc (G4) with GCC 4.2