### PR TITLE
cowsay: fix url and checksum

### DIFF
--- a/Library/Formula/cowsay.rb
+++ b/Library/Formula/cowsay.rb
@@ -1,8 +1,8 @@
 class Cowsay < Formula
   desc "Configurable talking characters in ASCII art"
   homepage "https://web.archive.org/web/20120225123719/http://www.nog.net/~tony/warez/cowsay.shtml"
-  url "http://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03.orig.tar.gz"
-  sha256 "0b8672a7ac2b51183780db72618b42af8ec1ce02f6c05fe612510b650540b2af"
+  url "https://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03+dfsg2.orig.tar.gz"
+  sha256 "3b89965c7d6b19f321867e59d14d4aec820d36068f56d2b1e783498beeb4183e"
 
   bottle do
     cellar :any_skip_relocation

--- a/Library/Formula/cowsay.rb
+++ b/Library/Formula/cowsay.rb
@@ -3,6 +3,7 @@ class Cowsay < Formula
   homepage "https://web.archive.org/web/20120225123719/http://www.nog.net/~tony/warez/cowsay.shtml"
   url "https://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03+dfsg2.orig.tar.gz"
   sha256 "3b89965c7d6b19f321867e59d14d4aec820d36068f56d2b1e783498beeb4183e"
+  version "3.0.3+dfsg2"
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
URL for cowsay source has changed: updating both URL and checksum. Tested on Leopard/PowerPC:

```
kabooties-emac:~ kabootie$ brew install cowsay
==> Downloading https://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03+dfsg2.orig.tar.gz
##################################################################################################################################################################################################### 100.0%
==> /bin/sh install.sh /usr/local/Cellar/cowsay/3.03+dfsg2.orig
/usr/local/Cellar/cowsay/3.03+dfsg2.orig: 44 files, 192K, built in 10 seconds
kabooties-emac:~ kabootie$ brew fetch cowsay
==> Downloading https://ftp.acc.umu.se/mirror/cdimage/snapshot/Debian/pool/main/c/cowsay/cowsay_3.03+dfsg2.orig.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/cowsay-3.03+dfsg2.orig.tar.gz
SHA1: 43120e1414408350763f8fd2be0c9c18782eccce
SHA256: 3b89965c7d6b19f321867e59d14d4aec820d36068f56d2b1e783498beeb4183e
kabooties-emac:~ kabootie$ cowsay I guess it worked
 ___________________ 
< I guess it worked >
 ------------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
kabooties-emac:~ kabootie$ 
```
