### PR TITLE
gettext/libpng/sqlite: revert clang exclusion

### DIFF
--- a/Library/Formula/gettext.rb
+++ b/Library/Formula/gettext.rb
@@ -21,11 +21,6 @@ class Gettext < Formula
   # https://savannah.gnu.org/bugs/?63866
   patch :p0, :DATA
 
-  fails_with :clang do
-    build 500
-    cause "___atomic_compare_exchange_n() / ___atomic_store_n() called in gnulib but not defined"
-  end
-
   def install
     ENV.libxml2
     ENV.universal_binary if build.universal?

--- a/Library/Formula/libpng.rb
+++ b/Library/Formula/libpng.rb
@@ -22,15 +22,6 @@ class Libpng < Formula
 
   option :universal
 
-  # pngvalid: read: truecolour+tRNS 8 bit: transform: +rgb_to_gray^0.55556: red/gray output value error: rgba(2,93,95,255): 80 expected: 82 (80.714..82.500)
-  # pngvalid: 1 errors, 0 warnings
-  # FAIL: pngvalid --strict --transform (floating point arithmetic)
-  # FAIL tests/pngvalid-transform (exit status: 1)
-  fails_with :clang do
-    build 500
-    cause "tests/pngvalid-transform fails due to error in floating point arithmetic"
-  end
-
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",

--- a/Library/Formula/sqlite.rb
+++ b/Library/Formula/sqlite.rb
@@ -39,11 +39,6 @@ class Sqlite < Formula
     sha256 "62e51962552fb204ef0a541d51f8f721499d1a3fffae6e86558d251c96084fcf"
   end
 
-  fails_with :clang do
-    build 500
-    cause "___atomic_load_n() / ___atomic_store_n() called but not defined"
-  end
-
   def install
     # sqlite segfaults on Tiger/PPC with our gcc-4.2
     # obviously we need a newer GCC stat!


### PR DESCRIPTION
The issues with clang on Lion and Mountain Lion were due to my own mistake of having outdated command line tools installed.
With the latest version installed, there's no issue on Lion with clang-425.0.28 and Mountain Lion with clang-503.0.40.