### PR TITLE
GCC 4.9.4

### DIFF
--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -21,32 +21,13 @@ class Gcc49 < Formula
 
   desc "The GNU Compiler Collection"
   homepage "https://gcc.gnu.org"
-  url "https://ftpmirror.gnu.org/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
-  sha256 "2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e"
+  url "https://ftpmirror.gnu.org/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
+  sha256 "6c11d292cd01b294f9f84c9a59c230d80e9e4a47e5c6355f046bb36d4f358092"
 
   head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
 
   bottle do
-    rebuild 3
-    sha256 "0acf2b010e3c2210fcb5fdc03de9dc14f0556cf5295347d8f72f2d8d1cfab4ff" => :el_capitan
-    sha256 "5b635a24e9f7464fb94d2933b00a8d1b1cfc0efb1de140fe568e313d24965140" => :yosemite
-    sha256 "dc24f86a9652fbb0ec0bc9dd0103d23bb68c315bd490ee5d0b10a7144453ecc4" => :mavericks
-  end
-
-  if MacOS.version >= :yosemite
-    # Fixes build with Xcode 7.
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66523
-    patch do
-      url "https://gcc.gnu.org/bugzilla/attachment.cgi?id=35773"
-      sha256 "db4966ade190fff4ed39976be8d13e84839098711713eff1d08920d37a58f5ec"
-    end
-    # Fixes assembler generation with XCode 7
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66509
-    patch do
-      url "https://gist.githubusercontent.com/tdsmith/d248e025029add31e7aa/raw/444e292786df41346a3a1cc6267bba587408a007/gcc.diff"
-      sha256 "636b65a160ccb7417cc4ffc263fc815382f8bb895e32262205cd10d65ea7804a"
-    end
   end
 
   option "without-fortran", "Build without the gfortran compiler"
@@ -67,7 +48,7 @@ class Gcc49 < Formula
   depends_on "libmpc08"
   depends_on "mpfr2"
   depends_on "cloog018"
-  depends_on "isl011"
+  depends_on "isl012"
   depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
   # The bottles are built on systems with the CLT installed, and do not work
@@ -80,6 +61,7 @@ class Gcc49 < Formula
   cxxstdlib_check :skip
 
   def install
+    ENV.no_optimization
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 
@@ -113,20 +95,10 @@ class Gcc49 < Formula
       "--with-mpfr=#{Formula["mpfr2"].opt_prefix}",
       "--with-mpc=#{Formula["libmpc08"].opt_prefix}",
       "--with-cloog=#{Formula["cloog018"].opt_prefix}",
-      "--with-isl=#{Formula["isl011"].opt_prefix}",
+      "--with-isl=#{Formula["isl012"].opt_prefix}",
       "--with-system-zlib",
-      "--enable-libstdcxx-time=yes",
-      "--enable-stage1-checking",
-      "--enable-checking=release",
-      "--enable-lto",
-      # Use 'bootstrap-debug' build configuration to force stripping of object
-      # files prior to comparison during bootstrap (broken by Xcode 6.3).
-      "--with-build-config=bootstrap-debug",
-      # A no-op unless --HEAD is built because in head warnings will
-      # raise errors. But still a good idea to include.
-      "--disable-werror",
-      "--with-pkgversion=Homebrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
-      "--with-bugurl=https://github.com/Homebrew/homebrew-versions/issues",
+      "--with-pkgversion=Tigerbrew #{name} #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/mistydemeo/tigerbrew/issues",
     ]
 
     # "Building GCC with plugin support requires a host that supports

--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -127,6 +127,9 @@ class Gcc49 < Formula
     # files prior to comparison during bootstrap (broken by Xcode 6.3).
     args << "--with-build-config=bootstrap-debug" if MacOS.version == :yosemite && ENV.compiler == :clang && MacOS.clang_build_version <= 700
 
+    # Looks up _SC_NPROCESSORS_ONLN which Tiger/i386 lacks
+    args << "enable_libcilkrts=no" if Hardware::CPU.intel? && MacOS.version == :tiger
+
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/homebrew/pull/34303
     inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"

--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -62,6 +62,10 @@ class Gcc49 < Formula
   cxxstdlib_check :skip
 
   def install
+    # GCC Bug 25127 for PowerPC
+    # https://gcc.gnu.org/bugzilla//show_bug.cgi?id=25127
+    # ../../../libgcc/unwind.inc: In function '_Unwind_RaiseException':
+    # ../../../libgcc/unwind.inc:136:1: internal compiler error: in rs6000_emit_prologue, at config/rs6000/rs6000.c:23164
     ENV.no_optimization
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"

--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -183,5 +183,30 @@ class Gcc49 < Formula
     EOS
     system bin/"gcc-4.9", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
