### PR TITLE
libidn2 2.3.8

### DIFF
--- a/Library/Formula/libidn2.rb
+++ b/Library/Formula/libidn2.rb
@@ -7,6 +7,17 @@ class Libidn2 < Formula
   sha256 "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
   license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
 
+  head do
+    url "https://gitlab.com/libidn/libidn2.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gengetopt" => :build
+    depends_on "gettext" => :build
+    depends_on "help2man" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkg-config" => :build
   depends_on "libunistring"
   depends_on "gettext"

--- a/Library/Formula/libidn2.rb
+++ b/Library/Formula/libidn2.rb
@@ -1,27 +1,11 @@
 class Libidn2 < Formula
   desc "International domain name library (IDNA2008, Punycode and TR46)"
   homepage "https://www.gnu.org/software/libidn/#libidn2"
-  url "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.7.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.7.tar.gz"
-  mirror "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.7.tar.gz"
-  sha256 "4c21a791b610b9519b9d0e12b8097bf2f359b12f8dd92647611a929e6bfd7d64"
+  url "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+  mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.8.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+  sha256 "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
   license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
-
-  bottle do
-    sha256 "eefd238f08db025045214510e64a3a0c9d075cf8cb0d3aef1ae72ad29e591d61" => :tiger_altivec
-  end
-
-  head do
-    url "https://gitlab.com/libidn/libidn2.git", branch: "master"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gengetopt" => :build
-    depends_on "gettext" => :build
-    depends_on "help2man" => :build
-    depends_on "libtool" => :build
-    depends_on "ronn" => :build
-  end
 
   depends_on "pkg-config" => :build
   depends_on "libunistring"


### PR DESCRIPTION
Update libidn2 from 2.3.7 to 2.3.8, latest available version. Remove now-out-of-date bottle hash. Also remove HEAD option, which adds a dependency on a nonexistent package called 'ronn'.

Test build succeeded on Tiger/PowerPC, Leopard/PowerPC, Leopard/Intel, and Snow Leopard/Intel.