### PR TITLE
fix outdated homepage urls

### DIFF
--- a/Library/Formula/a52dec.rb
+++ b/Library/Formula/a52dec.rb
@@ -1,6 +1,6 @@
 class A52dec < Formula
   desc "Library for decoding ATSC A/52 streams (AKA 'AC-3')"
-  homepage "http://liba52.sourceforge.net/"
+  homepage "https://liba52.sourceforge.io/"
   url "https://web.archive.org/web/20170110045630if_/http://liba52.sourceforge.net/files/a52dec-0.7.4.tar.gz"
   sha256 "a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33"
 

--- a/Library/Formula/aacgain.rb
+++ b/Library/Formula/aacgain.rb
@@ -1,6 +1,6 @@
 class Aacgain < Formula
   desc "AAC-supporting version of mp3gain"
-  homepage "http://aacgain.altosdesign.com/"
+  homepage "https://web.archive.org/web/20210828213043/http://aacgain.altosdesign.com/"
   # This server will autocorrect a 1.9 url back to this 1.8 tarball.
   # The 1.9 version mentioned on the website is pre-release, so make
   # sure 1.9 is actually out before updating.

--- a/Library/Formula/aalib.rb
+++ b/Library/Formula/aalib.rb
@@ -1,6 +1,6 @@
 class Aalib < Formula
   desc "Portable ASCII art graphics library"
-  homepage "http://aa-project.sourceforge.net/aalib/"
+  homepage "https://aa-project.sourceforge.net/aalib/"
   url "https://downloads.sourceforge.net/aa-project/aalib-1.4rc5.tar.gz"
   sha256 "fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee"
 

--- a/Library/Formula/abcde.rb
+++ b/Library/Formula/abcde.rb
@@ -1,6 +1,6 @@
 class Abcde < Formula
   desc "Better CD Encoder"
-  homepage "http://abcde.einval.com"
+  homepage "https://abcde.einval.com"
   url "http://abcde.einval.com/download/abcde-2.7.tar.gz"
   mirror "https://mirrors.kernel.org/debian/pool/main/a/abcde/abcde_2.7.orig.tar.gz"
   sha256 "0148698a09fedcbae37ee9da295afe411a1190cf8ae224b7814d31b5bf737746"

--- a/Library/Formula/abcl.rb
+++ b/Library/Formula/abcl.rb
@@ -1,6 +1,6 @@
 class Abcl < Formula
   desc "Armed Bear Common Lisp: a full implementation of Common Lisp"
-  homepage "http://abcl.org"
+  homepage "https://abcl.org"
   url "http://abcl.org/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
   sha256 "01105fe25c51873b71ffd6f0ba2d9b2688741ed96ff60c1950c0e62f9d84a785"
 

--- a/Library/Formula/abcmidi.rb
+++ b/Library/Formula/abcmidi.rb
@@ -1,6 +1,6 @@
 class Abcmidi < Formula
   desc "Converts abc music notation files to MIDI files"
-  homepage "http://www.ifdo.ca/~seymour/runabc/top.html"
+  homepage "https://ifdo.ca/~seymour/runabc/top.html"
   url "http://ifdo.ca/~seymour/runabc/abcMIDI-2015-08-06.zip"
   version "2015-08-06"
   sha256 "6ada64028344b5d778714bca02e41ed98a97c656aa45ea0e4a21de926502304e"

--- a/Library/Formula/abduco.rb
+++ b/Library/Formula/abduco.rb
@@ -1,6 +1,6 @@
 class Abduco < Formula
   desc "Provides session management: i.e. separate programs from terminals"
-  homepage "http://www.brain-dump.org/projects/abduco"
+  homepage "https://www.brain-dump.org/projects/abduco/"
   url "http://www.brain-dump.org/projects/abduco/abduco-0.4.tar.gz"
   sha256 "bda3729df116ce41f9a087188d71d934da2693ffb1ebcf33b803055eb478bcbb"
   head "git://repo.or.cz/abduco.git"

--- a/Library/Formula/abi-compliance-checker.rb
+++ b/Library/Formula/abi-compliance-checker.rb
@@ -1,6 +1,6 @@
 class AbiComplianceChecker < Formula
   desc "Check binary and source compatibility for C/C++"
-  homepage "http://ispras.linuxbase.org/index.php/ABI_compliance_checker"
+  homepage "https://ispras.linuxbase.org/index.php/ABI_compliance_checker"
   url "https://github.com/lvc/abi-compliance-checker/archive/1.99.9.tar.gz"
   sha256 "52b0daca89fcda73cde126497c8015ca823417074ba02fcff68b7acf2f45e516"
 

--- a/Library/Formula/abnfgen.rb
+++ b/Library/Formula/abnfgen.rb
@@ -1,6 +1,6 @@
 class Abnfgen < Formula
   desc "Quickly generate random documents that match an ABFN grammar"
-  homepage "http://www.quut.com/abnfgen/"
+  homepage "https://www.quut.com/abnfgen/"
   url "http://www.quut.com/abnfgen/abnfgen-0.16.tar.gz"
   sha256 "c256712a97415c86e1aa1847e2eac00019ca724d56b8ee921d21b258090d333a"
 

--- a/Library/Formula/abook.rb
+++ b/Library/Formula/abook.rb
@@ -1,6 +1,6 @@
 class Abook < Formula
   desc "Address book with mutt support"
-  homepage "http://abook.sourceforge.net/"
+  homepage "https://abook.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/abook/abook/0.5.6/abook-0.5.6.tar.gz"
   sha256 "0646f6311a94ad3341812a4de12a5a940a7a44d5cb6e9da5b0930aae9f44756e"
   revision 1

--- a/Library/Formula/ace.rb
+++ b/Library/Formula/ace.rb
@@ -1,6 +1,6 @@
 class Ace < Formula
   desc "ADAPTIVE Communication Environment: OO network programming in C++"
-  homepage "http://www.dre.vanderbilt.edu/~schmidt/ACE.html"
+  homepage "https://www.dre.vanderbilt.edu/~schmidt/ACE.html"
   url "http://download.dre.vanderbilt.edu/previous_versions/ACE-6.3.3.tar.bz2"
   sha256 "f362e45f624db3343db529654b601d5df69b5f56fa4597cf453da35d80989888"
 

--- a/Library/Formula/activemq-cpp.rb
+++ b/Library/Formula/activemq-cpp.rb
@@ -1,6 +1,6 @@
 class ActivemqCpp < Formula
   desc "C++ API for message brokers such as Apache ActiveMQ"
-  homepage "https://activemq.apache.org/cms/index.html"
+  homepage "https://activemq.apache.org/components/cms/"
   url "https://www.apache.org/dyn/closer.cgi?path=activemq/activemq-cpp/3.8.4/activemq-cpp-library-3.8.4-src.tar.bz2"
   sha256 "9fba18d57f7512ae4f17008d7745d1b4c957b858b585860deadbf9208cb733e3"
 

--- a/Library/Formula/adns.rb
+++ b/Library/Formula/adns.rb
@@ -1,6 +1,6 @@
 class Adns < Formula
   desc "C/C++ resolver library and DNS resolver utilities"
-  homepage "http://www.chiark.greenend.org.uk/~ian/adns/"
+  homepage "https://www.chiark.greenend.org.uk/~ian/adns/"
   url "http://www.chiark.greenend.org.uk/~ian/adns/ftp/adns-1.5.0.tar.gz"
   sha256 "7fc5eb4d315111a3a3a3f45ff143339ad4050185fbe6bff687f21364cb4ae841"
   head "git://git.chiark.greenend.org.uk/~ianmdlvl/adns.git"

