### PR TITLE
replace sha1 bottle checksums with sha256

### DIFF
--- a/Library/Formula/boost.rb
+++ b/Library/Formula/boost.rb
@@ -8,9 +8,9 @@ class Boost < Formula
 
   bottle do
     cellar :any
-    sha1 "8f6a8a1ee71302d218fde9b5837fdc32e52bc63d" => :tiger_altivec
-    sha1 "ef26d910e2ee155ebc37724a989b7d64a1b378a4" => :leopard_g3
-    sha1 "a5f06a58dd70d0deee7d738573528c2bf289980f" => :leopard_altivec
+    sha256 "9344005f51749e26ad13448df62c00a3d0bd92123b970fa673528884ff4e125c" => :tiger_altivec
+    sha256 "5aae838d474619995566af9dc282d3c3d9908b3a0b7ef4423f9d34446954005b" => :leopard_g3
+    sha256 "90e839ad335dfe436d59bb5b629061ddd75d7260da4f8722ce497173f2b77cf7" => :leopard_altivec
   end
 
   env :userpaths

--- a/Library/Formula/faad2.rb
+++ b/Library/Formula/faad2.rb
@@ -9,9 +9,9 @@ class Faad2 < Formula
 
   bottle do
     cellar :any
-    sha1 "96262445fa48886dc6ee84308b8b6118b7b796dc" => :tiger_altivec
-    sha1 "025ba2eeae000895a18647ac2e1560f620dffa81" => :leopard_g3
-    sha1 "3115d2defb838d13093d8a5401266178fc6fd6fe" => :leopard_altivec
+    sha256 "c64b6d56f3464fe198697cc666c717c897f0c3b5e079e0d2fbb641d525950bfe" => :tiger_altivec
+    sha256 "9824e92e089976d8cbca8f48dae86183dd0573bf82b495b32fb954b7fdb26322" => :leopard_g3
+    sha256 "0ba8b1ba5235248ae43646e11a70b8365e09141fc38b18556fc3af52440fe4ef" => :leopard_altivec
   end
 
   def install

--- a/Library/Formula/lame.rb
+++ b/Library/Formula/lame.rb
@@ -6,8 +6,8 @@ class Lame < Formula
 
   bottle do
     cellar :any
-    sha1 "ac89c99c2024cd109cd7aaa1d1edc9424715ac88" => :leopard_g3
-    sha1 "975485f851402e9f57ae26fe61115a9d295c02fb" => :leopard_altivec
+    sha256 "c792746e24c1585b7e03f58c21d42cbe7d581cad314dbc91e48b59a6b4841d92" => :leopard_g3
+    sha256 "9b704aef2371963a8941329c67c46a59cf8ed506e2af6f1380721a020d76edce" => :leopard_altivec
   end
 
   option :universal

--- a/Library/Formula/libvo-aacenc.rb
+++ b/Library/Formula/libvo-aacenc.rb
@@ -6,9 +6,9 @@ class LibvoAacenc < Formula
 
   bottle do
     cellar :any
-    sha1 "db988fca9280de51d16bddcf04bd22e9b3422b58" => :tiger_altivec
-    sha1 "b75add72a8f671b9fbfeeeb0e5335a7e08adcc05" => :leopard_g3
-    sha1 "1028521d75673ce18bc33018598e3a09b2aeee36" => :leopard_altivec
+    sha256 "cc1f30fc2ebcf4d2197c17ad6dd8874ef922232929d1042bdb0611b53236fe78" => :tiger_altivec
+    sha256 "050d5885633b5cc5d050ce432dc0be0d96553eaf74280e6d0fd2c3c11be58433" => :leopard_g3
+    sha256 "9825387b4c10d94aab5f13f94150021062a9077956f4d038124f1aca28f9c094" => :leopard_altivec
   end
 
   def install

--- a/Library/Formula/mad.rb
+++ b/Library/Formula/mad.rb
@@ -7,8 +7,8 @@ class Mad < Formula
   bottle do
     cellar :any
     sha256 "5b7a01e35e2f95e2151ed04a10f472c31e4778a5fefbf369a7929bcce3b90e9a" => :tiger_altivec
