### PR TITLE
gcc 8.5.0

### DIFF
--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -3,6 +3,7 @@ class Fish < Formula
   homepage "http://fishshell.com"
   url "https://github.com/fish-shell/fish-shell/releases/download/2.7.1/fish-2.7.1.tar.gz"
   sha256 "e42bb19c7586356905a58578190be792df960fa81de35effb1ca5a5a981f0c5a"
+  revision 1
 
   head do
     url "https://github.com/fish-shell/fish-shell.git", :shallow => false
@@ -14,8 +15,6 @@ class Fish < Formula
   end
 
   bottle do
-    sha256 "931bbe0322164134e8de86f4be1adc3bfd5a7e8e85f12bed2fa1f8aa2d05ade9" => :tiger_g4e
-    sha256 "5a74df5ca15c5b2ddb6b2556d2d7b06006556daa6d623fdf0ade3f9c377b4a50" => :leopard_g4e
   end
 
   needs :cxx11

--- a/Library/Formula/fish.rb
+++ b/Library/Formula/fish.rb
@@ -15,6 +15,7 @@ class Fish < Formula
   end
 
   bottle do
+    sha256 "3611b85af5358f8458c54513480a848dab4982b0060ad7aab2a165d859850e9a" => :tiger_altivec
   end
 
   needs :cxx11

--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -26,6 +26,7 @@ class Gcc < Formula
   sha256 "d308841a511bb830a6100397b0042db24ce11f642dab6ea6ee44842e5325ed50"
 
   bottle do
+    sha256 "092a1e615cdea11f55784252145d1da94f968d1a0ec59266d4f3a9e846be242d" => :tiger_altivec
   end
 
   option "with-nls", "Build with native language support (localization)"

--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -66,11 +66,13 @@ class Gcc < Formula
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
-    # GCC Bug 25127
+    # GCC Bug 25127 for PowerPC
     # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=25127
     # ../../../libgcc/unwind.inc: In function '_Unwind_RaiseException':
     # ../../../libgcc/unwind.inc:136:1: internal compiler error: in rs6000_emit_prologue, at config/rs6000/rs6000.c:26535
-    ENV.no_optimization if Hardware::CPU.type == :ppc
+    # GCC 7 fails to install on 10.6 x86_64 at stage3
+    # https://github.com/mistydemeo/tigerbrew/issues/554
+    ENV.no_optimization
 
     # Otherwise libstdc++ will be incorrectly tagged with cpusubtype 10 (G4e)
     # https://github.com/mistydemeo/tigerbrew/issues/538

--- a/Library/Formula/gcc7.rb
+++ b/Library/Formula/gcc7.rb
@@ -153,8 +153,6 @@ class Gcc7 < Formula
       system "../configure", *args
       system "make"
       system "make", "install"
-
-      bin.install_symlink bin/"gfortran-#{version_suffix}" => "gfortran"
     end
 
     # Handle conflicts between GCC formulae and avoid interfering
@@ -218,7 +216,7 @@ class Gcc7 < Formula
       write(*,"(A)") "Done"
       end
     EOS
-    system "#{bin}/gfortran", "-o", "test", "test.f90"
+    system "#{bin}/gfortran-7", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end
 end

--- a/Library/Formula/gcc7.rb
+++ b/Library/Formula/gcc7.rb
@@ -26,6 +26,7 @@ class Gcc7 < Formula
   sha256 "b81946e7f01f90528a1f7352ab08cc602b9ccc05d4e44da4bd501c5a189ee661"
 
   bottle do
+    sha256 "6aaaec70d0d139ab61709a09365d37bcc0901486704599c068731bcf75681986" => :tiger_altivec
   end
 
   option "with-nls", "Build with native language support (localization)"

--- a/Library/Formula/gcc7.rb
+++ b/Library/Formula/gcc7.rb
@@ -76,11 +76,13 @@ class Gcc7 < Formula
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
-    # GCC Bug 25127
+    # GCC Bug 25127 for PowerPC
     # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=25127
     # ../../../libgcc/unwind.inc: In function '_Unwind_RaiseException':
     # ../../../libgcc/unwind.inc:136:1: internal compiler error: in rs6000_emit_prologue, at config/rs6000/rs6000.c:26535
-    ENV.no_optimization if Hardware::CPU.type == :ppc
+    # GCC 7 fails to install on 10.6 x86_64 at stage3
+    # https://github.com/mistydemeo/tigerbrew/issues/554
+    ENV.no_optimization
 
     # Otherwise libstdc++ will be incorrectly tagged with cpusubtype 10 (G4e)
     # https://github.com/mistydemeo/tigerbrew/issues/538

