### PR TITLE
pcre2 10.44

### DIFF
--- a/Library/Formula/pcre2.rb
+++ b/Library/Formula/pcre2.rb
@@ -1,22 +1,18 @@
 class Pcre2 < Formula
   desc "Perl compatible regular expressions library with a new API"
   homepage "https://www.pcre.org/"
-  url "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2"
-  sha256 "8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840"
+  url "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.44/pcre2-10.44.tar.bz2"
+  sha256 "d34f02e113cf7193a1ebf2770d3ac527088d485d4e047ed10e5d217c6ef5de96"
 
   head "https://github.com/PCRE2Project/pcre2"
 
   bottle do
-    sha256 "8994bdc208954bda33063808e865b53f2f1fe3e84a5da2376d5e66275347cfb8" => :tiger_altivec
   end
 
   option :universal
 
-  # Allow building with JIT support on Tiger
-  patch :p0 do
-   url "https://raw.githubusercontent.com/macports/macports-ports/661d0212412d4f428a37d31e233fa6ca1efd4331/devel/pcre/files/no-OSCacheControl-on-tiger.diff"
-   sha256 "eac8b57207586f537382ebce98b0f36476bd50118e349fd8153980a2fc65be02"
-  end
+  depends_on "bzip2"
+  depends_on "zlib"
 
   def install
     ENV.universal_binary if build.universal?
@@ -26,8 +22,7 @@ class Pcre2 < Formula
                           "--enable-pcre2-16",
                           "--enable-pcre2-32",
                           "--enable-pcre2grep-libz",
-                          "--enable-pcre2grep-libbz2",
-                          "--enable-jit"
+                          "--enable-pcre2grep-libbz2"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
Don't enable JIT, we actually worked on PowerPC support and got it passing the test suite fully, however there appears to be a regression.

Tested on Tiger (G5/i386) with GCC 4.0.1.