### PR TITLE
Erlang build fixes

### DIFF
--- a/Library/Formula/erlang.rb
+++ b/Library/Formula/erlang.rb
@@ -60,6 +60,10 @@ class Erlang < Formula
 
     ENV["FOP"] = "#{HOMEBREW_PREFIX}/bin/fop" if build.with? "fop"
 
+    # Fixes an error with newer GCCs and in6addr
+    # https://github.com/asdf-vm/asdf-erlang/issues/157
+    ENV.append_to_cflags "-Wno-error=implicit-function-declaration"
+
     # Do this if building from a checkout to generate configure
     system "./otp_build", "autoconf" if File.exist? "otp_build"
 

--- a/Library/Formula/erlang.rb
+++ b/Library/Formula/erlang.rb
@@ -84,6 +84,11 @@ class Erlang < Formula
     # In /usr/include/c++/4.0.0/powerpc64-apple-darwin8/bits/stdc++.h.gch/O0g.gch & O2g.gch
     # symbol is found but configure's test for it fails, breaking the build
     args << "ac_cv_type___int128_t=no" if MacOS.version == :tiger && Hardware::CPU.family == :g5
+    # configure iritatingly picks a different compiler than CC in this one place
+    # It's set to prioritize a compiler named "gcc-4.2"
+    # over "gcc" if present, which causes build failures for Tiger users with
+    # apple-gcc42 installed
+    args << "ac_cv_prog_emu_cc=#{ENV.cc}"
 
     if MacOS.version >= :snow_leopard && MacOS::CLT.installed?
       args << "--with-dynamic-trace=dtrace"

--- a/Library/Formula/erlang.rb
+++ b/Library/Formula/erlang.rb
@@ -53,6 +53,11 @@ class Erlang < Formula
     cause "Bus error when attempting to build HiPE"
   end
 
+  # https://github.com/mistydemeo/tigerbrew/pull/1368
+  fails_with :gcc => "14" do
+    cause "ld64 fails to link - duplicate symbol _erts_allctr_wrappers"
+  end
+
   def install
     # Unset these so that building wx, kernel, compiler and
     # other modules doesn't fail with an unintelligable error.


### PR DESCRIPTION
This contains a few build fixes for Erlang, which I've run into on Tiger with a G5 using GCC 14.

It still doesn't 100% build for me yet; I ran into a link error at the end: https://gist.github.com/mistydemeo/b26c6e21c356a88ad6eb5dd104ed00a4