--- a/Library/Formula/adplug.rb
+++ b/Library/Formula/adplug.rb
@@ -1,6 +1,6 @@
 class Adplug < Formula
   desc "Free, hardware independent AdLib sound player library"
-  homepage "http://adplug.sf.net"
+  homepage "https://adplug.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/adplug/AdPlug%20core%20library/2.2.1/adplug-2.2.1.tar.bz2"
   sha256 "f95a015268a0dfe9ff5782f3ea7b2a69e09b8d36ccd19ebf4d979d767b6e53ef"
 

--- a/Library/Formula/advancecomp.rb
+++ b/Library/Formula/advancecomp.rb
@@ -1,6 +1,6 @@
 class Advancecomp < Formula
   desc "Recompression utilities for .PNG, .MNG, .ZIP, and .GZ files"
-  homepage "http://www.advancemame.it/comp-readme.html"
+  homepage "https://www.advancemame.it/comp-readme.html"
   url "https://github.com/amadvance/advancecomp/releases/download/v1.20/advancecomp-1.20.tar.gz"
   sha256 "590a447cfc7ab3a37ec707e13967a0046a81a888c561ebaff5415b1e946da67b"
 

--- a/Library/Formula/aescrypt.rb
+++ b/Library/Formula/aescrypt.rb
@@ -1,6 +1,6 @@
 class Aescrypt < Formula
   desc "Program for encryption/decryption"
-  homepage "http://aescrypt.sourceforge.net/"
+  homepage "https://aescrypt.sourceforge.net/"
   url "http://aescrypt.sourceforge.net/aescrypt-0.7.tar.gz"
   sha256 "7b17656cbbd76700d313a1c36824a197dfb776cadcbf3a748da5ee3d0791b92d"
 

--- a/Library/Formula/aeskeyfind.rb
+++ b/Library/Formula/aeskeyfind.rb
@@ -1,6 +1,6 @@
 class Aeskeyfind < Formula
   desc "Program for automatic key-finding"
-  homepage "https://citp.princeton.edu/research/memory/code/"
+  homepage "https://web.archive.org/web/20190512072829/https://citp.princeton.edu/research/memory/code/"
   url "https://citp.princeton.edu/memory-content/src/aeskeyfind-1.0.tar.gz"
   sha256 "1417e5c1b61e86bb9527db1f5bee1995a0eea82475db3cbc880e04bf706083e4"
 

--- a/Library/Formula/aespipe.rb
+++ b/Library/Formula/aespipe.rb
@@ -1,6 +1,6 @@
 class Aespipe < Formula
   desc "AES encryption or decryption for pipes"
-  homepage "http://loop-aes.sourceforge.net/"
+  homepage "https://loop-aes.sourceforge.net/"
   url "http://loop-aes.sourceforge.net/aespipe/aespipe-v2.4c.tar.bz2"
   sha256 "260190beea911190a839e711f610ec3454a9b13985d35479775b7e26ad4c845e"
 

--- a/Library/Formula/afio.rb
+++ b/Library/Formula/afio.rb
@@ -1,6 +1,6 @@
 class Afio < Formula
   desc "Creates cpio-format archives"
-  homepage "http://members.chello.nl/~k.holtman/afio.html"
+  homepage "https://web.archive.org/web/20190927012245/http://members.chello.nl/~k.holtman/afio.html"
   url "http://members.chello.nl/~k.holtman/afio-2.5.1.tgz"
   sha256 "363457a5d6ee422d9b704ef56d26369ca5ee671d7209cfe799cab6e30bf2b99a"
 

--- a/Library/Formula/afl-fuzz.rb
+++ b/Library/Formula/afl-fuzz.rb
@@ -1,6 +1,6 @@
 class AflFuzz < Formula
   desc "American fuzzy lop: Security-oriented fuzzer"
-  homepage "http://lcamtuf.coredump.cx/afl/"
+  homepage "https://lcamtuf.coredump.cx/afl/"
   url "http://lcamtuf.coredump.cx/afl/releases/afl-1.88b.tgz"
   sha256 "3bd4e2fef8e4528795ecefae21fad59ab04ee7c862c16e19753593fc27594082"
   head "http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz"

--- a/Library/Formula/afsctool.rb
+++ b/Library/Formula/afsctool.rb
@@ -1,6 +1,6 @@
 class Afsctool < Formula
   desc "Utility for manipulating HFS+ compressed files"
-  homepage "http://brkirch.wordpress.com/afsctool/"
+  homepage "https://brkirch.wordpress.com/afsctool/"
   url "https://docs.google.com/uc?export=download&id=0BwQlnXqL939ZQjBQNEhRQUo0aUk"
   version "1.6.4"
   sha256 "bb6a84370526af6ec1cee2c1a7199134806e691d1093f4aef060df080cd3866d"

--- a/Library/Formula/aften.rb
+++ b/Library/Formula/aften.rb
@@ -1,6 +1,6 @@
 class Aften < Formula
   desc "Audio encoder which generates ATSC A/52 compressed audio streams"
-  homepage "http://aften.sourceforge.net/"
+  homepage "https://aften.sourceforge.net/"
   url "https://downloads.sourceforge.net/aften/aften-0.0.8.tar.bz2"
   sha256 "87cc847233bb92fbd5bed49e2cdd6932bb58504aeaefbfd20ecfbeb9532f0c0a"
 

--- a/Library/Formula/agda.rb
+++ b/Library/Formula/agda.rb
@@ -4,7 +4,7 @@ class Agda < Formula
   include Language::Haskell::Cabal
 
   desc "Dependently typed functional programming language"
-  homepage "http://wiki.portal.chalmers.se/agda/"
+  homepage "https://wiki.portal.chalmers.se/agda/"
   url "https://hackage.haskell.org/package/Agda-2.4.2.3/Agda-2.4.2.3.tar.gz"
   mirror "https://github.com/agda/agda/archive/2.4.2.3.tar.gz"
   sha256 "bc6def45e32498f51863d67acfbe048c039d630c6a36761ed27e99a5f68d7b27"

--- a/Library/Formula/aget.rb
+++ b/Library/Formula/aget.rb
@@ -1,6 +1,6 @@
 class Aget < Formula
   desc "Multithreaded HTTP download accelerator"
-  homepage "http://www.enderunix.org/aget/"
+  homepage "https://github.com/EnderUNIX/Aget"
   url "http://www.enderunix.org/aget/aget-0.4.1.tar.gz"
   sha256 "d17393c7f44aab38028ae71f14b572ba1839b6e085fb2092b6ebe68bc931df4d"
   head "https://github.com/EnderUNIX/Aget.git"

--- a/Library/Formula/ahcpd.rb
+++ b/Library/Formula/ahcpd.rb
@@ -1,6 +1,6 @@
 class Ahcpd < Formula
   desc "Autoconfiguration protocol for IPv6 and IPv6/IPv4 networks"
-  homepage "http://www.pps.univ-paris-diderot.fr/~jch/software/ahcp/"
+  homepage "https://www.irif.fr/~jch/software/ahcp/"
   url "http://www.pps.univ-paris-diderot.fr/~jch/software/files/ahcpd-0.53.tar.gz"
   sha256 "a4622e817d2b2a9b878653f085585bd57f3838cc546cca6028d3b73ffcac0d52"
 