--- a/Library/Formula/gcc7.rb
+++ b/Library/Formula/gcc7.rb
@@ -1,0 +1,256 @@
+class Gcc7 < Formula
+  def arch
+    if Hardware::CPU.type == :intel
+      if MacOS.prefer_64_bit?
+        "x86_64"
+      else
+        "i686"
+      end
+    elsif Hardware::CPU.type == :ppc
+      if MacOS.prefer_64_bit?
+        "powerpc64"
+      else
+        "powerpc"
+      end
+    end
+  end
+
+  def osmajor
+    `uname -r`.chomp
+  end
+
+  desc "GNU compiler collection"
+  homepage "https://gcc.gnu.org"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-7.5.0/gcc-7.5.0.tar.xz"
+  sha256 "b81946e7f01f90528a1f7352ab08cc602b9ccc05d4e44da4bd501c5a189ee661"
+
+  bottle do
+  end
+
+  option "with-nls", "Build with native language support (localization)"
+  option "with-jit", "Build just-in-time compiler"
+  # enabling multilib on a host that can't run 64-bit results in build failures
+  option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "isl"
+
+  if MacOS.version < :leopard
+    # The as that comes with Tiger isn't capable of dealing with the
+    # PPC asm that comes in libitm
+    depends_on "cctools" => :build
+  end
+
+  # Bug 21514 - [DR 488] templates and anonymous enum - fixed in 4.0.2
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=21514
+  fails_with :gcc_4_0
+  fails_with :llvm
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  def pour_bottle?
+    MacOS::CLT.installed?
+  end
+
+  def version_suffix
+    version.to_s.slice(/\d/)
+  end
+
+  # Fix for libgccjit.so linkage on Darwin
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  patch :DATA
+
+  # Fix an Intel-only build failure on 10.4
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64184
+  patch do
+    url "https://gist.githubusercontent.com/mistydemeo/9c5b8dadd892ba3197a9cb431295cc83/raw/582d1ba135511272f7262f51a3f83c9099cd891d/sysdep-unix-tiger-intel.patch"
+    sha256 "17afaf7daec1dd207cb8d06a7e026332637b11e83c3ad552b4cd32827f16c1d8"
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+    # GCC Bug 25127
+    # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=25127
+    # ../../../libgcc/unwind.inc: In function '_Unwind_RaiseException':
+    # ../../../libgcc/unwind.inc:136:1: internal compiler error: in rs6000_emit_prologue, at config/rs6000/rs6000.c:26535
+    ENV.no_optimization if Hardware::CPU.type == :ppc
+
+    # Otherwise libstdc++ will be incorrectly tagged with cpusubtype 10 (G4e)
+    # https://github.com/mistydemeo/tigerbrew/issues/538
+    if Hardware::CPU.family == :g3 || ARGV.bottle_arch == :g3
+      ENV.append_to_cflags "-force_cpusubtype_ALL"
+    end
+
+    if MacOS.version < :leopard
+      ENV["AS"] = ENV["AS_FOR_TARGET"] = "#{Formula["cctools"].bin}/as"
+    end
+
+    # We avoiding building:
+    #  - Ada, which requires a pre-existing GCC Ada compiler to bootstrap
+    #  - Go, currently not supported on macOS
+    #  - BRIG
+    languages = %w[c c++ objc obj-c++ fortran]
+
+    # JIT compiler is off by default, enabling it has performance cost
+    languages << "jit" if build.with? "jit"
+
+    args = [
+      "--build=#{arch}-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-isl=#{Formula["isl"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-checking=release",
+      "--with-pkgversion=Tigerbrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/mistydemeo/tigerbrew/issues",
+    ]
+
+    # "Building GCC with plugin support requires a host that supports
+    # -fPIC, -shared, -ldl and -rdynamic."
+    args << "--enable-plugin" if MacOS.version > :leopard
+
+    # Otherwise make fails during comparison at stage 3
+    # See: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=45248
+    args << "--with-dwarf2" if MacOS.version < :leopard
+
+    args << "--disable-nls" if build.without? "nls"
+
+    if build.without?("multilib") || !MacOS.prefer_64_bit?
+      args << "--disable-multilib"
+    else
+      args << "--enable-multilib"
+    end
+
+    args << "--enable-host-shared" if build.with?("jit")
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+
+      bin.install_symlink bin/"gfortran-#{version_suffix}" => "gfortran"
+    end
+
+    # Handle conflicts between GCC formulae and avoid interfering
+    # with system compilers.
+    # Since GCC 4.8 libffi stuff are no longer shipped.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run. TODO fix this.
+    info.rmtree
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  def caveats
+    if build.with?("multilib") then <<-EOS.undent
+      GCC has been built with multilib support. Notably, OpenMP may not work:
+        https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60670
+      If you need OpenMP support you may want to
+        brew reinstall gcc --without-multilib
+      EOS
+    end
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<-EOS.undent
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system "#{bin}/gcc-#{version_suffix}", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+
+    (testpath/"hello-cc.cc").write <<-EOS.undent
+      #include <iostream>
+      int main()
+      {
+        std::cout << "Hello, world!" << std::endl;
+        return 0;
+      }
+    EOS
+    system "#{bin}/g++-#{version_suffix}", "-o", "hello-cc", "hello-cc.cc"
+    assert_equal "Hello, world!\n", `./hello-cc`
+
+    (testpath/"test.f90").write <<-EOS.undent
+      integer,parameter::m=10000
+      real::a(m), b(m)
+      real::fact=0.5
+
+      do concurrent (i=1:m)
+        a(i) = a(i) + fact*b(i)
+      end do
+      write(*,"(A)") "Done"
+      end
+    EOS
+    system "#{bin}/gfortran", "-o", "test", "test.f90"
+    assert_equal "Done\n", `./test`
+  end
+end
+__END__
+diff --git a/gcc/jit/Make-lang.in b/gcc/jit/Make-lang.in
+index 44d0750..4df2a9c 100644
+--- a/gcc/jit/Make-lang.in
++++ b/gcc/jit/Make-lang.in
+@@ -85,8 +85,7 @@ $(LIBGCCJIT_FILENAME): $(jit_OBJS) \
+	     $(jit_OBJS) libbackend.a libcommon-target.a libcommon.a \
+	     $(CPPLIB) $(LIBDECNUMBER) $(LIBS) $(BACKENDLIBS) \
+	     $(EXTRA_GCC_OBJS) \
+-	     -Wl,--version-script=$(srcdir)/jit/libgccjit.map \
+-	     -Wl,-soname,$(LIBGCCJIT_SONAME)
++	     -Wl,-install_name,$(LIBGCCJIT_SONAME)
+
+ $(LIBGCCJIT_SONAME_SYMLINK): $(LIBGCCJIT_FILENAME)
+	ln -sf $(LIBGCCJIT_FILENAME) $(LIBGCCJIT_SONAME_SYMLINK)
+diff --git a/gcc/jit/jit-playback.c b/gcc/jit/jit-playback.c
+index 925fa86..01cfd4b 100644
+--- a/gcc/jit/jit-playback.c
++++ b/gcc/jit/jit-playback.c
+@@ -2416,6 +2416,15 @@ invoke_driver (const char *ctxt_progname,
+      time.  */
+   ADD_ARG ("-fno-use-linker-plugin");
+
++#if defined (DARWIN_X86) || defined (DARWIN_PPC)
++  /* OS X's linker defaults to treating undefined symbols as errors.
++     If the context has any imported functions or globals they will be
++     undefined until the .so is dynamically-linked into the process.
++     Ensure that the driver passes in "-undefined dynamic_lookup" to the
++     linker.  */
++  ADD_ARG ("-Wl,-undefined,dynamic_lookup");
++#endif
++
+   /* pex argv arrays are NULL-terminated.  */
+   argvec.safe_push (NULL);

--- a/Library/Formula/gcc8.rb
+++ b/Library/Formula/gcc8.rb
@@ -144,8 +144,6 @@ class Gcc < Formula
       system "../configure", *args
       system "make"
       system "make", "install"
-
-      bin.install_symlink bin/"gfortran-#{version_suffix}" => "gfortran"
     end
 
     # Handle conflicts between GCC formulae and avoid interfering
@@ -209,7 +207,7 @@ class Gcc < Formula
       write(*,"(A)") "Done"
       end
     EOS
-    system "#{bin}/gfortran", "-o", "test", "test.f90"
+    system "#{bin}/gfortran-8", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end
 end

--- a/Library/Formula/gcc8.rb
+++ b/Library/Formula/gcc8.rb
@@ -26,10 +26,9 @@ class Gcc < Formula
   sha256 "d308841a511bb830a6100397b0042db24ce11f642dab6ea6ee44842e5325ed50"
 
   bottle do
-    sha256 "092a1e615cdea11f55784252145d1da94f968d1a0ec59266d4f3a9e846be242d" => :tiger_altivec
   end
 
-  conflicts_with "gcc8", :because => "both install the same version of GCC"
+  conflicts_with "gcc", :because => "both install the same version of GCC"
 
   option "with-nls", "Build with native language support (localization)"
   option "with-jit", "Build just-in-time compiler"

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -1,7 +1,7 @@
 # @private
 module CompilerConstants
-  GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7]
-  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-7])$/
+  GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7 8]
+  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-8])$/
   COMPILER_SYMBOL_MAP = {
     "gcc-4.0"  => :gcc_4_0,
     "gcc-4.2"  => :gcc,


### PR DESCRIPTION
Also moves the previous GCC 7.5.0 formula to `gcc7`, though that's going to need a new bottle.

I looked up the patches in GCC 7, and neither apply: one is to a library that no longer exists, and the other is a backport from a fix that's in GCC 8.

It'd be nice from here to keep moving forward on newer GCCs, to see how new we can go.