### PR TITLE
ejabberd 16.12

### DIFF
--- a/Library/Formula/ejabberd.rb
+++ b/Library/Formula/ejabberd.rb
@@ -1,8 +1,8 @@
 class Ejabberd < Formula
   desc "XMPP application server"
   homepage "https://www.ejabberd.im"
-  url "https://www.process-one.net/downloads/ejabberd/15.07/ejabberd-15.07.tgz"
-  sha256 "87d5001521cbb779b84bc74879e032e2514d9a651e24c4e40cce0907ab405bd1"
+  url "https://github.com/processone/ejabberd/archive/refs/tags/15.11.tar.gz"
+  sha256 "75dcb533c04df5926cc118ca997c843ff5a8a80ef0b49782d860e9d7cbe76ca0"
 
   head "https://github.com/processone/ejabberd.git"
 
@@ -38,6 +38,7 @@ class Ejabberd < Formula
             "--enable-odbc",
             "--enable-pam"]
 
+    system "./autogen.sh"
     system "./configure", *args
     system "make"
     system "make", "install"

--- a/Library/Formula/ejabberd.rb
+++ b/Library/Formula/ejabberd.rb
@@ -6,13 +6,6 @@ class Ejabberd < Formula
 
   head "https://github.com/processone/ejabberd.git"
 
-  bottle do
-    sha256 "4001c8bf43972697862ead67f944177c6a6b771c96a4d6de75f68694ed7aa620" => :el_capitan
-    sha256 "592a3412890d52da9d8a9f43a288dca8eab233dcd0c59d17d4bd8f89b7b4567b" => :yosemite
-    sha256 "17b97c88ea724e8816c445a944ad71a9be141cf9afe8e4f168dd271ea2bd8448" => :mavericks
-    sha256 "f53c7307acaee6aafa813785ede998900c0c32db2d0f28dfb5dd51c45b6f5366" => :mountain_lion
-  end
-
   option "32-bit"
 
   depends_on "openssl"
@@ -36,10 +29,12 @@ class Ejabberd < Formula
             "--enable-pgsql",
             "--enable-mysql",
             "--enable-odbc",
-            "--enable-pam"]
+#            "--enable-pam"
+          ]
 
     system "./autogen.sh"
     system "./configure", *args
+    system "git", "clone", "--branch", "0.1.7", "https://github.com/DeadZen/goldrush.git", "deps/goldrush"
     system "make"
     system "make", "install"
 

--- a/Library/Formula/ejabberd.rb
+++ b/Library/Formula/ejabberd.rb
@@ -6,9 +6,14 @@ class Ejabberd < Formula
 
   option "32-bit"
 
-  depends_on "openssl3"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "rebar" => :build
+
   depends_on "erlang"
   depends_on "libyaml"
+  depends_on "openssl3"
+
   # for CAPTCHA challenges
   depends_on "imagemagick" => :optional
 
@@ -27,16 +32,13 @@ class Ejabberd < Formula
             "--enable-pgsql",
             "--enable-mysql",
             "--enable-odbc",
-            "--enable-pam"
-          ]
+            "--enable-pam"]
+
+    inreplace "rebar.config", 'lager", {tag, "3.2.1', 'lager", {tag, "3.2.4'
 
     system "autoupdate"
     system "./autogen.sh"
     system "./configure", *args
-
-    # rebar tries to clone goldrush using a git://github.com/ url which is no longer offered by github.
-    # Work around by cloning it into the expected place using https.
-    system "git", "clone", "--branch", "0.1.8", "https://github.com/DeadZen/goldrush.git", "deps/goldrush"
 
     # Before Snow Leopard, the pam header files were in /usr/include/pam instead of /usr/include/security.
     # https://trac.macports.org/ticket/26127


### PR DESCRIPTION
Updating ejabberd to 16.12. Version 16 is the first version I was able to build on Leopard/PPC, and 16.12 is the highest minor version of ejabberd 16.

Also switch to using openssl3.

Build successfully tested on Leopard/PPC, and sure enough I can connect Adium clients to the server. I would love help testing on Snow Leopard if anyone is able to, as the pam_appl.h workaround I needed to add is apparently not needed on SL, but I don't currently have a way to test that.