### PR TITLE
autoconf: Unbreak on Leopard & up

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -64,7 +64,7 @@ module Superenv
     self["CMAKE_INCLUDE_PATH"] = determine_cmake_include_path
     self["CMAKE_LIBRARY_PATH"] = determine_cmake_library_path
     self["ACLOCAL_PATH"] = determine_aclocal_path
-    self["M4"] = MacOS.locate("m4") if deps.any? { |d| d.name == "autoconf" }
+    self["M4"] = "#{HOMEBREW_PREFIX}/opt/m4/bin/m4" if deps.any? { |d| d.name == "libtool" }
     self["HOMEBREW_ISYSTEM_PATHS"] = determine_isystem_paths
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths


### PR DESCRIPTION
$M4 is set to the version which ships with OS X, and when it comes to configuring automake, autoconf is tested which invokes the version of M4 included in OS X due to the variable being set and fails as m4 is too old and doesn't recognise --gnu to enable GNU extensions.
Upstream dropped the variable[1] for exactly this reason, and then reintroduce it to cover when libtool is involved[2] to prevent libtool from using the m4 shipped with OS X for the opposite reason ($M4 is not set, traverse $PATH to find m4).

Confirmed dropping the variable resolves the automake build on 10.5 to 10.11 (tested 10.4 too but it never was an issue there).

[1] https://github.com/Homebrew/brew/commit/f6eba3c1ea2c5ac069b667d45e39b739366e2ed6
[2] https://github.com/Homebrew/brew/commit/e8452de418b3ec7ac2864a5384d7e3fc4e0fb6b1

Issue which covers when $M4 was first introduced
https://github.com/Homebrew/legacy-homebrew/issues/24904