```
/usr/local/bin/gcc-14 -o /private/tmp/erlang20250517-24809-1gecgbh/otp-OTP-18.3.4.11/bin/powerpc-apple-darwin8.11.0/beam.smp \
 -m32 -L/usr/local/opt/zlib/lib -L/usr/local/lib -F/usr/local/Frameworks -Wl,-headerpad_max_install_names  obj/powerpc-apple-darwin8.11.0/opt/smp/erl_main.o	obj/powerpc-apple-darwin8.11.0/opt/smp/preload.o obj/powerpc-apple-darwin8.11.0/opt/smp/beam_emu.o		obj/powerpc-apple-darwin8.11.0/opt/smp/beam_opcodes.o obj/powerpc-apple-darwin8.11.0/opt/smp/beam_load.o		obj/powerpc-apple-darwin8.11.0/opt/smp/beam_bif_load.o obj/powerpc-apple-darwin8.11.0/opt/smp/beam_debug.o		obj/powerpc-apple-darwin8.11.0/opt/smp/beam_bp.o obj/powerpc-apple-darwin8.11.0/opt/smp/beam_catches.o obj/powerpc-apple-darwin8.11.0/opt/smp/code_ix.o obj/powerpc-apple-darwin8.11.0/opt/smp/beam_ranges.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_pbifs.o		obj/powerpc-apple-darwin8.11.0/opt/smp/benchmark.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_alloc.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_mtrace.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_alloc_util.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_goodfit_alloc.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bestfit_alloc.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_afit_alloc.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_instrument.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_init.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_atom_table.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_table.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_ddll.o  	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_guard.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_info.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_op.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_os.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_lists.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_trace.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_unique.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_wrap.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_trace.o		obj/powerpc-apple-darwin8.11.0/opt/smp/copy.o obj/powerpc-apple-darwin8.11.0/opt/smp/utils.o		obj/powerpc-apple-darwin8.11.0/opt/smp/bif.o obj/powerpc-apple-darwin8.11.0/opt/smp/io.o 			obj/powerpc-apple-darwin8.11.0/opt/smp/erl_printf_term.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_debug.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_md5.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_message.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_process.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_process_dict.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_process_lock.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_port_task.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_arith.o obj/powerpc-apple-darwin8.11.0/opt/smp/time.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_time_sup.o obj/powerpc-apple-darwin8.11.0/opt/smp/external.o		obj/powerpc-apple-darwin8.11.0/opt/smp/dist.o obj/powerpc-apple-darwin8.11.0/opt/smp/binary.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_db.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_db_util.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_db_hash.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_db_tree.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_thr_progress.o obj/powerpc-apple-darwin8.11.0/opt/smp/big.o			obj/powerpc-apple-darwin8.11.0/opt/smp/hash.o obj/powerpc-apple-darwin8.11.0/opt/smp/index.o		obj/powerpc-apple-darwin8.11.0/opt/smp/atom.o obj/powerpc-apple-darwin8.11.0/opt/smp/module.o		obj/powerpc-apple-darwin8.11.0/opt/smp/export.o obj/powerpc-apple-darwin8.11.0/opt/smp/register.o		obj/powerpc-apple-darwin8.11.0/opt/smp/break.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_async.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_lock_check.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_gc.o 		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_lock_count.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_posix_str.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bits.o 		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_math.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_fun.o             obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_port.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_term.o 		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_node_tables.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_monitors.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_process_dump.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_hl_timer.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_cpu_topology.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_drv_thread.o      obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_chksum.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_re.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_unicode.o obj/powerpc-apple-darwin8.11.0/opt/smp/packet_parser.o	obj/powerpc-apple-darwin8.11.0/opt/smp/safe_hash.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_zlib.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_nif.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_bif_binary.o      obj/powerpc-apple-darwin8.11.0/opt/smp/erl_ao_firstfit_alloc.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_thr_queue.o	obj/powerpc-apple-darwin8.11.0/opt/smp/erl_sched_spec_pre_alloc.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_ptab.o		obj/powerpc-apple-darwin8.11.0/opt/smp/erl_map.o obj/powerpc-apple-darwin8.11.0/opt/smp/sys.o obj/powerpc-apple-darwin8.11.0/opt/smp/driver_tab.o obj/powerpc-apple-darwin8.11.0/opt/smp/unix_efile.o obj/powerpc-apple-darwin8.11.0/opt/smp/gzio.o obj/powerpc-apple-darwin8.11.0/opt/smp/elib_memmove.o obj/powerpc-apple-darwin8.11.0/opt/smp/sys_float.o obj/powerpc-apple-darwin8.11.0/opt/smp/sys_time.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_poll.kp.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_check_io.kp.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_poll.nkp.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_check_io.nkp.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_mseg.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_mmap.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_unix_sys_ddll.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_mtrace_sys_wrap.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_sys_common_misc.o obj/powerpc-apple-darwin8.11.0/opt/smp/erl_os_monotonic_time_extender.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_bif0.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_bif1.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_bif2.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_debug.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_gc.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_mode_switch.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_native_bif.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_stack.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_ppc.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_ppc_glue.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_ppc_bifs.o obj/powerpc-apple-darwin8.11.0/opt/smp/hipe_risc_stack.o obj/powerpc-apple-darwin8.11.0/opt/smp/efile_drv.o obj/powerpc-apple-darwin8.11.0/opt/smp/inet_drv.o obj/powerpc-apple-darwin8.11.0/opt/smp/zlib_drv.o obj/powerpc-apple-darwin8.11.0/opt/smp/ram_file_drv.o obj/powerpc-apple-darwin8.11.0/opt/smp/ttsl_drv.o  \
  -lutil -ldl -lm  -lncurses -L../lib/internal/powerpc-apple-darwin8.11.0  -lz /private/tmp/erlang20250517-24809-1gecgbh/otp-OTP-18.3.4.11/erts/emulator/pcre/obj/powerpc-apple-darwin8.11.0/opt/libepcre.a  -lethread -lerts_internal_r -lpthread    -framework Carbon -framework Cocoa
ld: duplicate symbol _erts_allctr_wrappers in obj/powerpc-apple-darwin8.11.0/opt/smp/beam_emu.o and obj/powerpc-apple-darwin8.11.0/opt/smp/erl_main.o
collect2: error: ld returned 1 exit status
```