### PR TITLE
openssl3: Fix build on 10.6 to 10.8

### DIFF
--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -10,6 +10,10 @@ class Openssl3 < Formula
     sha256 "a3b738e4b3c6af98b0eaea8121c0c15a5dd8230ed481824a713e5a02abfea94b" => :tiger_altivec
   end
 
+  # 10.6 - 10.8: build with asm broken, due to unsupported directive (.previous)
+  # https://github.com/openssl/openssl/issues/26447
+  patch :DATA
+
   keg_only :provided_by_osx
 
   option "with-tests", "Build and run the test suite"
@@ -115,3 +119,17 @@ class Openssl3 < Formula
     end
   end
 end
+__END__
+--- a/crypto/perlasm/x86_64-xlate.pl
++++ b/crypto/perlasm/x86_64-xlate.pl
+@@ -957,7 +957,9 @@
+                         $current_segment = ".text";
+                         push(@segment_stack, $current_segment);
+                     }
+-		    $self->{value} = $current_segment if ($flavour eq "mingw64");
++                    if ($flavour eq "mingw64" || $flavour eq "macosx") {
++		        $self->{value} = $current_segment;
++                    }
+ 		}
+ 		$$line = "";
+ 		return $self;


### PR DESCRIPTION
`.previous` directive is unsupported by `as(1)`.
Skipping revbump to spare pointless rebuild on PowerPC/32bit x86 systems (it only applies to x86_64 builds)

Tested on 10.6 to 10.11, everything built successfully on all OS' but there's a new test failure in OpenSSL 3.4.0 on 10.6 & 10.7 which is unrelated to this build fix.