### PR TITLE
sip 4.16.9

### DIFF
--- a/Library/Formula/sip.rb
+++ b/Library/Formula/sip.rb
@@ -1,23 +1,18 @@
 class Sip < Formula
   desc "Tool to create Python bindings for C and C++ libraries"
   homepage "http://www.riverbankcomputing.co.uk/software/sip"
-  url "https://downloads.sourceforge.net/project/pyqt/sip/sip-4.16.9/sip-4.16.9.tar.gz"
-  sha256 "dbe173aa566e26ca0bb5bcbc1d30ef780f416267bb3b5df48149a737ea6b0555"
+  url "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.25/sip-4.19.25.tar.gz"
+  sha256 "b39d93e937647807bac23579edbff25fe46d16213f708370072574ab1f1b4211"
 
   bottle do
     cellar :any_skip_relocation
-    revision 1
-    sha256 "902c988504e52b3a69742b3b13b08f4ac4d33f46b80e65201a692417a95e68c3" => :el_capitan
-    sha256 "a88bff5227829979cc96ccb956f73e3a39c1e8e885f02d39e30a6040faf4d2e8" => :yosemite
-    sha256 "777e09e3635c2f445146e5f4612a3f812a7c40ce2ba47309703a0df1163992f2" => :mavericks
-    sha256 "8832546d36baa62fdecd0df427ba4f3b02ab2f39fc5fcb47f114ae5020f11342" => :mountain_lion
   end
 
   head "http://www.riverbankcomputing.co.uk/hg/sip", :using => :hg
 
   option "without-python", "Build without python2 support"
-  depends_on :python => :recommended if MacOS.version <= :snow_leopard
-  depends_on :python3 => :optional
+  depends_on :python => :recommended
+  depends_on :python3 => :recommended
 
   if build.without?("python3") && build.without?("python")
     odie "sip: --with-python3 must be specified when using --without-python"


### PR DESCRIPTION
This is listed as the last release of SIP v4.

Marking as draft because while it builds and installs just fine, PyQT4 modules still fail.