### PR TITLE
fontconfig: add python3 dependency

### DIFF
--- a/Library/Formula/fontconfig.rb
+++ b/Library/Formula/fontconfig.rb
@@ -14,6 +14,7 @@ class Fontconfig < Formula
 
   depends_on "pkg-config" => :build
   depends_on "freetype"
+  depends_on "python3"
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
fontconfig fails to build without python3. This adds the python3 package as a dependency.

Tested on Leopard/PowerPC. This fixes an error discussed in https://github.com/mistydemeo/tigerbrew/issues/1332.