### PR TITLE
frotz: install man pages

### DIFF
--- a/Library/Formula/frotz.rb
+++ b/Library/Formula/frotz.rb
@@ -13,6 +13,7 @@ class Frotz < Formula
 
   def install
     inreplace "Makefile", "PREFIX = /usr/local", "PREFIX = #{prefix}"
+    inreplace "Makefile", "MAN_PREFIX = $(PREFIX)", "MAN_PREFIX = #{man}/.."
     system "make", "all"
     system "make", "install"
     system "make", "install_dumb"


### PR DESCRIPTION
The Makefile for Frotz needs to have a variable called MAN_PREFIX defined in order to install man pages in the expected location for Tigerbrew. `frotz` now passes `brew audit --strict --online`.

Would a change like this warrant adding a `revision` number to the formula? 
