### PR TITLE
libftdi: fix build with gcc-4.2/Tiger

### DIFF
--- a/Library/Formula/libftdi.rb
+++ b/Library/Formula/libftdi.rb
@@ -23,10 +23,14 @@ class Libftdi < Formula
   def install
     ENV.enable_warnings if ENV.compiler == :gcc_4_0
     mkdir "libftdi-build" do
-      system "cmake", "..", "-DPYTHON_BINDINGS=OFF",
-                            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON",
-                            "-DFTDIPP=OFF",
-                            *std_cmake_args
+      args = std_cmake_args
+      args << "-DPYTHON_BINDINGS=OFF"
+      args << "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+      args << "-DFTDIPP=OFF"
+      # gcc-4.2 does not find stdarg.h if the sysroot is set to an SDK
+      args << "-DCMAKE_OSX_SYSROOT=/" if MacOS.version < :leopard
+
+      system "cmake", "..", *args
       system "make", "install"
       pkgshare.install "../examples"
       (pkgshare/"examples/bin").install Dir["examples/*"] \

--- a/Library/Formula/libftdi.rb
+++ b/Library/Formula/libftdi.rb
@@ -6,6 +6,7 @@ class Libftdi < Formula
   license "LGPL-2.1-only"
 
   bottle do
+    sha256 "21f34f59a9661a68c5f15b7aa025e7650a0c0ccbed2857828166cb51d186d6cd" => :tiger_altivec
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Noticed the build broke for GCC 4.2 on Tiger, but we have this fix in a couple places. Longer-term, might be worth seeing if this actually belongs in `std_cmake_args` itself.