### PR TITLE
non_apple_gcc_version: fix two-digit GCCs

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -155,6 +155,8 @@ module OS
         end
     end
 
+    # String format:
+    # gcc-14 (Tigerbrew gcc 14.2.0) 14.2.0
     def non_apple_gcc_version(cc)
       (@non_apple_gcc_version ||= {}).fetch(cc) do
         path = HOMEBREW_PREFIX.join("opt", "gcc", "bin", cc)

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -159,7 +159,7 @@ module OS
       (@non_apple_gcc_version ||= {}).fetch(cc) do
         path = HOMEBREW_PREFIX.join("opt", "gcc", "bin", cc)
         path = locate(cc) unless path.exist?
-        version = `#{path} --version`[/gcc(?:-\d(?:\.\d)? \(.+\))? (\d\.\d\.\d)/, 1] if path
+        version = `#{path} --version`[/gcc(?:-\d\d?(?:\.\d)? \(.+\))? (\d\d?\.\d\.\d)/, 1] if path
         @non_apple_gcc_version[cc] = version
       end
     end


### PR DESCRIPTION
This fixes finding GCC 14 in the compiler selection code; otherwise, the compiler selection machinery will pass it over for GCC 8.

Sample strings the regex is matching against:

gcc-8:

```
gcc-8 (Tigerbrew gcc8 8.5.0_1) 8.5.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

gcc-14:

```
gcc-14 (Tigerbrew gcc 14.2.0) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```