### PR TITLE
frotz 2.44

### DIFF
--- a/Library/Formula/frotz.rb
+++ b/Library/Formula/frotz.rb
@@ -5,7 +5,6 @@ class Frotz < Formula
   sha256 "dbb5eb3bc95275dcb984c4bdbaea58bc1f1b085b20092ce6e86d9f0bf3ba858f"
 
   depends_on "pkg-config" => :build
-  depends_on "ncurses"
 
   resource "testdata" do
     url "https://gitlab.com/DavidGriffith/frotz/-/raw/2.53/src/test/etude/etude.z5"

--- a/Library/Formula/frotz.rb
+++ b/Library/Formula/frotz.rb
@@ -1,0 +1,29 @@
+class Frotz < Formula
+  desc "Interpreter for Infocom games and other Z-machine games"
+  homepage "https://davidgriffith.gitlab.io/frotz/"
+  url "https://gitlab.com/DavidGriffith/frotz/-/archive/2.44/frotz-2.44.tar.gz"
+  sha256 "dbb5eb3bc95275dcb984c4bdbaea58bc1f1b085b20092ce6e86d9f0bf3ba858f"
+
+  depends_on "pkg-config" => :build
+  depends_on "ncurses"
+
+  resource "testdata" do
+    url "https://gitlab.com/DavidGriffith/frotz/-/raw/2.53/src/test/etude/etude.z5"
+    sha256 "bfa2ef69f2f5ce3796b96f9b073676902e971aedb3ba690b8835bb1fb0daface"
+  end
+
+  def install
+    inreplace "Makefile", "PREFIX = /usr/local", "PREFIX = #{prefix}"
+    system "make", "all"
+    system "make", "install"
+    system "make", "install_dumb"
+  end
+
+  test do
+    resource("testdata").stage do
+      assert_match "TerpEtude", pipe_output("#{bin}/dfrotz etude.z5", ".")
+    end
+    assert_match "FROTZ", shell_output("#{bin}/frotz | head -n 1").strip
+    assert_match "FROTZ", shell_output("#{bin}/dfrotz | head -n 1").strip
+  end
+end


### PR DESCRIPTION
I'd like to submit a formula for [Frotz](https://davidgriffith.gitlab.io/frotz/), the interpreter for text adventure games.

Version 2.50 of Frotz and beyond need `_strndup`, which I think requires Mac OS X 10.7 Lion or later - but please correct me if you know a workaround for this. So version 2.44 looks to be the latest version that can be built on Mac OS X 10.4 through 10.6. 

Modern Frotz comes in three flavors - a curses-based variant, a 'dumb' variant, and an SDL/graphical variant. I'm not able to figure out the SDL variant right now, but I thought it'd be great to start with the other two while I figure out whether this version of SDL frotz is in fact buildable.

Tested on Tiger and Leopard PowerPC; and Tiger, Leopard, and Snow Leopard Intel.