### PR TITLE
popt: Use llvm-gcc on 10.7/10.8

### DIFF
--- a/Library/Formula/popt.rb
+++ b/Library/Formula/popt.rb
@@ -10,6 +10,18 @@ class Popt < Formula
 
   option :universal
 
+  # Undefined symbols for architecture x86_64:
+  # "_alignof", referenced from:
+  #     _poptSaveLongLong in popt.o
+  #     _poptSaveLong in popt.o
+  #     _poptSaveInt in popt.o
+  #     _poptSaveShort in popt.o
+  # ld: symbol(s) not found for architecture x86_64
+  fails_with :clang do
+    build 500
+    cause "alignof() undefined"
+  end
+
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-debug", "--disable-dependency-tracking",


### PR DESCRIPTION
`alignof()` is undefined and results in a build failure with clang.

Tested on 10.7/10.8/10.9. 10.9 built fine with clang.