-    sha1 "9d591d72a744fb6a7d78a4307f83a7628efb731a" => :leopard_g3
-    sha1 "150c5852d8244e6f3429283b87e268dfdce7af79" => :leopard_altivec
+    sha256 "31d0f66ac6bb20b957c01ae971627fa2aa2c6d284c097fd2f4e9626fa9acec15" => :leopard_g3
+    sha256 "6bd736c3b2a8319d340b0da7e448a2b8709224d3efaf235f572b4d7ac5bc48be" => :leopard_altivec
   end
 
   def install

--- a/Library/Formula/pianobar.rb
+++ b/Library/Formula/pianobar.rb
@@ -7,9 +7,9 @@ class Pianobar < Formula
 
   bottle do
     cellar :any
-    sha1 "ac594a508ff186a483fc74d56e35460ec1c3127a" => :tiger_altivec
-    sha1 "d4aa59c4411f32c1c3655b7fcd16195ced843ff6" => :leopard_g3
-    sha1 "2d79864486410f89d28ebe287bd13d5b14c6267a" => :leopard_altivec
+    sha256 "ef2d4e3cb2478c1efa40986b53d6dbde50d147fa53e726f5a5145697c0bbbc3e" => :tiger_altivec
+    sha256 "bf1d6fe5f2785d51f7dad6fdb080d840548298eb467bac014b5e7ed10073f5d3" => :leopard_g3
+    sha256 "d0923378f486ead741c0eeaebb2f1c7d3b661975cc4a6a863d122f0d6b11c240" => :leopard_altivec
   end
 
   depends_on "make" => :build if MacOS.version < :leopard

--- a/Library/Formula/texi2html.rb
+++ b/Library/Formula/texi2html.rb
@@ -6,9 +6,9 @@ class Texi2html < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha1 "dab75b6b742681e2808178d0c2ea659ac20ccf19" => :tiger_altivec
-    sha1 "58cb2e4901212c31394dfdf317d1394a365eb98c" => :leopard_g3
-    sha1 "59304169ba3f1d720f2e0db52f41204a0d275e5e" => :leopard_altivec
+    sha256 "6dc3e72f8bc538ccbbf7488479cf5d28877640cef1d19282a59ddff2a77228a5" => :tiger_altivec
+    sha256 "37a5199a826a4e6751f637332f77eaa64f166c61f97c663e56da372678ea6482" => :leopard_g3
+    sha256 "0a9c1562ae122910318a97a19624f998a7dee16edb8f501d6ad4d52298b70070" => :leopard_altivec
   end
 
   keg_only :provided_pre_mountain_lion

--- a/Library/Formula/yasm.rb
+++ b/Library/Formula/yasm.rb
@@ -7,8 +7,8 @@ class Yasm < Formula
   bottle do
     cellar :any_skip_relocation
     sha256 "5c56307dadf4d4504dbe62934434685e69977c5a785ba0473e0a9b978252a0a2" => :tiger_altivec
-    sha1 "901eef3d8e3c45feb728d1ae14306a7b90e1f336" => :leopard_g3
-    sha1 "21a683bb375e328caaed0a9ce59ec2b83284cb81" => :leopard_altivec
+    sha256 "99f103621b4f461cf3fa2fdd6f29b0c04f1e6e449af1078569dab4dac030ddd1" => :leopard_g3
+    sha256 "3591a7c3eb770da4c5ccd1e77ec470ffcc3fbf180d38642e007f2330adfc1cb2" => :leopard_altivec
   end
 
   head do


### PR DESCRIPTION
Eight formulas have bottles that work, but which use sha1 checksums in the formula rather than sha256. This PR updates all these checksums to sha256.

Tested with `brew fetch` on `tiger_altivec` and `leopard_altivec`. I don't have a G3 mac for testing, so I wasn't able to confirm those checksums with `brew fetch`. 