--- a/Library/Formula/aide.rb
+++ b/Library/Formula/aide.rb
@@ -1,6 +1,6 @@
 class Aide < Formula
   desc "File and directory integrity checker"
-  homepage "http://aide.sourceforge.net"
+  homepage "https://aide.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/aide/aide/0.15.1/aide-0.15.1.tar.gz"
   sha256 "303e5c186257df8c86e418193199f4ea2183fc37d3d4a9098a614f61346059ef"
 

--- a/Library/Formula/aircrack-ng.rb
+++ b/Library/Formula/aircrack-ng.rb
@@ -1,6 +1,6 @@
 class AircrackNg < Formula
   desc "Next-generation aircrack with lots of new features"
-  homepage "http://aircrack-ng.org/"
+  homepage "https://aircrack-ng.org/"
   # We can't update this due to linux-only dependencies in >1.1.
   # See https://github.com/Homebrew/homebrew/issues/29450
   url "http://download.aircrack-ng.org/aircrack-ng-1.1.tar.gz"

--- a/Library/Formula/akka.rb
+++ b/Library/Formula/akka.rb
@@ -1,6 +1,6 @@
 class Akka < Formula
   desc "Toolkit for building concurrent, distributed, and fault tolerant apps"
-  homepage "http://akka.io/"
+  homepage "https://akka.io/"
 
   stable do
     url "https://downloads.typesafe.com/akka/akka_2.11-2.3.11.zip"

--- a/Library/Formula/aldo.rb
+++ b/Library/Formula/aldo.rb
@@ -1,6 +1,6 @@
 class Aldo < Formula
   desc "Morse code learning tool released under GPL"
-  homepage "http://www.nongnu.org/aldo/"
+  homepage "https://www.nongnu.org/aldo/"
   url "http://savannah.nongnu.org/download/aldo/aldo-0.7.7.tar.bz2"
   sha256 "f1b8849d09267fff3c1f5122097d90fec261291f51b1e075f37fad8f1b7d9f92"
 

--- a/Library/Formula/algernon.rb
+++ b/Library/Formula/algernon.rb
@@ -2,7 +2,7 @@ require "language/go"
 
 class Algernon < Formula
   desc "HTTP/2 web server with Lua support"
-  homepage "http://algernon.roboticoverlords.org/"
+  homepage "https://algernon.roboticoverlords.org/"
   url "https://github.com/xyproto/algernon/archive/0.85.tar.gz"
   sha256 "c30380d9781166a6cc6297210e70c742c5a6c91bbbbdbf223783db1ffa1aa7e6"
   head "https://github.com/xyproto/algernon.git"

--- a/Library/Formula/algol68g.rb
+++ b/Library/Formula/algol68g.rb
@@ -1,6 +1,6 @@
 class Algol68g < Formula
   desc "Algol 68 compiler-interpreter"
-  homepage "https://www.xs4all.nl/~jmvdveer/algol.html"
+  homepage "https://jmvdveer.home.xs4all.nl/en.algol-68-genie.html"
   url "http://jmvdveer.home.xs4all.nl/algol68/algol68g-2.8.1.tar.gz"
   sha256 "bd499f90576a8d86008316f55e026e08abe2c9bda930e7a00cd0bec5b2b2dc44"
 

--- a/Library/Formula/align.rb
+++ b/Library/Formula/align.rb
@@ -1,6 +1,6 @@
 class Align < Formula
   desc "Text column alignment filter"
-  homepage "http://www.cs.indiana.edu/~kinzler/align/"
+  homepage "https://kinzler.com/me/align/"
   url "http://www.cs.indiana.edu/~kinzler/align/align-1.7.4.tgz"
   sha256 "4775cc92bd7d5d991b32ff360ab74cfdede06c211def2227d092a5a0108c1f03"
 

--- a/Library/Formula/allegro.rb
+++ b/Library/Formula/allegro.rb
@@ -1,6 +1,6 @@
 class Allegro < Formula
   desc "C/C++ multimedia library for cross-platform game development"
-  homepage "http://liballeg.org/"
+  homepage "https://liballeg.org/"
 
   stable do
     url "https://downloads.sourceforge.net/project/alleg/allegro/5.0.11/allegro-5.0.11.tar.gz"

--- a/Library/Formula/alpine.rb
+++ b/Library/Formula/alpine.rb
@@ -1,6 +1,6 @@
 class Alpine < Formula
   desc "News and email agent"
-  homepage "http://alpine.freeiz.com/alpine/"
+  homepage "https://web.archive.org/web/20171105110624/http://alpine.freeiz.com/alpine/"
   url "http://alpine.freeiz.com/alpine/release/src/alpine-2.20.tar.xz"
   sha256 "ed639b6e5bb97e6b0645c85262ca6a784316195d461ce8d8411999bf80449227"
 

--- a/Library/Formula/alure.rb
+++ b/Library/Formula/alure.rb
@@ -1,6 +1,6 @@
 class Alure < Formula
   desc "Manage common tasks with OpenAL applications"
-  homepage "http://kcat.strangesoft.net/alure.html"
+  homepage "https://web.archive.org/web/20200927044901/http://kcat.strangesoft.net/alure.html"
   url "http://kcat.strangesoft.net/alure-releases/alure-1.2.tar.bz2"
   sha256 "465e6adae68927be3a023903764662d64404e40c4c152d160e3a8838b1d70f71"
 

--- a/Library/Formula/amap.rb
+++ b/Library/Formula/amap.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class Amap < Formula
   desc "Perform application protocol detection"
-  homepage "https://www.thc.org/thc-amap/"
+  homepage "https://web.archive.org/web/20171213010355/https://www.thc.org/thc-amap/"
   url "https://www.thc.org/releases/amap-5.4.tar.gz"
   sha1 "79056f29a3b9e0a21062116aec3e966b1a46d7d3"
   revision 1

--- a/Library/Formula/amtterm.rb
+++ b/Library/Formula/amtterm.rb
@@ -1,6 +1,6 @@
 class Amtterm < Formula
   desc "Serial-over-LAN (sol) client for Intel AMT"
-  homepage "https://www.kraxel.org/blog/linux/amtterm/"
+  homepage "https://web.archive.org/web/20250514145908/https://www.kraxel.org/blog/linux/amtterm/"
   url "https://www.kraxel.org/releases/amtterm/amtterm-1.4.tar.gz"
   sha256 "e10af2b02dbf66fb24abd292b9ddc6d86b31eea09887da5cb0eb8fb2ee900e21"
 

--- a/Library/Formula/analog.rb
+++ b/Library/Formula/analog.rb
@@ -1,8 +1,6 @@
 class Analog < Formula
   desc "Logfile analyzer"
-  homepage "https://tracker.debian.org/pkg/analog"
-  # The previous long-time homepage and url are stone-cold dead. Using Debian instead.
-  # homepage "http://analog.cx"
+  homepage "https://web.archive.org/web/20130805071936/http://analog.cx/"
   url "https://mirrors.kernel.org/debian/pool/main/a/analog/analog_6.0.orig.tar.gz"
   sha256 "31c0e2bedd0968f9d4657db233b20427d8c497be98194daf19d6f859d7f6fcca"
   revision 2

--- a/Library/Formula/android-ndk.rb
+++ b/Library/Formula/android-ndk.rb
@@ -1,6 +1,6 @@
 class AndroidNdk < Formula
   desc "Android native-code language toolset"
