### PR TITLE
don't use bashdefault option on bash version <= 2

### DIFF
--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -1,19 +1,9 @@
 # Bash completion script for brew(1)
 #
-# To use, add the following to your .bashrc:
+# To use, install the bash-completion package. Alternately, can be used with 
+# older versions of bash by adding the following to your .bashrc:
 #
 #    . $(brew --repository)/Library/Contributions/brew_bash_completion.sh
-#
-# Alternatively, if you have installed the bash-completion package,
-# you can create a symlink to this file in one of the following directories:
-#
-#    $(brew --prefix)/etc/bash_completion.d
-#    $(brew --prefix)/share/bash-completion/completions
-#
-# Installing to etc/bash_completion.d will cause bash-completion to load
-# it automatically at shell startup time. If you choose to install it to
-# share/bash-completion/completions, it will be loaded on-demand (i.e. the
-# first time you invoke the `brew` command in a shell session).
 
 __brewcomp_words_include ()
 {

--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -652,7 +652,7 @@ _brew_to_completion ()
     _brew
 }
 
-if [ `echo "${BASH_VERSION}" | sed "s/\([0-9]*\).*/\1/"` -le 2 ]; then 
+if [ $BASH_VERSINFO -le 2 ]; then 
     complete -o default -F _brew brew
 else
     complete -o bashdefault -o default -F _brew brew

--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -72,7 +72,7 @@ __brew_complete_formulae ()
 __brew_complete_installed ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local inst=$(\ls $(brew --cellar))
+    local inst="$(command ls "$(brew --cellar)" 2>/dev/null)"
     COMPREPLY=($(compgen -W "$inst" -- "$cur"))
 }
 
@@ -94,7 +94,7 @@ __brew_complete_versions ()
 __brew_complete_logs ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local logs=$(ls ${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/})
+    local logs="$(command ls "${HOMEBREW_LOGS:-${HOME}/Library/Logs/Homebrew/}" 2>/dev/null)"
     COMPREPLY=($(compgen -W "$logs" -- "$cur"))
 }
 
@@ -316,6 +316,7 @@ _brew_linkapps ()
         return
         ;;
     esac
+    __brew_complete_installed
 }
 
 _brew_list ()
@@ -589,6 +590,11 @@ _brew ()
 
     if [[ $i -eq $COMP_CWORD ]]; then
         __brewcomp "$(brew commands --quiet --include-aliases)"
+        # Do not auto-complete "instal" abbreviation for "install" command.
+        # Prefix newline to prevent not checking the first command.
+        # https://github.com/Homebrew/legacy-homebrew/pull/45086
+        local cmds=$'\n'"$(brew commands --quiet --include-aliases)"
+        __brewcomp "${cmds/$'\n'instal$'\n'/$'\n'}"
         return
     fi
 
@@ -610,7 +616,7 @@ _brew ()
     install|instal|reinstall)   _brew_install ;;
     irb)                        _brew_irb ;;
     link|ln)                    _brew_link ;;
-    linkapps)                   _brew_linkapps ;;
+    linkapps|unlinkapps)        _brew_linkapps ;;
     list|ls)                    _brew_list ;;
     log)                        _brew_log ;;
     man)                        _brew_man ;;

--- a/Library/Contributions/brew_bash_completion.sh
+++ b/Library/Contributions/brew_bash_completion.sh
@@ -656,4 +656,8 @@ _brew_to_completion ()
     _brew
 }
 
-complete -o bashdefault -o default -F _brew brew
+if [ `echo "${BASH_VERSION}" | sed "s/\([0-9]*\).*/\1/"` -le 2 ]; then 
+    complete -o default -F _brew brew
+else
+    complete -o bashdefault -o default -F _brew brew
+fi

--- a/Library/Formula/bash-completion.rb
+++ b/Library/Formula/bash-completion.rb
@@ -36,8 +36,8 @@ class BashCompletion < Formula
 
   def caveats; <<-EOS.undent
     Add the following lines to your ~/.bash_profile:
-      if [ -f $(brew --prefix)/etc/bash_completion ]; then
-        . $(brew --prefix)/etc/bash_completion
+      if [ -f $(brew --prefix)/etc/bash_completion.d/brew_bash_completion.sh ]; then
+        . $(brew --prefix)/etc/bash_completion.d/brew_bash_completion.sh
       fi
 
     Homebrew's own bash completion script has been installed to


### PR DESCRIPTION
The bash autocomplete script at `Library/Contributions/brew_bash_completion.sh` gives an error when running on the default bash version (2.05b.0(1)-release) on Mac OS X 104 / Tiger: `-bash: complete: bashdefault: invalid option name`. 

Completions work on Tiger if I remove the `bashdefault` option from the `complete` command.  The script works as-is with the default bash version in Leopard (3.2.17(1)-release) and Snow Leopard (3.2.48(1)-release). 

I'm adding a test for which version of bash is in use, and using the appropriate command for bash <= 2 and bash => 3.
