### PR TITLE
elixir 1.5.3

### DIFF
--- a/Library/Formula/elixir.rb
+++ b/Library/Formula/elixir.rb
@@ -25,16 +25,10 @@ end
 class Elixir < Formula
   desc "Functional metaprogramming aware language built on Erlang VM"
   homepage "http://elixir-lang.org/"
-  url "https://github.com/elixir-lang/elixir/archive/v1.1.1.tar.gz"
-  sha256 "3b7d6e4fdbcc82d19fa76f4e384f8a87535abcd00ef04528dc6b6706f32a106a"
+  url "https://github.com/elixir-lang/elixir/archive/v1.5.3.tar.gz"
+  sha256 "0fc6024b6027d87af9609b416448fd65d8927e0d05fc02410b35f4b9b9eb9629"
 
   head "https://github.com/elixir-lang/elixir.git"
-
-  bottle do
-    sha256 "663ecb37c67e006ea31374b22cbacbb1c8625ae1db5020a5427863f9a535c622" => :el_capitan
-    sha256 "33a7b3ca8a11eea513a457f29f1f590590528ec610eccea335c8c7f97a094fcc" => :yosemite
-    sha256 "d3bbb6aff815ccf49c6d0082033ccdaaa9893105ee1a8fe80818d5df6648c0f7" => :mavericks
-  end
 
   depends_on Erlang17Requirement
 


### PR DESCRIPTION
Update elixir to 1.5.3 and remove outdated bottle checksums. This is the latest version of `elixir` that is compatible with Erlang 18. Tested both with the current version of `erlang` as well as the version in PR https://github.com/mistydemeo/tigerbrew/pull/1344.