-  homepage "https://developer.android.com/sdk/ndk/index.html"
+  homepage "https://developer.android.com/ndk"
   url "https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin"
   sha256 "728c309e606f63101f1258c9d3d579b80ac74fe74c511ebb71f460ce5c5d084e"
 

--- a/Library/Formula/android-platform-tools.rb
+++ b/Library/Formula/android-platform-tools.rb
@@ -1,6 +1,6 @@
 class AndroidPlatformTools < Formula
   desc "Tools for the Android SDK"
-  homepage "https://developer.android.com/sdk"
+  homepage "https://developer.android.com/studio"
   # the url is from:
   # https://dl.google.com/android/repository/repository-10.xml
   url "https://dl.google.com/android/repository/platform-tools_r23-macosx.zip"

--- a/Library/Formula/anjuta.rb
+++ b/Library/Formula/anjuta.rb
@@ -1,6 +1,6 @@
 class Anjuta < Formula
   desc "GNOME Integrated Development Environment"
-  homepage "http://anjuta.org"
+  homepage "https://wiki.gnome.org/Apps(2f)Anjuta.html"
   url "https://download.gnome.org/sources/anjuta/3.18/anjuta-3.18.0.tar.xz"
   sha256 "6a3fec0963f04bc62a9dfb951e577a3276d39c3414083ef73163c3fea8e741ba"
 

--- a/Library/Formula/ansible.rb
+++ b/Library/Formula/ansible.rb
@@ -1,6 +1,6 @@
 class Ansible < Formula
   desc "Automate deployment, configuration, and upgrading"
-  homepage "http://www.ansible.com/home"
+  homepage "https://www.redhat.com/en/ansible-collaborative?intcmp=7015Y000003t7aWQAQ"
   url "http://releases.ansible.com/ansible/ansible-1.9.3.tar.gz"
   sha256 "2594f642fd800056a427c1026410dc6ed8dfa7c0033f5c3d187abdb2b0d4eeed"
 

--- a/Library/Formula/ansifilter.rb
+++ b/Library/Formula/ansifilter.rb
@@ -1,6 +1,6 @@
 class Ansifilter < Formula
   desc "Strip or convert ANSI codes into HTML, (La)Tex, RTF, or BBCode"
-  homepage "http://www.andre-simon.de/doku/ansifilter/ansifilter.html"
+  homepage "http://andre-simon.de/doku/ansifilter/en/ansifilter.php"
   url "http://www.andre-simon.de/zip/ansifilter-1.12.tar.bz2"
   sha256 "05f64cbc8440b44e8cfe26ae679074531997d14ecbbf595a9e03c0b489bf1cd1"
 

--- a/Library/Formula/ant-contrib.rb
+++ b/Library/Formula/ant-contrib.rb
@@ -1,6 +1,6 @@
 class AntContrib < Formula
   desc "Collection of tasks for Apache Ant"
-  homepage "http://ant-contrib.sourceforge.net/"
+  homepage "https://ant-contrib.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz"
   sha256 "6e58c2ee65e1f4df031796d512427ea213a92ae40c5fc0b38d8ac82701f42a3c"
   version "1.0b3"

--- a/Library/Formula/antigen.rb
+++ b/Library/Formula/antigen.rb
@@ -1,6 +1,6 @@
 class Antigen < Formula
   desc "Plugin manager for zsh, inspired by oh-my-zsh and vundle."
-  homepage "http://antigen.sharats.me/"
+  homepage "https://web.archive.org/web/20250513051241/https://antigen.sharats.me/"
   url "https://github.com/zsh-users/antigen/archive/v1.tar.gz"
   sha256 "6d4bd7b5d7bc3e36a23ac8feb93073b06e1e09b9100eb898f66c2e8c3f4d7847"
   head "https://github.com/zsh-users/antigen.git"

--- a/Library/Formula/antiword.rb
+++ b/Library/Formula/antiword.rb
@@ -1,6 +1,6 @@
 class Antiword < Formula
   desc "Utility to read Word (.doc) files"
-  homepage "http://www.winfield.demon.nl/"
+  homepage "https://web.archive.org/web/20221207132720/http://www.winfield.demon.nl/"
   url "http://www.winfield.demon.nl/linux/antiword-0.37.tar.gz"
   sha256 "8e2c000fcbc6d641b0e6ff95e13c846da3ff31097801e86702124a206888f5ac"
 

--- a/Library/Formula/antlr.rb
+++ b/Library/Formula/antlr.rb
@@ -1,6 +1,6 @@
 class Antlr < Formula
   desc "ANTLR: ANother Tool for Language Recognition"
-  homepage "http://www.antlr.org/"
+  homepage "https://www.antlr.org/"
   url "http://www.antlr.org/download/antlr-4.5.1-complete.jar"
   sha256 "9cff6c76bc5aafcbf51cac7f0974ae01e4f6119402e75436abbb97f8ab15c211"
 

--- a/Library/Formula/aoeui.rb
+++ b/Library/Formula/aoeui.rb
@@ -1,6 +1,6 @@
 class Aoeui < Formula
   desc "Lightweight text editor optimized for Dvorak and QWERTY keyboards"
-  homepage "http://aoeui.googlecode.com/"
+  homepage "https://code.google.com/archive/p/aoeui/"
   url "https://aoeui.googlecode.com/files/aoeui-1.6.tgz"
   sha256 "0655c3ca945b75b1204c5f25722ac0a07e89dd44bbf33aca068e918e9ef2a825"
   head "http://aoeui.googlecode.com/svn/trunk/"

--- a/Library/Formula/ape.rb
+++ b/Library/Formula/ape.rb
@@ -1,6 +1,6 @@
 class Ape < Formula
   desc "Ajax Push Engine"
-  homepage "http://www.ape-project.org/"
+  homepage "https://web.archive.org/web/20200810042306/http://www.ape-project.org/"
   url "https://github.com/APE-Project/APE_Server/archive/v1.1.2.tar.gz"
   sha256 "c5f6ec0740f20dd5eb26c223149fc4bade3daadff02a851e2abb7e00be97db42"
 

--- a/Library/Formula/apel.rb
+++ b/Library/Formula/apel.rb
@@ -1,6 +1,6 @@
 class Apel < Formula
   desc "Emacs Lisp library to help write portable Emacs programs"
-  homepage "http://git.chise.org/elisp/apel/"
+  homepage "https://web.archive.org/web/20241211193757/http://git.chise.org/elisp/apel/"
   url "http://git.chise.org/elisp/dist/apel/apel-10.8.tar.gz"
   sha256 "a511cc36bb51dc32b4915c9e03c67a994060b3156ceeab6fafa0be7874b9ccfe"
 

--- a/Library/Formula/apg.rb
+++ b/Library/Formula/apg.rb
@@ -1,6 +1,6 @@
 class Apg < Formula
   desc "Tool set for random password generation"
-  homepage "http://www.adel.nursat.kz/apg/"
+  homepage "https://web.archive.org/web/20130313042424/http://www.adel.nursat.kz/apg/"
   url "http://www.adel.nursat.kz/apg/download/apg-2.2.3.tar.gz"
   sha256 "69c9facde63958ad0a7630055f34d753901733d55ee759d08845a4eda2ba7dba"
 

--- a/Library/Formula/apgdiff.rb
+++ b/Library/Formula/apgdiff.rb
@@ -1,6 +1,6 @@
 class Apgdiff < Formula
   desc "Another PostgreSQL diff tool"
