### PR TITLE
xvid 1.3.7

### DIFF
--- a/Library/Formula/xvid.rb
+++ b/Library/Formula/xvid.rb
@@ -1,21 +1,17 @@
 class Xvid < Formula
   desc "High-performance, high-quality MPEG-4 video library"
-  homepage "https://www.xvid.org"
-  url "https://fossies.org/unix/privat/xvidcore-1.3.4.tar.gz"
-  # Official download takes a long time to fail, so set it as the mirror for now
-  mirror "http://downloads.xvid.org/downloads/xvidcore-1.3.4.tar.gz"
-  sha256 "4e9fd62728885855bc5007fe1be58df42e5e274497591fec37249e1052ae316f"
+  homepage "https://labs.xvid.com"
+  url "https://downloads.xvid.com/downloads/xvidcore-1.3.7.tar.gz"
+  mirror "https://fossies.org/linux/misc/xvidcore-1.3.7.tar.gz"
+  sha256 "abbdcbd39555691dd1c9b4d08f0a031376a3b211652c0d8b3b8aa9be1303ce2d"
+  license "GPL-2.0-or-later"
 
   bottle do
-    cellar :any
-    sha256 "ec7422d4b91dd4b4df077b62c570ae69c81631f07e4cbb0a4c399743cd086f67" => :tiger_altivec
-    sha256 "6a4338ba070c5512b0607d44587df14ffb5f6b28c7463044ec034e1dd46e64b9" => :leopard_g3
-    sha256 "2555cd6f7798940b32ba3f0b1f52c04362e6438f2fa56f3aca79369730504e6c" => :leopard_altivec
   end
 
   def install
     cd "build/generic" do
-      system "./configure", "--disable-assembly", "--prefix=#{prefix}"
+      system "./configure", "--prefix=#{prefix}"
       ENV.j1 # Or make fails
       system "make"
       system "make", "install"
@@ -32,7 +28,7 @@ class Xvid < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.cpp", "-L#{lib}", "-lxvidcore", "-o", "test"
+    system ENV.cxx, "test.cpp", "-L#{lib}", "-lxvidcore", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Fix urls reported in issue #1194
Enable assembly support, xvid support Altivec & Intel CPU extensions. The configure stage makes all the right noises about endiannes/arch/OS regarding assembly support. Compile tested only.
Fix test otherwise GCC 4.0 complains about compiling C++.

On Tiger/Intel it won't enable assembly as
configure: WARNING: nasm version is too old
configure: WARNING: no correct assembler was found - Compiling generic sources only

Tested on Tiger (G5/core2duo) with GCC 4.0, core2duo only: GCC 4.2