### PR TITLE
recode 3.7.14

### DIFF
--- a/Library/Formula/recode.rb
+++ b/Library/Formula/recode.rb
@@ -1,25 +1,20 @@
 class Recode < Formula
   desc "Convert character set (charsets)"
-  homepage "http://recode.progiciels-bpi.ca/index.html"
-  url "https://github.com/pinard/Recode/archive/v3.7-beta2.tar.gz"
-  sha256 "72c3c0abcfe2887b83a8f27853a9df75d7e94a9ebacb152892cc4f25108e2144"
-  version "3.7-beta2"
+  homepage "https://web.archive.org/web/20140620121336/http://recode.progiciels-bpi.ca/index.html"
+  url "https://github.com/rrthomas/recode/releases/download/v3.7.14/recode-3.7.14.tar.gz"
+  sha256 "786aafd544851a2b13b0a377eac1500f820ce62615ccc2e630b501e7743b9f33"
+  version "3.7.14"
 
   depends_on "gettext"
+  depends_on "libiconv"
   depends_on "libtool" => :build
 
   def install
-    # Yep, missing symbol errors without these
-    ENV.append "LDFLAGS", "-liconv"
-    ENV.append "LDFLAGS", "-lintl"
-
-    cp Dir["#{Formula["libtool"].opt_share}/libtool/*/config.{guess,sub}"], buildpath
-
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--without-included-gettext",
+    system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--infodir=#{info}",
+                          "--with-libiconv-prefix=#{Formula["libiconv"].opt_prefix}",
+                          "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}",
                           "--mandir=#{man}"
     system "make", "install"
   end


### PR DESCRIPTION
Switch to a fork which is actively maintained.
The original repo hasn't been touched in some years and has build issues.
This fork is also used by MacPorts.

Tested on Tiger (G5) with GCC 5.