### PR TITLE
sqlite: Use llvm-gcc on 10.7 & 10.8

### DIFF
--- a/Library/Formula/sqlite.rb
+++ b/Library/Formula/sqlite.rb
@@ -39,6 +39,9 @@ class Sqlite < Formula
     sha256 "62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf"
   end
 
+  #___atomic_load_n() / ___atomic_store_n() called but not defined.
+  fails_with :clang if MacOS.version == :lion || MacOS.version == :mountain_lion
+
   def install
     # sqlite segfaults on Tiger/PPC with our gcc-4.2
     # obviously we need a newer GCC stat!

--- a/Library/Formula/sqlite.rb
+++ b/Library/Formula/sqlite.rb
@@ -39,8 +39,10 @@ class Sqlite < Formula
     sha256 "62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf"
   end
 
-  #___atomic_load_n() / ___atomic_store_n() called but not defined.
-  fails_with :clang if MacOS.version == :lion || MacOS.version == :mountain_lion
+  fails_with :clang do
+    build 500
+    cause "___atomic_load_n() / ___atomic_store_n() called but not defined"
+  end
 
   def install
     # sqlite segfaults on Tiger/PPC with our gcc-4.2


### PR DESCRIPTION
`___atomic_load_n()` / `___atomic_store_n()` called but not defined.