### PR TITLE
rabbitmq: update download url

### DIFF
--- a/Library/Formula/rabbitmq.rb
+++ b/Library/Formula/rabbitmq.rb
@@ -1,7 +1,7 @@
 class Rabbitmq < Formula
   desc "Messaging broker"
   homepage "https://www.rabbitmq.com"
-  url "https://www.rabbitmq.com/releases/rabbitmq-server/v3.5.4/rabbitmq-server-mac-standalone-3.5.4.tar.gz"
+  url "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_5_4/rabbitmq-server-mac-standalone-3.5.4.tar.gz"
   sha256 "5a3cbf4a27ef7d81f64f511faa89a45c371713c459218ad893407d31d525d711"
 
   depends_on "simplejson" => :python if MacOS.version <= :leopard


### PR DESCRIPTION
Previous download url is returning 404, updating to github.com url.

Tested on Leopard/PPC. Resolves an issue identified in https://github.com/mistydemeo/tigerbrew/issues/1332