### PR TITLE
gnupg: doesn't build with certain older compilers

### DIFF
--- a/Library/Formula/gnupg.rb
+++ b/Library/Formula/gnupg.rb
@@ -13,6 +13,11 @@ class Gnupg < Formula
 
   depends_on "curl" if MacOS.version <= :mavericks
 
+  # https://github.com/mistydemeo/tigerbrew/pull/1216#issuecomment-2664287991
+  fails_with :gcc_4_0
+  fails_with :gcc
+  fails_with :llvm
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
cc @sevan 

I'm not sure if we also need to pick a clang build, too; I'm not currently using any systems that have a clang old enough that it wouldn't be able to build this.