-  homepage "http://www.apgdiff.com/"
+  homepage "https://www.apgdiff.com/"
   url "http://www.apgdiff.com/download/apgdiff-2.4-bin.zip"
   sha256 "12d95fbb0b8188d7f90e7aaf8bdd29d0eecac26e08d6323624b5b7e3f7c7a3f7"
 

--- a/Library/Formula/apollo.rb
+++ b/Library/Formula/apollo.rb
@@ -1,6 +1,6 @@
 class Apollo < Formula
   desc "Multi-protocol messaging broker based on ActiveMQ"
-  homepage "https://activemq.apache.org/apollo"
+  homepage "https://activemq.apache.org/"
   url "https://archive.apache.org/dist/activemq/activemq-apollo/1.7.1/apache-apollo-1.7.1-unix-distro.tar.gz"
   version "1.7.1"
   sha256 "74577339a1843995a5128d14c68b21fb8f229d80d8ce1341dd3134f250ab689d"

--- a/Library/Formula/app-engine-java.rb
+++ b/Library/Formula/app-engine-java.rb
@@ -1,6 +1,6 @@
 class AppEngineJava < Formula
   desc "Google App Engine for Java"
-  homepage "https://cloud.google.com/appengine/docs/java/gettingstarted/introduction"
+  homepage "https://web.archive.org/web/20160426152633/https://cloud.google.com/appengine/docs/java/gettingstarted/introduction"
   url "https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.23.zip"
   sha256 "05e667036e9ef4f999b829fc08f8e5395b33a5a3c30afa9919213088db2b2e89"
 

--- a/Library/Formula/apparix.rb
+++ b/Library/Formula/apparix.rb
@@ -1,6 +1,6 @@
 class Apparix < Formula
   desc "File system navigation via bookmarking directories"
-  homepage "http://micans.org/apparix/"
+  homepage "https://micans.org/apparix/"
   url "http://micans.org/apparix/src/apparix-11-062.tar.gz"
   version "11-062"
   sha256 "211bb5f67b32ba7c3e044a13e4e79eb998ca017538e9f4b06bc92d5953615235"

--- a/Library/Formula/apt-dater.rb
+++ b/Library/Formula/apt-dater.rb
@@ -1,6 +1,6 @@
 class AptDater < Formula
   desc "Manage package updates on remote hosts using SSH"
-  homepage "http://www.ibh.de/apt-dater/"
+  homepage "https://apt-dater.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/apt-dater/apt-dater/0.9.0/apt-dater-0.9.0.tar.gz"
   sha256 "10b8335c156dabae249aa071cf8689900fae325c2e9540e36a840a2a77d3eeb4"
 

--- a/Library/Formula/aqbanking.rb
+++ b/Library/Formula/aqbanking.rb
@@ -1,6 +1,6 @@
 class Aqbanking < Formula
   desc "Generic online banking interface"
-  homepage "http://www.aqbanking.de/"
+  homepage "https://www.aquamaniac.de/"
   head "http://devel.aqbanking.de/svn/aqbanking/trunk"
   url "http://www2.aquamaniac.de/sites/download/download.php?package=03&release=118&file=01&dummy=aqbanking-5.5.1.tar.gz"
   sha256 "238f17d27d86e0cef239479c4be152cb98f5be9d6b87fca38741d32e762faddf"

--- a/Library/Formula/arabica.rb
+++ b/Library/Formula/arabica.rb
@@ -1,6 +1,6 @@
 class Arabica < Formula
   desc "XML toolkit written in C++"
-  homepage "http://www.jezuk.co.uk/cgi-bin/view/arabica"
+  homepage "https://www.jezuk.co.uk/tags/arabica.html"
   url "https://downloads.sourceforge.net/project/arabica/arabica/November-12/arabica-2012-November.tar.gz"
   version "20121126"
   sha256 "2e64e38d773ff37f5d7da181fe07d6dde2c35e633b9772b604439a286cd4f98b"

--- a/Library/Formula/arangodb.rb
+++ b/Library/Formula/arangodb.rb
@@ -1,6 +1,6 @@
 class Arangodb < Formula
   desc "Universal open-source database with a flexible data model"
-  homepage "https://www.arangodb.com/"
+  homepage "https://arangodb.com/"
   url "https://www.arangodb.com/repositories/Source/ArangoDB-2.6.8.tar.gz"
   sha256 "5d6f7b5a8c94a3ccf645c03dea37f8d4c28bfd3f6ab1a418365bdc4e162630f1"
 

--- a/Library/Formula/argtable.rb
+++ b/Library/Formula/argtable.rb
@@ -1,6 +1,6 @@
 class Argtable < Formula
   desc "ANSI C library for parsing GNU-style command-line options"
-  homepage "http://argtable.sourceforge.net"
+  homepage "https://argtable.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/argtable/argtable/argtable-2.13/argtable2-13.tar.gz"
   version "2.13"
   sha256 "8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf"

--- a/Library/Formula/argus-clients.rb
+++ b/Library/Formula/argus-clients.rb
@@ -1,6 +1,6 @@
 class ArgusClients < Formula
   desc "Audit Record Generation and Utilization System clients"
-  homepage "http://qosient.com/argus/"
+  homepage "https://qosient.com/argus/"
   url "http://qosient.com/argus/src/argus-clients-3.0.8.tar.gz"
   sha256 "aee8585d50959e00070a382f3121edfaa844a0a51dc0b73edf84c0f4eb8912c9"
   revision 1

--- a/Library/Formula/argus.rb
+++ b/Library/Formula/argus.rb
@@ -1,6 +1,6 @@
 class Argus < Formula
   desc "Audit Record Generation and Utilization System server"
-  homepage "http://qosient.com/argus/"
+  homepage "https://qosient.com/argus/"
   url "http://qosient.com/argus/src/argus-3.0.8.1.tar.gz"
   sha256 "1fb921104c8bd843fb9f5a1c32b57b20bfe8cd8a103b3f1d9bb686b9e6c490a4"
 

--- a/Library/Formula/argyll-cms.rb
+++ b/Library/Formula/argyll-cms.rb
@@ -1,6 +1,6 @@
 class ArgyllCms < Formula
   desc "ICC compatible color management system"
-  homepage "http://www.argyllcms.com/"
+  homepage "https://www.argyllcms.com/"
   url "http://www.argyllcms.com/Argyll_V1.8.2_src.zip"
   version "1.8.2"
   sha256 "59bdfaeace35d2007c90fc53234ba33bf8a64cffc08f7b27a297fc5f85455377"

--- a/Library/Formula/aria2.rb
+++ b/Library/Formula/aria2.rb
@@ -1,6 +1,6 @@
 class Aria2 < Formula
   desc "Download with resuming and segmented downloading"
-  homepage "http://aria2.sourceforge.net/"
+  homepage "https://aria2.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/aria2/stable/aria2-1.19.0/aria2-1.19.0.tar.bz2"
   mirror "https://mirrors.kernel.org/debian/pool/main/a/aria2/aria2_1.19.0.orig.tar.bz2"
   sha256 "ae2b6fce7a0974c9156415cccf2395cd258580ab34eec2b34a8e76120b7240ce"

--- a/Library/Formula/arp-scan.rb
+++ b/Library/Formula/arp-scan.rb
@@ -1,6 +1,6 @@
 class ArpScan < Formula
   desc "ARP scanning and fingerprinting tool"
-  homepage "http://www.nta-monitor.com/tools-resources/security-tools/arp-scan"
+  homepage "https://github.com/royhills/arp-scan"
   url "http://www.nta-monitor.com/files/arp-scan/arp-scan-1.9.tar.gz"
   mirror "https://github.com/royhills/arp-scan/releases/download/1.9/arp-scan-1.9.tar.gz"
   sha256 "ce908ac71c48e85dddf6dd4fe5151d13c7528b1f49717a98b2a2535bd797d892"

