### PR TITLE
arm: update urls

### DIFF
--- a/Library/Formula/arm.rb
+++ b/Library/Formula/arm.rb
@@ -1,8 +1,10 @@
 class Arm < Formula
   desc "Terminal status monitor for Tor"
-  homepage "http://www.atagar.com/arm/"
-  url "http://www.atagar.com/arm/resources/static/arm-1.4.5.0.tar.bz2"
+  homepage "https://archive.torproject.org/"
+  url "https://archive.torproject.org/arm/arm-1.4.5.0.tar.bz2"
   sha256 "fc0e771585dde3803873b4807578060f0556cf1cac6c38840a714ffada3b28fa"
+
+  depends_on "python" if MacOS.version == :tiger
 
   def install
     (share+"arm").install Dir["*"]


### PR DESCRIPTION
The source files for `arm` have moved, and the homepage is no longer current. Update both of these to new URLs. Note the checksum for the source tarball matches with the new URL.

In addition, `arm` requires the brew version of `python` on Tiger, so adding that dependency. 

Tested on:
* Tiger PowerPC & Intel
* Leopard PowerPC & Intel
* Snow Leopard Intel