### PR TITLE
python: remove sphinx-doc option

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -15,13 +15,6 @@ class Python < Formula
   option :universal
   option "with-tcl-tk", "Use Tigerbrew's Tk instead of OS X Tk (has optional Cocoa and threads support)"
 
-  # sphinx-doc depends on python, but on 10.6 or earlier python is fulfilled by
-  # brew, which would lead to circular dependency.
-  if MacOS.version > :snow_leopard
-    option "with-sphinx-doc", "Build HTML documentation"
-    depends_on "sphinx-doc" => [:build, :optional]
-  end
-
   deprecated_option "quicktest" => "with-quicktest"
   deprecated_option "with-brewed-tk" => "with-tcl-tk"
 
@@ -201,12 +194,6 @@ class Python < Formula
     (libexec/"pip").install resource("pip")
     (libexec/"wheel").install resource("wheel")
 
-    if MacOS.version > :snow_leopard && build.with?("sphinx-doc")
-      cd "Doc" do
-        system "make", "html"
-        doc.install Dir["build/html/*"]
-      end
-    end
   end
 
   def post_install


### PR DESCRIPTION
The sphinx-doc option for python adds a dependency to a nonexistent package, 'sphinx-doc'. Remove.

Test build succeeded on Tiger/PowerPC, Leopard/PowerPC, Leopard/Intel, and Snow Leopard/Intel.