### PR TITLE
ld64: Use OpenSSL included with OS

### DIFF
--- a/Library/Formula/ld64.rb
+++ b/Library/Formula/ld64.rb
@@ -26,8 +26,6 @@ class Ld64 < Formula
   depends_on "cctools-headers" => :build
   depends_on "dyld-headers" => :build
   depends_on "libunwind-headers" => :build
-  # No CommonCrypto
-  depends_on "openssl" if MacOS.version < :leopard
 
   keg_only :provided_by_osx,
     "ld64 is an updated version of the ld shipped by Apple."
@@ -60,7 +58,7 @@ class Ld64 < Formula
     inreplace "src/ld/Options.cpp", "@@VERSION@@", version
 
     if MacOS.version < :leopard
-      # No CommonCrypto
+      # No CommonCrypto, use MD5 support in OpenSSL included with OS
       inreplace "src/ld/MachOWriterExecutable.hpp" do |s|
         s.gsub! "<CommonCrypto/CommonDigest.h>", "<openssl/md5.h>"
         s.gsub! "CC_MD5", "MD5"


### PR DESCRIPTION
Saves a detour into building OpenSSL + deps when version included with OS is sufficient for providing MD5 support.

Tested on Tiger (G5) with GCC 4.2, then built `cctools` which depends on `ld64`

Not sure if a revbump is needed as it will create churn, really beneficial for those on G3 based systems, starting out, who do not get prebuilt packages in the first place.

```
Cellar/ld64/97.17_1/bin/ld:
	/usr/lib/libcrypto.0.9.7.dylib (compatibility version 0.9.7, current version 0.9.7)
	/usr/lib/libstdc++.6.dylib (compatibility version 7.0.0, current version 7.4.0)
	/usr/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 88.1.12)
```