### PR TITLE
Remove Github basic auth from gist-log command

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -103,7 +103,7 @@ module Homebrew
     end
 
     unless HOMEBREW_GITHUB_API_TOKEN
-      puts "Create a personal Github access token at: https://github.com/settings/tokens"
+      puts "Create a personal Github access token at https://github.com/settings/tokens/new?scopes=gist,public_repo"
       puts "and then set the environment variable HOMEBREW_GITHUB_API_TOKEN to its value."
       return
     end


### PR DESCRIPTION
Since Github has deprecated basic authentication, change the gist-log command to prompt the user to create a Github personal access token any time `HOMEBREW_GITHUB_API_TOKEN` isn't found in the environment, rather than attempting to fall back to basic auth and failing. This should make it clearer to a user how to successfully post a build log to Github gists.

With basic auth functionality no longer available, several lines of code that had enabled it can also be removed - doing so.

Tested on Tiger PowerPC, successfully created these gists:
* https://gist.github.com/jcgraybill/84ab625a64caf64946b5b12812cd2c3d
* https://gist.github.com/jcgraybill/6ef55bbfa9bb602d2b7b83b868fdab76

I'm also currently testing with the `--new-issue` flag, but wow does it take a long time for Ruby on one of these old Macintoshes to process the response body from a command that created the gist: I suspect it's trying to JSON parse the entire contents of the logs or something. The only thing it seems to use from the response body is the URL of the gist it just created, so a good optimization might be to do something more efficient than `Utils::JSON.load get_body(response)`.