### PR TITLE
wget 1.25.0

### DIFF
--- a/Library/Formula/wget.rb
+++ b/Library/Formula/wget.rb
@@ -4,10 +4,9 @@
 class Wget < Formula
   desc "Internet file retriever"
   homepage "https://www.gnu.org/software/wget/"
-  url "https://ftpmirror.gnu.org/wget/wget-1.21.3.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/wget/wget-1.21.3.tar.gz"
-  sha256 "5726bb8bc5ca0f6dc7110f6416e4bb7019e2d2ff5bf93d1ca2ffcc6656f220e5"
-  revision 1
+  url "https://ftpmirror.gnu.org/wget/wget-1.24.5.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/wget/wget-1.24.5.tar.gz"
+  sha256 "fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de"
 
   head do
     url "git://git.savannah.gnu.org/wget.git"
@@ -18,19 +17,18 @@ class Wget < Formula
   end
 
   bottle do
-    sha256 "81581a3befe8af2552a4f6b3a574b712ae9fb0f85b2d1bbe1f1de2e96d4d1a9f" => :tiger_altivec
   end
 
-  deprecated_option "enable-iri" => "with-iri"
   deprecated_option "enable-debug" => "with-debug"
 
-  option "with-iri", "Enable iri support"
   option "with-debug", "Build with debug support"
 
+  depends_on "pkg-config" => :build
   depends_on "openssl3" => :recommended
   depends_on "libressl" => :optional
-  depends_on "libidn" if build.with? "iri"
-  depends_on "pcre2" => :optional
+  depends_on "libidn2" => :recommended
+  depends_on "pcre2" => :recommended
+  depends_on "libunistring"
   depends_on "zlib"
 
   def install
@@ -39,17 +37,18 @@ class Wget < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --with-ssl=openssl
+      --disable-pcre
     ]
 
     if build.with? "libressl"
       args << "--with-libssl-prefix=#{Formula["libressl"].opt_prefix}"
     else
-      args << "--with-libssl-prefix=#{Formula["openssl"].opt_prefix}"
+      args << "--with-libssl-prefix=#{Formula["openssl3"].opt_prefix}"
     end
 
     args << "--disable-debug" if build.without? "debug"
-    args << "--disable-iri" if build.without? "iri"
-    args << "--disable-pcre" if build.without? "pcre"
+    args << "--disable-iri" if build.without? "libidn2"
+    args << "--disable-pcre2" if build.without? "pcre2"
 
     system "./bootstrap" if build.head?
     system "./configure", *args
@@ -57,6 +56,6 @@ class Wget < Formula
   end
 
   test do
-    system bin/"wget", "-O", "-", "https://github.com"
+    system bin/"wget", "-O", "/dev/null", "https://example.com"
   end
 end

--- a/Library/Formula/wget.rb
+++ b/Library/Formula/wget.rb
@@ -4,16 +4,15 @@
 class Wget < Formula
   desc "Internet file retriever"
   homepage "https://www.gnu.org/software/wget/"
-  url "https://ftpmirror.gnu.org/wget/wget-1.24.5.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/wget/wget-1.24.5.tar.gz"
-  sha256 "fa2dc35bab5184ecbc46a9ef83def2aaaa3f4c9f3c97d4bd19dcb07d4da637de"
+  url "https://ftpmirror.gnu.org/wget/wget-1.25.0.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/wget/wget-1.25.0.tar.gz"
+  sha256 "766e48423e79359ea31e41db9e5c289675947a7fcf2efdcedb726ac9d0da3784"
 
   head do
     url "git://git.savannah.gnu.org/wget.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "gettext"
   end
 
   bottle do
@@ -30,6 +29,8 @@ class Wget < Formula
   depends_on "pcre2" => :recommended
   depends_on "libunistring"
   depends_on "zlib"
+  depends_on "gettext"
+  depends_on "libpsl"
 
   def install
   ENV.append "CFLAGS", "-std=gnu99"


### PR DESCRIPTION
Build with IDN and PCRE support by default.
Make use of pkg-config support for finding dependencies Missed out switching from openssl to openssl3 in configure last time. Adjust test so that it doesn't output to stdout and use a lighter target.

Should be merged after #1037 and #1196.
Tested on Tiger powerpc (G5) with GCC 4.0.1