```
Tiger-PowerPC:~ kabootie$ brew fetch boost faad2 libvo-aacenc pianobar texi2html
Fetching: boost, faad2, libvo-aacenc, pianobar, texi2html
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/boost-1.58.0.tiger_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/boost-1.58.0.tiger_altivec.bottle.tar.gz
SHA1: 8f6a8a1ee71302d218fde9b5837fdc32e52bc63d
SHA256: 9344005f51749e26ad13448df62c00a3d0bd92123b970fa673528884ff4e125c
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/faad2-2.7.tiger_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/faad2-2.7.tiger_altivec.bottle.tar.gz
SHA1: 96262445fa48886dc6ee84308b8b6118b7b796dc
SHA256: c64b6d56f3464fe198697cc666c717c897f0c3b5e079e0d2fbb641d525950bfe
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/libvo-aacenc-0.1.3.tiger_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/libvo-aacenc-0.1.3.tiger_altivec.bottle.tar.gz
SHA1: db988fca9280de51d16bddcf04bd22e9b3422b58
SHA256: cc1f30fc2ebcf4d2197c17ad6dd8874ef922232929d1042bdb0611b53236fe78
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/pianobar-2014.09.28.tiger_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/pianobar-2014.09.28.tiger_altivec.bottle.tar.gz
SHA1: ac594a508ff186a483fc74d56e35460ec1c3127a
SHA256: ef2d4e3cb2478c1efa40986b53d6dbde50d147fa53e726f5a5145697c0bbbc3e
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/texi2html-1.82.tiger_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/texi2html-1.82.tiger_altivec.bottle.tar.gz
SHA1: dab75b6b742681e2808178d0c2ea659ac20ccf19
SHA256: 6dc3e72f8bc538ccbbf7488479cf5d28877640cef1d19282a59ddff2a77228a5
```

```
Leopard-PowerPC:~ kabootie$ brew fetch boost faad2 lame libvo-aacenc mad pianobar texi2html yasm
Fetching: boost, faad2, lame, libvo-aacenc, mad, pianobar, texi2html, yasm
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/boost-1.58.0.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/boost-1.58.0.leopard_altivec.bottle.tar.gz
SHA1: a5f06a58dd70d0deee7d738573528c2bf289980f
SHA256: 90e839ad335dfe436d59bb5b629061ddd75d7260da4f8722ce497173f2b77cf7
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/faad2-2.7.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/faad2-2.7.leopard_altivec.bottle.tar.gz
SHA1: 3115d2defb838d13093d8a5401266178fc6fd6fe
SHA256: 0ba8b1ba5235248ae43646e11a70b8365e09141fc38b18556fc3af52440fe4ef
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/lame-3.99.5.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/lame-3.99.5.leopard_altivec.bottle.tar.gz
SHA1: 975485f851402e9f57ae26fe61115a9d295c02fb
SHA256: 9b704aef2371963a8941329c67c46a59cf8ed506e2af6f1380721a020d76edce
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/libvo-aacenc-0.1.3.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/libvo-aacenc-0.1.3.leopard_altivec.bottle.tar.gz
SHA1: 1028521d75673ce18bc33018598e3a09b2aeee36
SHA256: 9825387b4c10d94aab5f13f94150021062a9077956f4d038124f1aca28f9c094
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/mad-0.15.1b.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/mad-0.15.1b.leopard_altivec.bottle.tar.gz
SHA1: 150c5852d8244e6f3429283b87e268dfdce7af79
SHA256: 6bd736c3b2a8319d340b0da7e448a2b8709224d3efaf235f572b4d7ac5bc48be
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/pianobar-2014.09.28.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/pianobar-2014.09.28.leopard_altivec.bottle.tar.gz
SHA1: 2d79864486410f89d28ebe287bd13d5b14c6267a
SHA256: d0923378f486ead741c0eeaebb2f1c7d3b661975cc4a6a863d122f0d6b11c240
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/texi2html-1.82.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/texi2html-1.82.leopard_altivec.bottle.tar.gz
SHA1: 59304169ba3f1d720f2e0db52f41204a0d275e5e
SHA256: 0a9c1562ae122910318a97a19624f998a7dee16edb8f501d6ad4d52298b70070
==> Downloading https://ia904500.us.archive.org/24/items/tigerbrew/yasm-1.3.0.leopard_altivec.bottle.tar.gz
Already downloaded: /Users/kabootie/Library/Caches/Homebrew/yasm-1.3.0.leopard_altivec.bottle.tar.gz
SHA1: 21a683bb375e328caaed0a9ce59ec2b83284cb81
SHA256: 3591a7c3eb770da4c5ccd1e77ec470ffcc3fbf180d38642e007f2330adfc1cb2
```