--- a/Library/Formula/arp-sk.rb
+++ b/Library/Formula/arp-sk.rb
@@ -1,6 +1,6 @@
 class ArpSk < Formula
   desc "ARP traffic generation tool"
-  homepage "http://sid.rstack.org/arp-sk/"
+  homepage "https://web.archive.org/web/20200510204332/http://sid.rstack.org/arp-sk/"
   url "http://sid.rstack.org/arp-sk/files/arp-sk-0.0.16.tgz"
   sha256 "6e1c98ff5396dd2d1c95a0d8f08f85e51cf05b1ed85ea7b5bcf73c4ca5d301dd"
 

--- a/Library/Formula/arpon.rb
+++ b/Library/Formula/arpon.rb
@@ -1,6 +1,6 @@
 class Arpon < Formula
   desc "Handler daemon to secure the ARP protocol from MITM attacks"
-  homepage "http://arpon.sourceforge.net/"
+  homepage "https://arpon.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/arpon/arpon/ArpON-2.7.2.tar.gz"
   sha256 "99adf83e4cdf2eda01601a60e2e1a611b5bce73865745fe67774c525c5f7d6d0"
 

--- a/Library/Formula/arss.rb
+++ b/Library/Formula/arss.rb
@@ -1,6 +1,6 @@
 class Arss < Formula
   desc "Analyze a sound file into a spectrogram"
-  homepage "http://arss.sourceforge.net/"
+  homepage "https://arss.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/arss/arss/0.2.3/arss-0.2.3-src.tar.gz"
   sha256 "e2faca8b8a3902226353c4053cd9ab71595eec6ead657b5b44c14b4bef52b2b2"
 

--- a/Library/Formula/artifactory.rb
+++ b/Library/Formula/artifactory.rb
@@ -1,6 +1,6 @@
 class Artifactory < Formula
   desc "Manages binaries"
-  homepage "http://www.jfrog.com/artifactory/"
+  homepage "https://jfrog.com/artifactory/"
   url "https://dl.bintray.com/jfrog/artifactory/jfrog-artifactory-oss-4.0.2.zip"
   sha256 "52a882b3681bc00eb73fddfe6abdc739156c2940be073406185be23a5f35bff2"
 

--- a/Library/Formula/asciidoc.rb
+++ b/Library/Formula/asciidoc.rb
@@ -1,6 +1,6 @@
 class Asciidoc < Formula
   desc "Formatter/translator for text files to numerous formats"
-  homepage "http://asciidoc.org/"
+  homepage "https://asciidoc.org/"
   url "https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
   sha256 "78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0"
 

--- a/Library/Formula/asciitex.rb
+++ b/Library/Formula/asciitex.rb
@@ -1,6 +1,6 @@
 class Asciitex < Formula
   desc "Generate ASCII-art representations of mathematical equations"
-  homepage "http://asciitex.sourceforge.net"
+  homepage "https://asciitex.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/asciitex/asciiTeX-0.21.tar.gz"
   sha256 "abf964818833d8b256815eb107fb0de391d808fe131040fb13005988ff92a48d"
 

--- a/Library/Formula/asm6.rb
+++ b/Library/Formula/asm6.rb
@@ -1,6 +1,6 @@
 class Asm6 < Formula
   desc "6502 assembler"
-  homepage "http://home.comcast.net/~olimar/NES/"
+  homepage "https://web.archive.org/web/20150802135328/http://home.comcast.net/~olimar/NES/"
   url "http://home.comcast.net/~olimar/NES/asm6.zip"
   version "1.6"
   sha256 "b37956f37815a75a6712c0d1f8eea06d1207411921c2e7ff46a133f35f0b3e1d"

--- a/Library/Formula/aspcud.rb
+++ b/Library/Formula/aspcud.rb
@@ -1,6 +1,6 @@
 class Aspcud < Formula
   desc "Package dependency solver"
-  homepage "http://potassco.sourceforge.net/"
+  homepage "https://potassco.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/potassco/aspcud/1.9.1/aspcud-1.9.1-source.tar.gz"
   sha256 "e0e917a9a6c5ff080a411ff25d1174e0d4118bb6759c3fe976e2e3cca15e5827"
 

--- a/Library/Formula/assimp.rb
+++ b/Library/Formula/assimp.rb
@@ -1,6 +1,6 @@
 class Assimp < Formula
   desc "Portable library for importing many well-known 3D model formats"
-  homepage "http://assimp.sourceforge.net/"
+  homepage "https://assimp.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/assimp/assimp-3.1/assimp-3.1.1_no_test_models.zip"
   sha256 "da9827876f10a8b447270368753392cfd502e70a2e9d1361554e5dfcb1fede9e"
   version "3.1.1"

--- a/Library/Formula/astyle.rb
+++ b/Library/Formula/astyle.rb
@@ -1,6 +1,6 @@
 class Astyle < Formula
   desc "Source code beautifier for C, C++, C#, and Java"
-  homepage "http://astyle.sourceforge.net/"
+  homepage "https://astyle.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/astyle/astyle/astyle%202.05.1/astyle_2.05.1_macosx.tar.gz"
   sha256 "de66da286dee2b9de1dc1c05092cbf5368c0889f25d1e2ee8b51766aff8e4baf"
   head "svn://svn.code.sf.net/p/astyle/code/trunk/AStyle"

--- a/Library/Formula/at-spi2-atk.rb
+++ b/Library/Formula/at-spi2-atk.rb
@@ -1,6 +1,6 @@
 class AtSpi2Atk < Formula
   desc "Accessibility Toolkit GTK+ module"
-  homepage "http://a11y.org"
+  homepage "https://web.archive.org/web/20040928142449/http://www.a11y.org/"
   url "https://download.gnome.org/sources/at-spi2-atk/2.14/at-spi2-atk-2.14.1.tar.xz"
   sha256 "058f34ea60edf0a5f831c9f2bdd280fe95c1bcafb76e466e44aa0fb356d17bcb"
 

--- a/Library/Formula/at-spi2-core.rb
+++ b/Library/Formula/at-spi2-core.rb
@@ -1,6 +1,6 @@
 class AtSpi2Core < Formula
   desc "Protocol definitions and daemon for D-Bus at-spi"
-  homepage "http://a11y.org"
+  homepage "https://web.archive.org/web/20040928142449/http://www.a11y.org/"
   url "https://download.gnome.org/sources/at-spi2-core/2.14/at-spi2-core-2.14.1.tar.xz"
   sha256 "eef9660b14fdf0fb1f30d1be7c72d591fa7cbb87b00ca3a444425712f46ce657"
 

--- a/Library/Formula/aterm.rb
+++ b/Library/Formula/aterm.rb
@@ -1,6 +1,6 @@
 class Aterm < Formula
   desc "AfterStep terminal emulator"
-  homepage "http://strategoxt.org/Tools/ATermFormat"
+  homepage "https://strategoxt.org/Tools/ATermFormat"
   url "http://www.meta-environment.org/releases/aterm-2.8.tar.gz"
   sha256 "bab69c10507a16f61b96182a06cdac2f45ecc33ff7d1b9ce4e7670ceeac504ef"
 

--- a/Library/Formula/atf.rb
+++ b/Library/Formula/atf.rb
@@ -1,6 +1,6 @@
 class Atf < Formula
   desc "ATF: Automated Testing Framework"
