### PR TITLE
python 3.10.16

### DIFF
--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -1,11 +1,10 @@
 class Python3 < Formula
   desc "Interpreted, interactive, object-oriented programming language"
   homepage "https://www.python.org/"
-  url "https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tar.xz"
-  sha256 "9c50481faa8c2832329ba0fc8868d0a606a680fc4f60ec48d26ce8e076751fda"
+  url "https://www.python.org/ftp/python/3.10.16/Python-3.10.16.tar.xz"
+  sha256 "bfb249609990220491a1b92850a07135ed0831e41738cf681d63cf01b2a8fbd1"
 
   bottle do
-    sha256 "eaebc29ef8cd0b64b4032694e68c7f8b95352cc790f457c9fd5a3d4bb76f93ab" => :tiger_altivec
   end
 
   option :universal
@@ -14,6 +13,7 @@ class Python3 < Formula
   depends_on "readline" => :recommended
   depends_on "sqlite"
   depends_on "gdbm" => :recommended
+  depends_on "gettext"
   depends_on "openssl3"
   depends_on "bzip2"
   depends_on "xz" => :recommended # for the lzma module added in 3.3
@@ -24,8 +24,8 @@ class Python3 < Formula
   skip_clean "bin/easy_install3", "bin/easy_install-3.4", "bin/easy_install-3.5", "bin/easy_install-3.6", "bin/easy_install-3.7", "bin/easy_install-3.10"
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
-    sha256 "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"
+    url "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz"
+    sha256 "8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"
   end
 
   resource "pip" do
@@ -34,8 +34,8 @@ class Python3 < Formula
   end
 
   resource "wheel" do
-    url "https://files.pythonhosted.org/packages/b8/d6/ac9cd92ea2ad502ff7c1ab683806a9deb34711a1e2bd8a59814e8fc27e69/wheel-0.43.0.tar.gz"
-    sha256 "465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"
+    url "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz"
+    sha256 "661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729"
   end
 
   # Homebrew's tcl-tk is built in a standard unix fashion (due to link errors)


### PR DESCRIPTION
Skipping upgrading pip as setup.py was removed in the following release. Expectation is ensurepip module is used now with the newer releases. Add gettext as dependency since version included in 10.5 is missing symbols

Undefined symbols:
  "_libintl_textdomain", referenced from:
      __locale_textdomain in libpython3.10.a(_localemodule.o)
  "_libintl_dgettext", referenced from:
      __locale_dgettext in libpython3.10.a(_localemodule.o)
  "_libintl_dcgettext", referenced from:
      __locale_dcgettext in libpython3.10.a(_localemodule.o)
  "_libintl_bindtextdomain", referenced from:
      __locale_bindtextdomain in libpython3.10.a(_localemodule.o)
  "_libintl_gettext", referenced from:
      __locale_gettext in libpython3.10.a(_localemodule.o)

Tested on Tiger (G5/c2d) with GCC 4.0.1, Leopard (G4) with GCC 4.2