### PR TITLE
apachetop 0.18.4

### DIFF
--- a/Library/Formula/apachetop.rb
+++ b/Library/Formula/apachetop.rb
@@ -1,44 +1,31 @@
 class Apachetop < Formula
   desc "Top-like display of Apache log"
-  homepage "http://freecode.com/projects/apachetop"
-  url "https://mirrors.ocf.berkeley.edu/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz"
-  mirror "https://mirrors.kernel.org/debian/pool/main/a/apachetop/apachetop_0.12.6.orig.tar.gz"
-  sha256 "850062414517055eab2440b788b503d45ebe9b290d4b2e027a5f887ad70f3f29"
+  homepage "https://github.com/tessus/apachetop"
+  url "https://github.com/tessus/apachetop/releases/download/0.18.4/apachetop-0.18.4.tar.gz"
+  sha256 "34ee3ad380f1f7c055a96296420f15011b522781691137ea4e3a36f6bd195568"
 
-  bottle do
-    cellar :any
-    revision 1
-    sha256 "1cfb399a8548e1ac48d7cb61374e23273aa1eb289e49ba452aa2c55641fe5bae" => :yosemite
-    sha256 "78aa56c9141cfc658120edfb27e795cf178067d54f66c79fc752536d8e0335ea" => :mavericks
-    sha256 "d2383e14241b9af39c197462339393463ae6f8161dae508f49b0753dff846287" => :mountain_lion
-  end
-
-  # Freecode is officially static from this point forwards. Do not rely on it for up-to-date package information.
-  # Upstream hasn't had activity in years, patch from MacPorts
-  patch :p0, :DATA
+  head "https://github.com/tessus/apachetop.git"
 
   def install
-    system "./configure", "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--with-logfile=/var/log/apache2/access_log"
+    args = [
+      "--prefix=#{prefix}",
+      "--mandir=#{man}",
+      "--disable-debug",
+      "--disable-dependency-tracking"
+    ]
+
+    args << if MacOS.version <= :tiger then
+      "--with-logfile=/var/log/httpd/access_log"
+    else
+      "--with-logfile=/var/log/apache2/access_log"
+    end
+
+    system "./configure", *args
     system "make", "install"
   end
-end
 
-__END__
---- src/resolver.h    2005-10-15 18:10:01.000000000 +0200
-+++ src/resolver.h        2007-02-17 11:24:37.000000000 
-0100
-@@ -10,8 +10,8 @@
- class Resolver
- {
- 	public:
--	Resolver::Resolver(void);
--	Resolver::~Resolver(void);
-+	Resolver(void);
-+	~Resolver(void);
- 	int add_request(char *request, enum resolver_action act);
- 
- 
+  test do
+    output = shell_output("#{bin}/apachetop -v")
+    assert_match "ApacheTop #{version}", output
+  end
+end


### PR DESCRIPTION
Update `apachetop` to version 0.18.4, and make the following changes to the formula:
* Use new homepage and Github URLs, tracking the ones being used upstream
* add `head`
* Remove unused bottle hashes
* Update `--with-logfile` to reflect correct Apache `httpd` logfile location on Tiger
* Remove patch - this fix is upstreamed in this version of `apachetop`
* Update test to use new `-v` option

There were two `apachetop` releases after this version: [0.19.7](https://github.com/tessus/apachetop/releases/tag/0.19.7) and [0.23.2](https://github.com/tessus/apachetop/releases/tag/0.23.2). These start to take dependencies on versions of `ncurses`, `adns`, and `pcre`/ `pcre2` that I can't get to work together. This version gives a warning about missing `adns` but is otherwise fully functional.