### PR TITLE
ld64 add apple-gcc42 build dependency

### DIFF
--- a/Library/Formula/ld64.rb
+++ b/Library/Formula/ld64.rb
@@ -26,7 +26,7 @@ class Ld64 < Formula
   depends_on "cctools-headers" => :build
   depends_on "dyld-headers" => :build
   depends_on "libunwind-headers" => :build
-  depends_on "apple-gcc42" => :build if MacOS.version == :tiger && Hardware::CPU.type == :intel
+  depends_on "apple-gcc42" => :build if MacOS.version == :tiger 
 
   keg_only :provided_by_osx,
     "ld64 is an updated version of the ld shipped by Apple."

--- a/Library/Formula/ld64.rb
+++ b/Library/Formula/ld64.rb
@@ -26,6 +26,7 @@ class Ld64 < Formula
   depends_on "cctools-headers" => :build
   depends_on "dyld-headers" => :build
   depends_on "libunwind-headers" => :build
+  depends_on "apple-gcc42" => :build if MacOS.version > :tiger && Hardware::CPU.type == :intel
 
   keg_only :provided_by_osx,
     "ld64 is an updated version of the ld shipped by Apple."

--- a/Library/Formula/ld64.rb
+++ b/Library/Formula/ld64.rb
@@ -26,7 +26,7 @@ class Ld64 < Formula
   depends_on "cctools-headers" => :build
   depends_on "dyld-headers" => :build
   depends_on "libunwind-headers" => :build
-  depends_on "apple-gcc42" => :build if MacOS.version > :tiger && Hardware::CPU.type == :intel
+  depends_on "apple-gcc42" => :build if MacOS.version == :tiger && Hardware::CPU.type == :intel
 
   keg_only :provided_by_osx,
     "ld64 is an updated version of the ld shipped by Apple."


### PR DESCRIPTION
When building `ld64` on Tiger Intel, a `CompilerSelectionError` is raised, which shows the user this error message:
```
To install this formula, you may need to either:
   brew install apple-gcc42
or:
   brew install gcc
```

Only `apple-gcc42` is a valid compiler to choose for `ld64`: `gcc` is version 8.5.0 and `ld64` is itself one of `gcc`'s dependencies. Adding a build dependency for `apple-gcc42` for Tiger Intel builds. 

Tested on Tiger Intel.