### PR TITLE
git: avoid gcc-4.2 on Tiger

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -7,7 +7,8 @@ class Git < Formula
   head "https://github.com/git/git.git", :shallow => false
 
   bottle do
-    sha256 "9c0752ab5edc3b310379ff394e2f9c2fa7bf52223c632fb357403145d8ec4080" => :tiger_altivec
+    revision 1
+    sha256 "8804eb059f29303fd334eb4b1432e5c1ebf41d932a5c7e962e89ac97b0ffcfa1" => :tiger_altivec
   end
 
   resource "html" do

--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -47,6 +47,12 @@ class Git < Formula
     depends_on "subversion" => "with-perl"
   end
 
+  # https://github.com/mistydemeo/tigerbrew/issues/1250
+  fails_with :gcc do
+    build 5553
+    cause "Misoptimization, fails to fetch certain repos"
+  end
+
   def install
     # GCC is invoked with -w
     ENV.enable_warnings if ENV.compiler == :gcc_4_0


### PR DESCRIPTION
It works fine if built with GCC 4.0.

Fixes #1250.