### PR TITLE
openssl3 3.5.0

### DIFF
--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -42,6 +42,10 @@ class Openssl3 < Formula
     elsif Hardware::CPU.intel?
       args << (Hardware::CPU.is_64_bit? && MacOS.version > :leopard ? "darwin64-x86_64-cc" : "darwin-i386-cc")
     end
+    # 01-test_sanity.t fails test_sanity_sleep when on a G5, nanosleep(2) is the suspect.
+    # Switch to using usleep(3) as a workaround.
+    # https://github.com/openssl/openssl/issues/27317
+    args << "-DOPENSSL_USE_USLEEP" if MacOS.version == :leopard && Hardware::CPU.family == :g5
     args
   end
 

--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -1,18 +1,13 @@
 class Openssl3 < Formula
   desc "Cryptography and SSL/TLS Toolkit"
   homepage "https://openssl.org/"
-  url "https://www.openssl.org/source/openssl-3.4.0.tar.gz"
-  mirror "https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz"
-  sha256 "e15dda82fe2fe8139dc2ac21a36d4ca01d5313c75f99f46c4e8a27709b7294bf"
+  url "https://www.openssl.org/source/openssl-3.5.0.tar.gz"
+  mirror "https://github.com/openssl/openssl/releases/download/openssl-3.5.0/openssl-3.5.0.tar.gz"
+  sha256 "344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0"
   license "Apache-2.0"
 
   bottle do
-    sha256 "a3b738e4b3c6af98b0eaea8121c0c15a5dd8230ed481824a713e5a02abfea94b" => :tiger_altivec
   end
-
-  # 10.6 - 10.8: build with asm broken, due to unsupported directive (.previous)
-  # https://github.com/openssl/openssl/issues/26447
-  patch :DATA
 
   keg_only :provided_by_osx
 
@@ -119,17 +114,3 @@ class Openssl3 < Formula
     end
   end
 end
-__END__
---- a/crypto/perlasm/x86_64-xlate.pl
-+++ b/crypto/perlasm/x86_64-xlate.pl
-@@ -957,7 +957,9 @@
-                         $current_segment = ".text";
-                         push(@segment_stack, $current_segment);
-                     }
--		    $self->{value} = $current_segment if ($flavour eq "mingw64");
-+                    if ($flavour eq "mingw64" || $flavour eq "macosx") {
-+		        $self->{value} = $current_segment;
-+                    }
- 		}
- 		$$line = "";
- 		return $self;


### PR DESCRIPTION
Built with tests on a 1.8Ghz iMac G5 running Tiger in 181 minutes using GCC 4.0.1
Built with tests on a 2Ghz c2d mac mini running Tiger in 153 minutes using GCC 4.0.1
Built with tests on 1.33Ghz iBook G4 running Leopard using GCC 4.2 - forgot to note the time.
Built with tests on 1st gen 1.8Ghz iMac G5 running Leopard using GCC 4.0.1 in 114 minutes.
Built with tests on mid-2009 Air running Leopard using GCC 4.2 in 65 minutes.
Built with tests on late 2009 white MacBook running Mountain Lion using clang in 34 minutes.
Built with tests on late 2009 white MacBook running Mavericks using clang - forgot to note the time.
 Built with tests on late 2009 white MacBook running Yosemite using clang in 34 minutes.
Built with tests on mid-2009 Air running El Capitan using clang in 49 minutes.

Issues running the test suite on 10.4/PowerPC on a G4 fails quic test (https://github.com/openssl/openssl/issues/27356), 10.5/PowerPC on a G5 fails sanity test due to nanosleep (committed workaround), 10.6 & 10.7 both fail with same 82-test_ocsp_cert_chain test (https://github.com/openssl/openssl/issues/27358) .
