### PR TITLE
anttweakbar: remove unused bottle hashes, fix crlf in patch

### DIFF
--- a/Library/Formula/anttweakbar.rb
+++ b/Library/Formula/anttweakbar.rb
@@ -5,13 +5,6 @@ class Anttweakbar < Formula
   version "1.16"
   sha256 "fbceb719c13ceb13b9fd973840c2c950527b6e026f9a7a80968c14f76fcf6e7c"
 
-  bottle do
-    cellar :any
-    sha1 "103b4c69883ace7c1d24a8ea9405669f491a00bc" => :yosemite
-    sha1 "52b1d49b36d290e5f90897b3fb291c52c936007b" => :mavericks
-    sha1 "370619e705719ed57ba0b31447c1f33a3b014c77" => :mountain_lion
-  end
-
   # See
   # http://sourceforge.net/p/anttweakbar/code/ci/5a076d13f143175a6bda3c668e29a33406479339/tree/src/LoadOGLCore.h?diff=5528b167ed12395a60949d7c643262b6668f15d5&diformat=regular
   # https://sourceforge.net/p/anttweakbar/tickets/14/


### PR DESCRIPTION
The lines in the patch section of the `anttweakbar` formula end in CRLF, but don't need to. I've test-built this package (Snow Leopard / Intel) with and without those line endings to confirm.

Cleaning this up so the file is easier to work with, and removing unused bottle hashes while I'm at it.