### PR TITLE
libiconv 1.18

### DIFF
--- a/Library/Formula/libiconv.rb
+++ b/Library/Formula/libiconv.rb
@@ -1,12 +1,12 @@
 class Libiconv < Formula
   desc "Conversion library"
   homepage "https://www.gnu.org/software/libiconv/"
-  url "https://ftpmirror.gnu.org/libiconv/libiconv-1.17.tar.gz"
-  mirror "https://ftp.gnu.org/gnu/libiconv/libiconv-1.17.tar.gz"
-  sha256 "8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313"
+  url "https://ftpmirror.gnu.org/libiconv/libiconv-1.18.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
+  sha256 "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8"
+  license all_of: ["GPL-3.0-or-later", "LGPL-2.0-or-later"]
 
   bottle do
-    sha256 "533c88e9e63c7f9b98919951d1aae09a0ac385919cb53957b78ee0eb65f615fc" => :tiger_altivec
   end
 
   keg_only :provided_by_osx
@@ -26,7 +26,8 @@ class Libiconv < Formula
                           "--enable-extra-encodings",
                           "--enable-static",
                           "--docdir=#{doc}"
-    system "make", "-f", "Makefile.devel", "CFLAGS=#{ENV.cflags}", "CC=#{ENV.cc}"
+    system "make"
+    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
Use the stock Makefile rather than Makefile.devel as the latter has an autotools dependency and I suspect it was used history because it respected CC & CFLAGS. It turns out so does Makefile now. Tested by building with --cc stated & without as well as well as ENV.no_optimization set to ensure that set CC & CFLAGS values are made use of.
Run the test suite for peace of mind, it is not a lengthy run.

Tested on Tiger (G5) with GCC 4.0 & 5