### PR TITLE
cloog18 0.18.1

### DIFF
--- a/Library/Formula/cloog018.rb
+++ b/Library/Formula/cloog018.rb
@@ -1,11 +1,11 @@
 class Cloog018 < Formula
   desc "Generate code for scanning Z-polyhedra"
   homepage "http://www.cloog.org/"
-  # Track gcc infrastructure releases.
-  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.0.tar.gz"
-  mirror "https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/infrastructure/cloog-0.18.0.tar.gz"
-  mirror "https://gcc.gnu.org/pub/gcc/infrastructure/cloog-0.18.0.tar.gz"
-  sha256 "1c4aa8dde7886be9cbe0f9069c334843b21028f61d344a2d685f88cb1dcf2228"
+  # Need a minimum of isl 0.12 with v0.18.3 onwards.
+  url "http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-0.18.1.tar.gz"
+  mirror "https://www.mirrorservice.org/sites/sourceware.org/pub/gcc/infrastructure/cloog-0.18.1.tar.gz"
+  mirror "https://gcc.gnu.org/pub/gcc/infrastructure/cloog-0.18.1.tar.gz"
+  sha256 "02500a4edd14875f94fe84cbeda4290425cb0c1c2474c6f75d75a303d64b4196"
 
   bottle do
     cellar :any
@@ -21,8 +21,11 @@ class Cloog018 < Formula
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
+                          "--with-bits=gmp",
                           "--with-gmp-prefix=#{Formula["gmp4"].opt_prefix}",
-                          "--with-isl-prefix=#{Formula["isl011"].opt_prefix}"
+                          "--with-isl=system",
+                          "--with-isl-exec-prefix==#{Formula["isl011"].opt_lib}"
+                          "--with-isl-prefix=#{Formula["isl011"].opt_include}"
     system "make", "install"
   end
 


### PR DESCRIPTION
v0.18.2 is the last version which is compatible with isl v0.11.x but install is broken.
Ensure that isl and gmp from Tigerbrew are used and not the bundled version of isl.

Tested across the board as part of testing changes gcc48 in pull request #1299 