### PR TITLE
python major_minor_version() fix

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -3,9 +3,9 @@ require "utils.rb"
 module Language
   module Python
     def self.major_minor_version(python)
-      version = /\d\.\d/.match `#{python} --version 2>&1`
+      version = `#{python} --version 2>&1`.chomp[/(\d\.\d+)/, 1]
       return unless version
-      Version.new(version.to_s)
+      Version.new(version)
     end
 
     def self.homebrew_site_packages(version = "2.7")


### PR DESCRIPTION
With the recent upgrade from Python 3.7 to 3.10 the minor version needs to be double digits.

Taken from upstream
https://github.com/Homebrew/brew/commit/a1efaf1864049977d7d90f32e5ff1e897cf57d96#diff-7e7f927b5a956040b1e5cd4fc54be50d29778145d2cfd57cd1598ed3823e95c0R54

Tested change by installing `internetarchive` module using `pip2` & `pip3`