### PR TITLE
maven: fix download url and java dependency

### DIFF
--- a/Library/Formula/maven.rb
+++ b/Library/Formula/maven.rb
@@ -1,11 +1,10 @@
 class Maven < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
-  mirror "https://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
+  url "https://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz"
   sha256 "3a8dc4a12ab9f3607a1a2097bbab0150c947ad6719d8f1bb6d5b47d0fb0c4779"
 
-  depends_on :java
+  depends_on :java => "1.8+"
 
   def install
     # Remove windows files


### PR DESCRIPTION
Remove URL that's returning 404, promote mirror URL to main URL. Specify that Maven 3.3.3 requires Java 8, so that systems with lower versions fail the dependency check rather than fail with build errors.

Tested package download/dependency check on Leopard/PowerPC, but I don't have Java 8 on my development machine to test the build beyond this.

Resolves a maven build issue identified in https://github.com/mistydemeo/tigerbrew/issues/1332