### PR TITLE
curl: drop extra --with-ca-bundle

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -67,10 +67,6 @@ class Curl < Formula
       args << "--disable-ares"
     end
 
-    # Tiger/Leopard ship with a horrendously outdated set of certs,
-    # breaking any software that relies on curl, e.g. git
-    args << "--with-ca-bundle=#{HOMEBREW_PREFIX}/share/ca-bundle.crt"
-
     system "./configure", *args
     system "make", "install"
     system "make", "install", "-C", "scripts"


### PR DESCRIPTION
It's already covered on line 53 & 57
No revision bump needed as the previous statements already took effect.