-  homepage "https://github.com/jmmv/atf"
+  homepage "https://github.com/freebsd/atf"
   url "https://github.com/jmmv/atf/releases/download/atf-0.21/atf-0.21.tar.gz"
   sha256 "92bc64180135eea8fe84c91c9f894e678767764f6dbc8482021d4dde09857505"
 

--- a/Library/Formula/atk.rb
+++ b/Library/Formula/atk.rb
@@ -1,6 +1,6 @@
 class Atk < Formula
   desc "GNOME accessibility toolkit"
-  homepage "https://library.gnome.org/devel/atk/"
+  homepage "https://web.archive.org/web/20110313025835/https://library.gnome.org/devel/atk/"
   url "https://download.gnome.org/sources/atk/2.18/atk-2.18.0.tar.xz"
   sha256 "ce6c48d77bf951083029d5a396dd552d836fff3c1715d3a7022e917e46d0c92b"
 

--- a/Library/Formula/atkmm.rb
+++ b/Library/Formula/atkmm.rb
@@ -1,6 +1,6 @@
 class Atkmm < Formula
   desc "Official C++ interface for the ATK accessibility toolkit library"
-  homepage "http://www.gtkmm.org"
+  homepage "https://gtkmm.gnome.org/"
   url "https://download.gnome.org/sources/atkmm/2.22/atkmm-2.22.7.tar.xz"
   sha256 "bfbf846b409b4c5eb3a52fa32a13d86936021969406b3dcafd4dd05abd70f91b"
 

--- a/Library/Formula/atomicparsley.rb
+++ b/Library/Formula/atomicparsley.rb
@@ -1,6 +1,6 @@
 class Atomicparsley < Formula
   desc "MPEG-4 command-line tool"
-  homepage "https://bitbucket.org/wez/atomicparsley/overview/"
+  homepage "https://web.archive.org/web/20190301211932/https://bitbucket.org/wez/atomicparsley/overview/"
   url "https://bitbucket.org/dinkypumpkin/atomicparsley/downloads/atomicparsley-0.9.6.tar.bz2"
   sha256 "49187a5215520be4f732977657b88b2cf9203998299f238067ce38f948941562"
 

--- a/Library/Formula/ats2-postiats.rb
+++ b/Library/Formula/ats2-postiats.rb
@@ -1,6 +1,6 @@
 class Ats2Postiats < Formula
   desc "ATS programming language implementation"
-  homepage "http://www.ats-lang.org/"
+  homepage "https://www.cs.bu.edu/~hwxi/atslangweb/"
   url "https://downloads.sourceforge.net/project/ats2-lang/ats2-lang/ats2-postiats-0.2.3/ATS2-Postiats-0.2.3.tgz"
   sha256 "a2a50305ddfc8c88d475e0378a9f476887d11c0a64f381b849f2b9f1746258cd"
 

--- a/Library/Formula/audiofile.rb
+++ b/Library/Formula/audiofile.rb
@@ -1,6 +1,6 @@
 class Audiofile < Formula
   desc "Reads and writes many common audio file formats"
-  homepage "http://www.68k.org/~michael/audiofile/"
+  homepage "https://audiofile.68k.org/"
   url "http://audiofile.68k.org/audiofile-0.3.6.tar.gz"
   sha256 "cdc60df19ab08bfe55344395739bb08f50fc15c92da3962fac334d3bff116965"
 

--- a/Library/Formula/augeas.rb
+++ b/Library/Formula/augeas.rb
@@ -1,6 +1,6 @@
 class Augeas < Formula
   desc "Configuration editing tool and API"
-  homepage "http://augeas.net"
+  homepage "https://augeas.net"
   url "http://download.augeas.net/augeas-1.4.0.tar.gz"
   sha256 "659fae7ac229029e60a869a3b88c616cfd51cf2fba286cdfe3af3a052cb35b30"
   revision 1

--- a/Library/Formula/auto-scaling.rb
+++ b/Library/Formula/auto-scaling.rb
@@ -1,6 +1,6 @@
 class AutoScaling < Formula
   desc "Client interface to the Amazon Auto Scaling web service"
-  homepage "https://aws.amazon.com/developertools/2535"
+  homepage "https://docs.aws.amazon.com/cli/latest/reference/autoscaling/"
   url "https://ec2-downloads.s3.amazonaws.com/AutoScaling-2011-01-01.zip"
   version "1.0.61.6"
   sha256 "2c81e092d5c479896007e7d1a3cf40631d09e6bffd83b42f49a56f42207326b6"

--- a/Library/Formula/autoconf.rb
+++ b/Library/Formula/autoconf.rb
@@ -1,6 +1,6 @@
 class Autoconf < Formula
   desc "Automatic configure script builder"
-  homepage "https://www.gnu.org/software/autoconf"
+  homepage "https://www.gnu.org/software/autoconf/"
   url "https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.xz"
   mirror "https://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz"
   sha256 "ba885c1319578d6c94d46e9b0dceb4014caafe2490e437a0dbca3f270a223f5a"

--- a/Library/Formula/autoenv.rb
+++ b/Library/Formula/autoenv.rb
@@ -1,6 +1,6 @@
 class Autoenv < Formula
   desc "Per-project, per-directory shell environments"
-  homepage "https://github.com/kennethreitz/autoenv"
+  homepage "https://github.com/hyperupcall/autoenv"
   url "https://github.com/kennethreitz/autoenv/archive/v0.1.0.tar.gz"
   sha256 "5e0fb3af642ee54b050b9d04f7f32fef1c6db14a6a3b6c6d05796b5681aeec90"
 

--- a/Library/Formula/autogen.rb
+++ b/Library/Formula/autogen.rb
@@ -1,6 +1,6 @@
 class Autogen < Formula
   desc "Automated text file generator"
-  homepage "http://autogen.sourceforge.net"
+  homepage "https://autogen.sourceforge.net/"
   url "http://ftpmirror.gnu.org/autogen/rel5.18.4/autogen-5.18.4.tar.xz"
   mirror "https://ftp.gnu.org/gnu/autogen/rel5.18.4/autogen-5.18.4.tar.xz"
   sha256 "7fbaff0c25035aee5b96913de2c83d9a5cc973b8dc08d6b7489ecbcfd72eb84b"

--- a/Library/Formula/automysqlbackup.rb
+++ b/Library/Formula/automysqlbackup.rb
@@ -1,6 +1,6 @@
 class Automysqlbackup < Formula
   desc "Automate MySQL backups"
-  homepage "http://sourceforge.net/projects/automysqlbackup/"
+  homepage "https://automysqlbackup.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/automysqlbackup/AutoMySQLBackup/AutoMySQLBackup%20VER%203.0/automysqlbackup-v3.0_rc6.tar.gz"
   version "3.0-rc6"
   sha256 "889e064d086b077e213da11e937ea7242a289f9217652b9051c157830dc23cc0"

--- a/Library/Formula/autopano-sift-c.rb
+++ b/Library/Formula/autopano-sift-c.rb
@@ -1,6 +1,6 @@
 class AutopanoSiftC < Formula
   desc "Find control points in overlapping image pairs"
-  homepage "http://wiki.panotools.org/Autopano-sift-C"
+  homepage "https://wiki.panotools.org/Autopano-sift-C"
   url "https://downloads.sourceforge.net/project/hugin/autopano-sift-C/autopano-sift-C-2.5.1/autopano-sift-C-2.5.1.tar.gz"
   sha256 "9a9029353f240b105a9c0e31e4053b37b0f9ef4bd9166dcb26be3e819c431337"
 

