### PR TITLE
gettext: Use fails_with in block-form

### DIFF
--- a/Library/Formula/gettext.rb
+++ b/Library/Formula/gettext.rb
@@ -21,14 +21,10 @@ class Gettext < Formula
   # https://savannah.gnu.org/bugs/?63866
   patch :p0, :DATA
 
-  # clang shipped with 10.7 & 10.8, use llvm-gcc until gnulib is fixed
-  #  "___atomic_compare_exchange_n", referenced from:
-  #      _asyncsafe_spin_lock in libgettextlib_la-asyncsafe-spin.o
-  #      _asyncsafe_spin_unlock in libgettextlib_la-asyncsafe-spin.o
-  #  "___atomic_store_n", referenced from:
-  #      _asyncsafe_spin_init in libgettextlib_la-asyncsafe-spin.o
-  # ld: symbol(s) not found for architecture x86_64
-  fails_with :clang if MacOS.version == :lion || MacOS.version == :mountain_lion
+  fails_with :clang do
+    build 500
+    cause "___atomic_compare_exchange_n() / ___atomic_store_n() called in gnulib but not defined"
+  end
 
   def install
     ENV.libxml2


### PR DESCRIPTION
That way we can be specific about the affected clang version, rather than excluding by OS version.