### PR TITLE
ejabberd: add resource for pam dependency

### DIFF
--- a/Library/Formula/ejabberd.rb
+++ b/Library/Formula/ejabberd.rb
@@ -17,6 +17,11 @@ class Ejabberd < Formula
   # for CAPTCHA challenges
   depends_on "imagemagick" => :optional
 
+  resource "p1_pam" do
+    url "https://github.com/processone/epam/archive/refs/tags/1.0.0.zip"
+    sha256 "6704010b14034881d8c60f52d1a82d8125f20cdf1e52a7113c838f1db6be7e81"
+  end
+
   def install
     ENV["TARGET_DIR"] = ENV["DESTDIR"] = "#{lib}/ejabberd/erlang/lib/ejabberd-#{version}"
     ENV["MAN_DIR"] = man
@@ -43,7 +48,9 @@ class Ejabberd < Formula
     # Before Snow Leopard, the pam header files were in /usr/include/pam instead of /usr/include/security.
     # https://trac.macports.org/ticket/26127
     if MacOS.version <= :leopard
-      system "git", "clone", "--branch", "1.0.0", "https://github.com/processone/epam", "deps/p1_pam"
+      mkdir_p("deps/p1_pam")
+      resource("p1_pam").verify_download_integrity(resource("p1_pam").fetch)
+      resource("p1_pam").unpack("#{buildpath}/deps/p1_pam")
       inreplace "deps/p1_pam/configure", "security/pam_appl.h", "pam/pam_appl.h"
       inreplace "deps/p1_pam/configure.ac", "security/pam_appl.h", "pam/pam_appl.h"
       inreplace "deps/p1_pam/c_src/epam.c", "security/pam_appl.h", "pam/pam_appl.h"


### PR DESCRIPTION
Small refactor, based on discussion in https://github.com/mistydemeo/tigerbrew/pull/1352#issuecomment-2832603798. Use a resource to manage downloading the erlang PAM dependency in a more canonical way. 

Built successfully on Leopard/PPC.