### PR TITLE
curl 8.10.1

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -1,12 +1,11 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.haxx.se/"
-  url "https://curl.se/download/curl-8.8.0.tar.xz"
-  sha256 "0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400"
+  url "https://curl.se/download/curl-8.10.1.tar.xz"
+  sha256 "73a4b0e99596a09fa5924a4fb7e4b995a85fda0d18a2c02ab9cf134bebce04ee"
 
   bottle do
     cellar :any
-    sha256 "d798c40a4bf32610d49cf5339bd60b9e40db82172bb7b6b895a7e2f1d8ca9807" => :tiger_altivec
   end
 
   keg_only :provided_by_osx
@@ -31,6 +30,7 @@ class Curl < Formula
   depends_on "c-ares" => :optional
   depends_on "libressl" => :optional
   depends_on "libnghttp2"
+  depends_on "libpsl"
   depends_on "zlib"
 
   def install


### PR DESCRIPTION
Curl now requires libpsl for security around cookies to build.
https://daniel.haxx.se/blog/2024/01/10/psl-in-curl/

Needs #1198 to be merged before.
Ideally should be merged after #1037, #1182