### PR TITLE
pcre: just avoid JIT

### DIFF
--- a/Library/Formula/pcre.rb
+++ b/Library/Formula/pcre.rb
@@ -34,9 +34,6 @@ class Pcre < Formula
               "--enable-pcregrep-libz",
               "--enable-pcregrep-libbz2" ]
 
-    # JIT fails tests very badly on PPC right now
-    args << "--enable-jit" unless Hardware::CPU.type == :ppc
-
     system "./configure", *args
     system "make"
     ENV.deparallelize


### PR DESCRIPTION
Test fails on Leopard/i386 and El Capitan as well.

Resolves issue #1301

Tested on El Capitan with clang.