--- a/Library/Formula/autopsy.rb
+++ b/Library/Formula/autopsy.rb
@@ -1,6 +1,6 @@
 class Autopsy < Formula
   desc "Graphical interface to Sleuth Kit investigation tools"
-  homepage "http://www.sleuthkit.org/autopsy/index.php"
+  homepage "https://www.sleuthkit.org/autopsy/index.php"
   url "https://downloads.sourceforge.net/project/autopsy/autopsy/2.24/autopsy-2.24.tar.gz"
   sha256 "ab787f519942783d43a561d12be0554587f11f22bc55ab79d34d8da703edc09e"
 

--- a/Library/Formula/autotrace.rb
+++ b/Library/Formula/autotrace.rb
@@ -1,6 +1,6 @@
 class Autotrace < Formula
   desc "Convert bitmap to vector graphics"
-  homepage "http://autotrace.sourceforge.net"
+  homepage "https://autotrace.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/autotrace/AutoTrace/0.31.1/autotrace-0.31.1.tar.gz"
   sha256 "5a1a923c3335dfd7cbcccb2bbd4cc3d68cafe7713686a2f46a1591ed8a92aff6"
   revision 1

--- a/Library/Formula/avian.rb
+++ b/Library/Formula/avian.rb
@@ -1,6 +1,6 @@
 class Avian < Formula
   desc "Lightweight VM and class library for a subset of Java features"
-  homepage "http://oss.readytalk.com/avian/"
+  homepage "https://web.archive.org/web/20151027043913/http://oss.readytalk.com/avian/"
   head "https://github.com/ReadyTalk/avian.git"
   url "https://github.com/ReadyTalk/avian/archive/v1.2.0.tar.gz"
   sha256 "e3639282962239ce09e4f79f327c679506d165810f08c92ce23e53e86e1d621c"

--- a/Library/Formula/aview.rb
+++ b/Library/Formula/aview.rb
@@ -1,6 +1,6 @@
 class Aview < Formula
   desc "ASCII-art image browser and animation viewer"
-  homepage "http://aa-project.sourceforge.net/aview/"
+  homepage "https://aa-project.sourceforge.net/aview/"
   url "https://downloads.sourceforge.net/aa-project/aview-1.3.0rc1.tar.gz"
   sha256 "42d61c4194e8b9b69a881fdde698c83cb27d7eda59e08b300e73aaa34474ec99"
 

--- a/Library/Formula/avra.rb
+++ b/Library/Formula/avra.rb
@@ -1,6 +1,6 @@
 class Avra < Formula
   desc "Assember for the Atmel AVR microcontroller family"
-  homepage "http://avra.sourceforge.net/"
+  homepage "https://avra.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/avra/1.3.0/avra-1.3.0.tar.bz2"
   sha256 "a62cbf8662caf9cc4e75da6c634efce402778639202a65eb2d149002c1049712"
 

--- a/Library/Formula/aws-cfn-tools.rb
+++ b/Library/Formula/aws-cfn-tools.rb
@@ -1,6 +1,6 @@
 class AwsCfnTools < Formula
   desc "Client for Amazon CloudFormation web service"
-  homepage "https://aws.amazon.com/developertools/AWS-CloudFormation/2555753788650372"
+  homepage "https://aws.amazon.com/developer/tools/"
   url "https://s3.amazonaws.com/cloudformation-cli/AWSCloudFormation-cli.zip"
   version "1.0.12"
   sha256 "382e3e951833fd77235fae41c1742224d68bdf165e1ace4200ee88c01ac29a90"

--- a/Library/Formula/aws-cloudsearch.rb
+++ b/Library/Formula/aws-cloudsearch.rb
@@ -1,6 +1,6 @@
 class AwsCloudsearch < Formula
   desc "Client for Amazon CloudSearch web service"
-  homepage "https://aws.amazon.com/developertools/9054800585729911"
+  homepage "https://aws.amazon.com/developer/tools/"
   url "https://s3.amazonaws.com/amazon-cloudsearch-data/cloud-search-tools-v2-2.0.1.0-2014.10.27.tar.gz"
   version "2.0.1.0-2014.10.27"
   sha256 "882a6442172957b27c0b3cd1f271531112092d4d227b528ce912b2e7ea886d51"

--- a/Library/Formula/aws-elasticache.rb
+++ b/Library/Formula/aws-elasticache.rb
@@ -1,6 +1,6 @@
 class AwsElasticache < Formula
   desc "Client for Amazon ElastiCache web service"
-  homepage "https://aws.amazon.com/developertools/2310261897259567"
+  homepage "https://aws.amazon.com/developer/tools/"
   url "https://s3.amazonaws.com/elasticache-downloads/AmazonElastiCacheCli-2014-09-30-1.12.000.zip"
   version "1.12.000"
   sha256 "0aee0849a78c8129ed16e99706dde34972c02ed1846e70b76a1e21a133d9648f"

--- a/Library/Formula/aws-elasticbeanstalk.rb
+++ b/Library/Formula/aws-elasticbeanstalk.rb
@@ -1,6 +1,6 @@
 class AwsElasticbeanstalk < Formula
   desc "Client for Amazon Elastic Beanstalk web service"
-  homepage "https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-reference-eb.html"
+  homepage "https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html"
   url "https://pypi.python.org/packages/source/a/awsebcli/awsebcli-3.5.4.tar.gz"
   sha256 "9f5c7ff42b58b3d470851e9494051c1788e5b891ef9296c13c29a91d1c468aa2"
 

--- a/Library/Formula/aws-sns-cli.rb
+++ b/Library/Formula/aws-sns-cli.rb
@@ -1,6 +1,6 @@
 class AwsSnsCli < Formula
   desc "Client for Amazon Simple Notification web service"
-  homepage "https://aws.amazon.com/developertools/3688"
+  homepage "https://aws.amazon.com/developer/tools/"
   url "https://sns-public-resources.s3.amazonaws.com/SimpleNotificationServiceCli-2010-03-31.zip"
   # The version in the tarball is the API version; this is the tool version
   version "2013-09-27"


### PR DESCRIPTION
I've been doing some audits of Tigerbrew formulas, and it looks like a number of the URLs are out of date. I suspect that updating URLs will restore some packages that currently don't build to being functional again. I'm trying this in phases.

This first commit updates `homepage` urls, as these are informational rather than functional.  The changes here are:

1. I updated all `http` urls to `https` if an `https` url was available - this was done with automation.
2. I followed all `301` (permanent) redirects - this was done with automation
3. I manually reviewed  `302` (temporary) redirects, `40X` errors, errors and otherwise nonfunctional websites, and manually fixed the ones that could be fixed. I either followed links on the existing websites, or used other URLs in the formula (such as the `head` url) to find the existing project. I didn't update any `302` redirects that looked truly temporary - for example, a lot of sourceforge projects have what seems to be a canonical url that links to the project's specific page, and I left those canonical urls in place.
4. While doing this, I found some packages that look like they're truly nonfunctional - I'm going to confirm this, and may follow up with PRs to remove them: https://github.com/jcgraybill/tigerbrew/issues/3

I realize this is a massive commit - 1,793 files - which makes it beyond unwieldy to manually review. I'm happy to share some of the scripts I've been using to look for homepage urls with issues, which can be used to check the work here. Or to break the commit up into smaller pieces, or whatever might help.

