### PR TITLE
perl 5.40.1

### DIFF
--- a/Library/Formula/perl.rb
+++ b/Library/Formula/perl.rb
@@ -1,8 +1,9 @@
 class Perl < Formula
   desc "Highly capable, feature-rich programming language"
   homepage "https://www.perl.org/"
-  url "https://www.cpan.org/src/5.0/perl-5.40.0.tar.gz"
-  sha256 "c740348f357396327a9795d3e8323bafd0fe8a5c7835fc1cbaba0cc8dfe7161f"
+  url "https://www.cpan.org/src/5.0/perl-5.40.1.tar.gz"
+  sha256 "02f8c45bb379ed0c3de7514fad48c714fd46be8f0b536bfd5320050165a1ee26"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
 
   head "https://perl5.git.perl.org/perl.git", :branch => "blead"
 


### PR DESCRIPTION
Tested on Tiger (G4/i386) with GCC 4.0.1 and Leopard (G5/i386) with GCC 4.2, 10.6 to 10.11.

Tiger/i386 fails several tests with regards to locale and Yosemite fails some tests regarding floating point, otherwise all other systems passed their testsuite run and should not block packaging for PowerPC. I'll follow up on 10.4/10.10 on intel separately.