### PR TITLE
rhash: restore missing symlink

### DIFF
--- a/Library/Formula/rhash.rb
+++ b/Library/Formula/rhash.rb
@@ -5,6 +5,7 @@ class Rhash < Formula
   mirror "https://github.com/rhash/RHash/archive/refs/tags/v1.4.5.tar.gz"
   sha256 "6db837e7bbaa7c72c5fd43ca5af04b1d370c5ce32367b9f6a1f7b49b2338c09a"
   license "0BSD"
+  revision 1
 
   head "https://github.com/rhash/RHash.git"
 
@@ -35,6 +36,7 @@ class Rhash < Formula
     system "make"
     system "make", "install", "install-pkg-config"
     system "make", "-C", "librhash", "install-lib-headers"
+    lib.install_symlink (lib/"librhash.#{version.major.to_s}.dylib") => "librhash.dylib"
   end
 
   test do

--- a/Library/Formula/rhash.rb
+++ b/Library/Formula/rhash.rb
@@ -10,7 +10,7 @@ class Rhash < Formula
   head "https://github.com/rhash/RHash.git"
 
   bottle do
-    sha256 "e488f8e6718441de5eaa6329ab9d5ca6361200d04ed9d2b1b8648752fc31601f" => :tiger_altivec
+    sha256 "7881119273fd9797cc8425cab6236a9d924bd6aa33653b9ded1275f93dfab5b5" => :tiger_altivec
   end
 
   # wants to pass -install_name to the linker

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -240,6 +240,42 @@ class Version
   end
   alias_method :to_str, :to_s
 
+  def null?
+    version.nil?
+  end
+
+  def major
+    return NULL_TOKEN if null?
+
+    tokens.first
+  end
+
+  def minor
+    return NULL_TOKEN if null?
+
+    tokens[1]
+  end
+
+  def patch
+    return NULL_TOKEN if null?
+
+    tokens[2]
+  end
+
+  def major_minor
+    return self if null?
+
+    major_minor = tokens[0..1]
+    major_minor.empty? ? NULL : self.class.new(major_minor.join("."))
+  end
+
+  def major_minor_patch
+    return self if null?
+
+    major_minor_patch = tokens[0..2]
+    major_minor_patch.empty? ? NULL : self.class.new(major_minor_patch.join("."))
+  end
+
   protected
 
   attr_reader :version


### PR DESCRIPTION
Looks like we both missed that rhash lost its unversioned `librhash.dylib` with the patch changes in the 1.4.5 update. Only noticed when cmake had trouble finding it.