### PR TITLE
scheme48 1.9.3

### DIFF
--- a/Library/Formula/scheme48.rb
+++ b/Library/Formula/scheme48.rb
@@ -1,23 +1,48 @@
 class Scheme48 < Formula
   desc "Scheme byte-code interpreter"
   homepage "http://www.s48.org/"
-  url "http://s48.org/1.9.2/scheme48-1.9.2.tgz"
-  sha256 "9c4921a90e95daee067cd2e9cc0ffe09e118f4da01c0c0198e577c4f47759df4"
+  url "https://s48.org/1.9.3/scheme48-1.9.3.tgz"
+  sha256 "6ef5a9f3fca14110b0f831b45801d11f9bdfb6799d976aa12e4f8809daf3904c"
 
   bottle do
-    sha1 "c2d1d64385b004856a2bf1e1683f49ba339c8046" => :mavericks
-    sha1 "75692a9d2fdb41ffb11f05c1be298eb33143724b" => :mountain_lion
-    sha1 "061274969680e03b26a5c2c44719a41fa417ff74" => :lion
   end
 
   conflicts_with "gambit-scheme", :because => "both install `scheme-r5rs` binaries"
   conflicts_with "scsh", :because => "both install include/scheme48.h"
 
+  # Use the included PDF/PS/HTML files and skip regeneration which requires LaTeX
+  patch :p0, :DATA
+
+  option "with-check", 'Execute "make check" before installing'
+
   def install
-    ENV.O0 if ENV.compiler == :clang
     ENV.deparallelize
-    system "./configure", "--prefix=#{prefix}", "--enable-gc=bibop"
+    system "./configure", "--prefix=#{prefix}"
     system "make"
+    system "make", "check" if build.with? "check"
     system "make", "install"
   end
 end
+__END__
+--- Makefile.in.orig	2025-05-24 14:09:09.000000000 +0100
++++ Makefile.in	2025-05-24 14:09:44.000000000 +0100
+@@ -470,7 +470,7 @@
+ 
+ doc: doc/manual.pdf doc/manual.ps doc/html/manual.html
+ 
+-install: install-no-doc install-doc
++install: install-no-doc
+ 
+ install-no-doc: enough dirs
+ # install the VM
+@@ -535,10 +535,6 @@
+ # install the documentation
+ 	$(srcdir)/mkinstalldirs $(DESTDIR)$(docdir)
+ 	$(INSTALL_DATA) $(srcdir)/COPYING $(DESTDIR)$(docdir)
+-
+-install-doc: dirs doc
+-	$(srcdir)/mkinstalldirs $(DESTDIR)$(docdir)
+-	$(INSTALL_DATA) $(srcdir)/COPYING $(DESTDIR)$(docdir)
+ 	$(INSTALL_DATA) $(srcdir)/doc/manual.pdf $(DESTDIR)$(docdir)
+ 	$(INSTALL_DATA) $(srcdir)/doc/manual.ps $(DESTDIR)$(docdir)
+ 	for f in $(srcdir)/doc/html/*; do \


### PR DESCRIPTION
Source archive comes with documentation already generated from tex files. Use them instead of regenerating which would pull in a LaTeX dependency.
No need to adjust optimisation level when building with clang (tested on 10.7 to 10.11)
bibop garbage collector is the default.
Add an option to run the test suite.

This is the first formula where I've seen noticable difference in performance with the compiler optimisation.
With default optimisation settings it took 17 minutes to build & run the test suite.
With no_optimization set, it took 55 minutes to build & run the test suite. Tested on a 1.8Ghz iMac G5.

Tested on Tiger (G5), Leopard (i386) to El Capitan with the default compiler for each OS.