### PR TITLE
flac 1.4.3

### DIFF
--- a/Library/Formula/flac.rb
+++ b/Library/Formula/flac.rb
@@ -1,8 +1,18 @@
 class Flac < Formula
   desc "Free lossless audio codec"
   homepage "https://xiph.org/flac/"
-  url "http://downloads.xiph.org/releases/flac/flac-1.3.1.tar.xz"
-  sha256 "4773c0099dba767d963fd92143263be338c48702172e8754b9bc5103efe1c56c"
+  url "https://downloads.xiph.org/releases/flac/flac-1.4.3.tar.xz"
+  mirror "https://ftp.osuosl.org/pub/xiph/releases/flac/flac-1.4.3.tar.xz"
+  sha256 "6c58e69cd22348f441b861092b825e591d0b822e106de6eb0ee4d05d27205b70"
+  license all_of: [
+    "BSD-3-Clause",
+    "GPL-2.0-or-later",
+    "ISC",
+    "LGPL-2.0-or-later",
+    "LGPL-2.1-or-later",
+    :public_domain,
+    any_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"],
+  ]
 
   head do
     url "https://git.xiph.org/flac.git"
@@ -12,20 +22,10 @@ class Flac < Formula
   end
 
   bottle do
-    cellar :any
-    sha256 "993da436abd03400977ec266a2747a955595a6418462b8fb328661ff83b41f9e" => :leopard_g3
-    sha256 "eebc1cd5a2204c9d223c476e5148ada3663ba58ffe5caa6faeaa24eb2d6a5cc8" => :leopard_altivec
   end
-
-  option :universal
 
   depends_on "pkg-config" => :build
-  depends_on "libogg" => :optional
-
-  fails_with :llvm do
-    build 2326
-    cause "Undefined symbols when linking"
-  end
+  depends_on "libogg"
 
   fails_with :clang do
     build 500
@@ -33,31 +33,16 @@ class Flac < Formula
   end
 
   def install
-    ENV.universal_binary if build.universal?
-
-    ENV.append "CFLAGS", "-std=gnu89"
-
     args = %W[
       --disable-dependency-tracking
       --disable-debug
       --prefix=#{prefix}
       --mandir=#{man}
-      --enable-sse
       --enable-static
     ]
 
-    args << "--disable-asm-optimizations" if build.universal? || Hardware.is_32_bit?
-    args << "--without-ogg" if build.without? "libogg"
-
     system "./autogen.sh" if build.head?
     system "./configure", *args
-
-    ENV["OBJ_FORMAT"] = "macho"
-
-    # adds universal flags to the generated libtool script
-    inreplace "libtool" do |s|
-      s.gsub! ":$verstring\"", ":$verstring -arch #{Hardware::CPU.arch_32_bit} -arch #{Hardware::CPU.arch_64_bit}\""
-    end
 
     system "make", "install"
   end


### PR DESCRIPTION
Drop universal build support as build was broken on new version.
`--enable-sse` no longer recognised.
configure sets things up, no need to set [OBJ_FORMAT](url), assembly support is enabled if building with clang.
Due to shortcoming in clang shipped with 10.8/10.9, llvm-gcc needs to be used, but there's no longer an issue building with llvm-gcc.
Enable OGG support, build times are for both are very short.

Tested on Tiger (G5/G4/i386) with GCC 4.0.1, Leopard (G4/i386) with GCC 4.2, 10.6 (i386) with GCC 4.2 / llvm-gcc, 10.7 & 10.8 with clang/llvm-gcc, 10.9 to 10.11 with clang.
Resolves #335