### PR TITLE
Add Palm OS development toolchain

### DIFF
--- a/Library/Formula/palm-os-sdk.rb
+++ b/Library/Formula/palm-os-sdk.rb
@@ -1,0 +1,29 @@
+class PalmOsSdk < Formula
+  desc "Collection of Palm OS SDKs"
+  homepage "https://web.archive.org/web/20041204085429/http://www.palmos.com:80/dev/tools/core.html"
+  url "https://github.com/jichu4n/palm-os-sdk/archive/1fa22066ca0f8b74949c14dd1d626294145d1c09.tar.gz"
+  version "2023-12-19"
+  sha256 "f4481184a489929aac44395f933b53af75d684a1c26ce217deb61566be80be53"
+
+  depends_on "prc-tools"
+
+  def install
+    cp_r Dir["*"], "#{prefix}"
+    mkdir_p "#{Formula["prc-tools"].opt_prefix}/palm-os-sdks"
+    ["sdk-1", "sdk-2", "sdk-3.1", "sdk-3.5", "sdk-4", "sdk-5r3", "sdk-5r4"].each do |sdks|
+      ln_s "#{prefix}/#{sdks}", "#{Formula["prc-tools"].opt_prefix}/palm-os-sdks/#{sdks}"
+    end
+    # palmdev-prep looks for directories prefixed with "sdk-".
+    # State the version number first in the target symlink to help sort so that sdk-5r4 remains default.
+    ln_s "#{prefix}/dana-2.0", "#{Formula["prc-tools"].opt_prefix}/palm-os-sdks/sdk-2.0-dana"
+    ln_s "#{prefix}/handera-105", "#{Formula["prc-tools"].opt_prefix}/palm-os-sdks/sdk-1.05-handera"
+
+    system "#{Formula["prc-tools"].opt_bin}/palmdev-prep"
+  end
+
+  def caveats; <<~EOS
+    When GCC is given no -palmos options, SDK '5r4' will be used by default.
+    Run #{HOMEBREW_PREFIX}/bin/palmdev-prep to change the default SDK.
+    EOS
+  end
+end

--- a/Library/Formula/pilot-link.rb
+++ b/Library/Formula/pilot-link.rb
@@ -36,7 +36,7 @@ class PilotLink < Formula
   def caveats; <<-EOS.undent
     For a list of installed utilites and how to connect to your PDA,
     see the pilot-link(7) manual installed at
-    #{man}/man7/pilot-link.7
+    #{man7}/pilot-link.7
     EOS
   end
 

--- a/Library/Formula/pilrc.rb
+++ b/Library/Formula/pilrc.rb
@@ -1,0 +1,14 @@
+class Pilrc < Formula
+  desc "PILot Resource Compiler for Palm OS"
+  homepage "https://pilrc.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/pilrc/pilrc/3.2/pilrc-3.2.tar.gz"
+  sha256 "f3d6ea3c77f5d2a00707f4372a212377ab7bd77b3d68c3db7e28a553b235903f"
+
+  def install
+    system "./unix/configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end

--- a/Library/Formula/prc-tools.rb
+++ b/Library/Formula/prc-tools.rb
@@ -1,0 +1,50 @@
+class PrcTools < Formula
+  desc "Toolchain supporting C and C++ programming for Palm OS"
+  homepage "https://prc-tools.sourceforge.net"
+  url "https://github.com/jichu4n/prc-tools-remix/archive/refs/tags/v2.3.5.tar.gz"
+  sha256 "d8c29e81c197ba7801d8331eddcb94990f780c96b3ccea83b60b08d8349c96a8"
+
+  def arch
+    # Configuration x86_64-apple-darwin not supported
+    if Hardware::CPU.type == :intel
+        "i686"
+    elsif Hardware::CPU.type == :ppc
+        "powerpc"
+    end
+  end
+
+  def install
+    # cc1: Invalid option `cpu=970'
+    # cc1: Invalid option `macosx-version-min=10.4'
+    # cc1: Invalid option `-faltivec'
+    # cc1: Invalid option `arch=prescott'
+    ENV.no_optimization
+    ENV.deparallelize
+
+    args = %W[
+        --prefix=#{prefix}
+        --enable-targets=m68k-palmos,arm-palmos
+        --enable-languages=c,c++
+        --with-palmdev-prefix=#{opt_prefix}/palm-os-sdks
+        --host=#{arch}-apple-darwin
+        --disable-nls
+        --mandir=#{man}
+        --infodir=#{info}
+    ]
+
+    mkdir "build" do
+      # Need to use a Bourne like shell otherwise the build trips up setting environment variables.
+      ENV["SHELL"] = "/bin/sh"
+      system "../prc-tools-2.3/configure", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  def caveats; <<~EOS
+    The toolchain is set to look for SDKs in #{opt_prefix}/palm-os-sdks
+    You can install the "palm-os-sdk" formula to populate this directory with
+    a collection SDKs, if you don't have your own SDK to use.
+    EOS
+  end
+end

--- a/Library/Formula/prc-tools.rb
+++ b/Library/Formula/prc-tools.rb
@@ -23,7 +23,7 @@ class PrcTools < Formula
 
     args = %W[
         --prefix=#{prefix}
-        --enable-targets=m68k-palmos,arm-palmos
+        --enable-targets=m68k-palmos
         --enable-languages=c,c++
         --with-palmdev-prefix=#{opt_prefix}/palm-os-sdks
         --host=#{arch}-apple-darwin


### PR DESCRIPTION
Build tested on 10.4 (G4/G5/i386),10.5 (G5/i386), 10.6 to 10.11 (x86_64).

Actual use tested on 10.4 (G4) to build a [Hello World](https://en.wikibooks.org/wiki/Programming_for_Palm_OS%2FC%2FHelloWorld) app and run it on a Palm m515.
```
m68k−palmos−gcc hello.c −o hello
m68k−palmos−obj−res hello
build−prc hello.prc "Hello, World" WRLD *.hello.grc
pilot-xfer -p usb: -i hello.prc
```