### PR TITLE
cloog018/libmpc/libmpc08/mpfr2: update urls

### DIFF
--- a/Library/Formula/cloog018.rb
+++ b/Library/Formula/cloog018.rb
@@ -3,15 +3,12 @@ class Cloog018 < Formula
   homepage "http://www.cloog.org/"
   # Track gcc infrastructure releases.
   url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.0.tar.gz"
-  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/cloog-0.18.0.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/infrastructure/cloog-0.18.0.tar.gz"
+  mirror "https://gcc.gnu.org/pub/gcc/infrastructure/cloog-0.18.0.tar.gz"
   sha256 "1c4aa8dde7886be9cbe0f9069c334843b21028f61d344a2d685f88cb1dcf2228"
 
   bottle do
     cellar :any
-    revision 1
-    sha256 "95b8d981633d853151cae2efa07bcf6655e5af04dad88418087fc614de8f160d" => :el_capitan
-    sha256 "5befa09d6f42cebefe5085959a9d7267158bd9eb7a1d7d0a95c122c5377ccaa9" => :yosemite
-    sha256 "b64ee12cd97286090e012e25882119b82ce4dc9b8dbaacf7ac17f7570f327cfa" => :mavericks
   end
 
   keg_only "Conflicts with cloog in main repository."

--- a/Library/Formula/libmpc.rb
+++ b/Library/Formula/libmpc.rb
@@ -1,8 +1,9 @@
 class Libmpc < Formula
   desc "C library for the arithmetic of high precision complex numbers"
   homepage "http://multiprecision.org"
-  url "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
-  mirror "http://multiprecision.org/mpc/download/mpc-1.3.1.tar.gz"
+  url "https://ftpmirror.gnu.org/mpc/mpc-1.3.1.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+  mirror "https://www.multiprecision.org/downloads/mpc-1.3.1.tar.gz"
   sha256 "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
 
   bottle do

--- a/Library/Formula/libmpc08.rb
+++ b/Library/Formula/libmpc08.rb
@@ -2,16 +2,12 @@ class Libmpc08 < Formula
   desc "C library for high precision complex numbers"
   homepage "http://multiprecision.org"
   # Track gcc infrastructure releases.
-  url "http://multiprecision.org/mpc/download/mpc-0.8.1.tar.gz"
-  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/mpc-0.8.1.tar.gz"
+  url "https://www.multiprecision.org/downloads/mpc-0.8.1.tar.gz"
+  mirror "https://gcc.gnu.org/pub/gcc/infrastructure/mpc-0.8.1.tar.gz"
   sha256 "e664603757251fd8a352848276497a4c79b7f8b21fd8aedd5cc0598a38fee3e4"
 
   bottle do
     cellar :any
-    revision 1
-    sha256 "e3bb3e309c6c5bd709fee9a136a642289357fcc4aa9c793df1c96785947c99d9" => :el_capitan
-    sha256 "79a024cd86280716cc82f35e88ae9695f0606d2b09e585d3d9a0f7fc800eec20" => :yosemite
-    sha256 "105469fc116eae8a19000848c91ea1bea71ad5e3f395624938030c3813eca0ed" => :mavericks
   end
 
   keg_only "Conflicts with libmpc in main repository."

--- a/Library/Formula/mpfr2.rb
+++ b/Library/Formula/mpfr2.rb
@@ -2,16 +2,13 @@ class Mpfr2 < Formula
   desc "Multiple-precision floating-point computations C lib"
   homepage "http://www.mpfr.org/"
   # Track gcc infrastructure releases.
-  url "http://www.mpfr.org/mpfr-2.4.2/mpfr-2.4.2.tar.bz2"
-  mirror "ftp://gcc.gnu.org/pub/gcc/infrastructure/mpfr-2.4.2.tar.bz2"
+  url "https://www.mpfr.org/mpfr-2.4.2/mpfr-2.4.2.tar.bz2"
+  mirror "https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/infrastructure/mpfr-2.4.2.tar.bz2"
+  mirror "https://gcc.gnu.org/pub/gcc/infrastructure/mpfr-2.4.2.tar.bz2"
   sha256 "c7e75a08a8d49d2082e4caee1591a05d11b9d5627514e678f02d66a124bcf2ba"
 
   bottle do
     cellar :any
-    revision 1
-    sha256 "08e5aa9a8b8631afe6478ab7973a152316237cbddcb0f76ddaebebec99ee77b0" => :el_capitan
-    sha256 "bb6d912bd1688077a961a91ae12a94e372e339546df84295013473bb9882def5" => :yosemite
-    sha256 "8745f1ca353d9bd28c07ac4c602b2836ca6d39477fa8736baba55fc46ce66d85" => :mavericks
   end
 
   option "with-32-bit"


### PR DESCRIPTION
Drop old package hashes which are no longer around.