### PR TITLE
tree: add variables passed to make

### DIFF
--- a/Library/Formula/tree.rb
+++ b/Library/Formula/tree.rb
@@ -3,6 +3,7 @@ class Tree < Formula
   homepage "https://oldmanprogrammer.net/source.php?dir=projects/tree"
   url "https://github.com/Old-Man-Programmer/tree/archive/refs/tags/2.2.1.tar.gz"
   sha256 "5caddcbca805131ff590b126d3218019882e4ca10bc9eb490bba51c05b9b3b75"
+  license "GPL-2.0-or-later"
 
   bottle do
   end
@@ -11,8 +12,8 @@ class Tree < Formula
     ENV.append "CFLAGS", "-fomit-frame-pointer"
     objs = "tree.o unix.o html.o xml.o hash.o color.o strverscmp.o json.o list.o file.o filter.o info.o"
 
-    system "make", "prefix=#{prefix}",
-                   "MANDIR=#{man1}",
+    system "make", "PREFIX=#{prefix}",
+                   "MANDIR=#{man}",
                    "CC=#{ENV.cc}",
                    "CFLAGS=#{ENV.cflags}",
                    "LDFLAGS=#{ENV.ldflags}",


### PR DESCRIPTION
It now uses the common prefix capitalised
Need to state the root of the man directory, it will suffix the destination.
Add a license while here, obtained from
https://github.com/Homebrew/homebrew-core/blob/238f95575d520714c7b5f5914bd036693769ef41/Formula/t/tree.rb