+
+    (testpath/"hello-cc.cc").write <<-EOS.undent
+      #include <iostream>
+      int main()
+      {
+        std::cout << "Hello, world!" << std::endl;
+        return 0;
+      }
+    EOS
+    system "#{bin}/g++-4.9", "-o", "hello-cc", "hello-cc.cc"
+    assert_equal "Hello, world!\n", `./hello-cc`
+
+    (testpath/"test.f90").write <<-EOS.undent
+      integer,parameter::m=10000
+      real::a(m), b(m)
+      real::fact=0.5
+
+      do concurrent (i=1:m)
+        a(i) = a(i) + fact*b(i)
+      end do
+      write(*,"(A)") "Done"
+      end
+    EOS
+    system "#{bin}/gfortran-4.9", "-o", "test", "test.f90" if build.with? "fortran"
+    assert_equal "Done\n", `./test` if build.with? "fortran"
   end
 end

--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -24,6 +24,7 @@ class Gcc49 < Formula
   url "https://ftpmirror.gnu.org/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
   mirror "https://ftp.gnu.org/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2"
   sha256 "6c11d292cd01b294f9f84c9a59c230d80e9e4a47e5c6355f046bb36d4f358092"
+  revision 1
 
   head "svn://gcc.gnu.org/svn/gcc/branches/gcc-4_9-branch"
 

--- a/Library/Formula/gcc49.rb
+++ b/Library/Formula/gcc49.rb
@@ -121,6 +121,12 @@ class Gcc49 < Formula
       args << "--enable-multilib"
     end
 
+    # clang on Yosemite generates binaries containing different CIE versions
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65733
+    # Use 'bootstrap-debug' build configuration to force stripping of object
+    # files prior to comparison during bootstrap (broken by Xcode 6.3).
+    args << "--with-build-config=bootstrap-debug" if MacOS.version == :yosemite && ENV.compiler == :clang && MacOS.clang_build_version <= 700
+
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/homebrew/pull/34303
     inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"

--- a/Library/Formula/isl012.rb
+++ b/Library/Formula/isl012.rb
@@ -1,0 +1,43 @@
+class Isl012 < Formula
+  desc "Integer Set Library for the polyhedral model"
+  homepage "https://libisl.sourceforge.io"
+  # Track gcc infrastructure releases.
+  url "https://libisl.sourceforge.io/isl-0.12.2.tar.bz2"
+  mirror "https://gcc.gnu.org/pub/gcc/infrastructure/isl-0.12.2.tar.bz2"
+  sha256 "f4b3dbee9712850006e44f0db2103441ab3d13b406f77996d1df19ee89d11fb4"
+
+  bottle do
+    cellar :any
+  end
+
+  keg_only "Conflicts with isl in main repository."
+
+  depends_on "gmp4"
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}",
+                          "--with-gmp=system",
+                          "--with-gmp-prefix=#{Formula["gmp4"].opt_prefix}"
+    system "make", "check"
+    system "make", "install"
+    (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.py"]
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <isl/ctx.h>
+
+      int main()
+      {
+        isl_ctx* ctx = isl_ctx_alloc();
+        isl_ctx_free(ctx);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lisl",
+      "-I#{include}", "-I#{Formula["gmp4"].include}", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Add a formula for isl 0.12.2
Unlike GCC 4.8 which requires isl 0.11.1 as a minimum, GCC 4.9 states that isl 0.12.2 is required in its install documentation.

GCC 4.9.4
Drop patches, they were specifically for 4.9.3. 4.9.4 was listed as
unaffected.
Need isl 0.12.2 to build GCC 4.9.4
Turn off optimisation to avoid compilation issues during a lengthy build.
--enable-libstdcxx-time alters the C++11 ABI and shouldn't be used. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61758#c6
Allow the build itself to set the type of checking.
Use the default build config & address any fallouts, rather than use a debug bootstrap.
We're not building head so no need to specify disable werror.
Update URLs


Tested on Tiger (G4) with GCC 4.0.1
Built on a 1.33Ghz PowerBook G4 running Tiger in 481 minutes using GCC 4.0.1
Built on a 1.8Ghz iMac G5 running Tiger in 438 minutes using GCC 4.0.1
Built on a 2Ghz c2d mac mini running Tiger in 84 minutes using GCC 4.0.1
Built on a 1.33Ghz iBook G4 running Leopard in 327 minutes using GCC 4.2
Built on a 1.8Ghz iMac G5 running Leopard in 247 minutes using GCC 4.2
Built on a mid-2009 Air running Leopard using GCC 4.2 in 89 minutes.
Built on a mid-2009 Air running Snow Leopard using GCC 4.2 in 113 minutes.
Built on late 2009 white MacBook running Lion using clang in 60something minutes.
Built on late 2009 white MacBook running Mountain Lion using clang in 67 minutes.
Built on late 2009 white MacBook running Mavericks using clang in 73 minutes.
Built on late 2009 white MacBook running Yosemite using clang in 104 minutes `--with-build-config=bootstrap-debug` (only way to get it to build)
Built on a mid-2009 Air running El Capitan using clang in 112 minutes.
Marking as draft until I've done more testing beyond just Tiger