### PR TITLE
python3: Build fix for Apple LLVM 4.2 on 10.7

### DIFF
--- a/Library/Formula/python3.rb
+++ b/Library/Formula/python3.rb
@@ -77,8 +77,6 @@ class Python3 < Formula
       --with-system-ffi
     ]
 
-    args << "--without-gcc" if ENV.compiler == :clang
-
     cflags   = []
     ldflags  = []
     cppflags = []


### PR DESCRIPTION
Support for atomics is buggy and causes of backend failure in compiler.
In Apple LLVM 4.1 __atomic_load_n & __atomic_store_n were not implemented
so there was not an issue but with the command line tools from
Xcode 4.6.2 these functions are present & the build tries to make use
of them & fails.

fails:
Apple LLVM version 4.2 (clang-425.0.28) (based on LLVM 3.2svn)
Target: x86_64-apple-darwin11.4.2
Thread model: posix

lacks support:
Apple clang version 4.1 (tags/Apple/clang-421.11.66) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin11.4.2
Thread model: posix

Patch via Macports.

Tested on Lion with Command line tools from Xcode 4.6.2  (xcode462_cltools_10_76938260a.dmg)
Resolves #1294