### PR TITLE
libtiff: Don't use GCC 4.0 on Tiger/intel

### DIFF
--- a/Library/Formula/libtiff.rb
+++ b/Library/Formula/libtiff.rb
@@ -15,6 +15,10 @@ class Libtiff < Formula
   depends_on "xz"
   depends_on "zlib"
 
+  fails_with :gcc_4_0 if MacOS.version == :tiger && Hardware::CPU.intel? do
+    cause "libtiff/tif_lzw.c calls ___builtin_bswap32() on i386 builds with GCC and that's missing from v4.0 here"
+  end
+
   def install
     ENV.universal_binary if build.universal?
     ENV.cxx11 if build.cxx11?


### PR DESCRIPTION
GCC 4.0 lacks ___builtin_bswap32()
ld: Undefined symbols:
___builtin_bswap32

Tested on Tiger (c2d) with GCC 4.2