### PR TITLE
use wayback machine for missing resources when available

### DIFF
--- a/Library/Formula/aardvark_shell_utils.rb
+++ b/Library/Formula/aardvark_shell_utils.rb
@@ -1,7 +1,7 @@
 class AardvarkShellUtils < Formula
   desc "Utilities to aid shell scripts or command-line users"
   homepage "http://www.laffeycomputer.com/shellutils.html"
-  url "http://downloads.laffeycomputer.com/current_builds/shellutils/aardvark_shell_utils-1.0.tar.gz"
+  url "https://web.archive.org/web/20220311224548/http://downloads.laffeycomputer.com/current_builds/shellutils/aardvark_shell_utils-1.0.tar.gz"
   sha256 "aa2b83d9eea416aa31dd1ce9b04054be1a504e60e46426225543476c0ebc3f67"
 
   conflicts_with "coreutils", :because => "both install `realpath` binaries"

--- a/Library/Formula/aeskeyfind.rb
+++ b/Library/Formula/aeskeyfind.rb
@@ -1,7 +1,7 @@
 class Aeskeyfind < Formula
   desc "Program for automatic key-finding"
   homepage "https://citp.princeton.edu/research/memory/code/"
-  url "https://citp.princeton.edu/memory-content/src/aeskeyfind-1.0.tar.gz"
+  url "https://web.archive.org/web/20110713071130/https://citp.princeton.edu/memory-content/src/aeskeyfind-1.0.tar.gz"
   sha256 "1417e5c1b61e86bb9527db1f5bee1995a0eea82475db3cbc880e04bf706083e4"
 
   bottle do

--- a/Library/Formula/afio.rb
+++ b/Library/Formula/afio.rb
@@ -1,7 +1,7 @@
 class Afio < Formula
   desc "Creates cpio-format archives"
   homepage "http://members.chello.nl/~k.holtman/afio.html"
-  url "http://members.chello.nl/~k.holtman/afio-2.5.1.tgz"
+  url "https://web.archive.org/web/20150801211443/http://members.chello.nl/~k.holtman/afio-2.5.1.tgz"
   sha256 "363457a5d6ee422d9b704ef56d26369ca5ee671d7209cfe799cab6e30bf2b99a"
 
   bottle do

--- a/Library/Formula/align.rb
+++ b/Library/Formula/align.rb
@@ -1,7 +1,7 @@
 class Align < Formula
   desc "Text column alignment filter"
   homepage "http://www.cs.indiana.edu/~kinzler/align/"
-  url "http://www.cs.indiana.edu/~kinzler/align/align-1.7.4.tgz"
+  url "https://web.archive.org/web/20150401190306/https://www.cs.indiana.edu/~kinzler/align/align-1.7.4.tgz"
   sha256 "4775cc92bd7d5d991b32ff360ab74cfdede06c211def2227d092a5a0108c1f03"
 
   bottle do

--- a/Library/Formula/alure.rb
+++ b/Library/Formula/alure.rb
@@ -1,7 +1,7 @@
 class Alure < Formula
   desc "Manage common tasks with OpenAL applications"
   homepage "http://kcat.strangesoft.net/alure.html"
-  url "http://kcat.strangesoft.net/alure-releases/alure-1.2.tar.bz2"
+  url "https://web.archive.org/web/20190529213651/http://kcat.strangesoft.net/alure-releases/alure-1.2.tar.bz2"
   sha256 "465e6adae68927be3a023903764662d64404e40c4c152d160e3a8838b1d70f71"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/antiword.rb
+++ b/Library/Formula/antiword.rb
@@ -1,7 +1,7 @@
 class Antiword < Formula
   desc "Utility to read Word (.doc) files"
   homepage "http://www.winfield.demon.nl/"
-  url "http://www.winfield.demon.nl/linux/antiword-0.37.tar.gz"
+  url "https://web.archive.org/web/20221117105329/http://www.winfield.demon.nl/linux/antiword-0.37.tar.gz"
   sha256 "8e2c000fcbc6d641b0e6ff95e13c846da3ff31097801e86702124a206888f5ac"
 
   resource "sample.doc" do

--- a/Library/Formula/aoeui.rb
+++ b/Library/Formula/aoeui.rb
@@ -1,7 +1,7 @@
 class Aoeui < Formula
   desc "Lightweight text editor optimized for Dvorak and QWERTY keyboards"
   homepage "http://aoeui.googlecode.com/"
-  url "https://aoeui.googlecode.com/files/aoeui-1.6.tgz"
+  url "https://web.archive.org/web/20151220201151/https://aoeui.googlecode.com/files/aoeui-1.6.tgz"
   sha256 "0655c3ca945b75b1204c5f25722ac0a07e89dd44bbf33aca068e918e9ef2a825"
   head "http://aoeui.googlecode.com/svn/trunk/"
 

--- a/Library/Formula/apel.rb
+++ b/Library/Formula/apel.rb
@@ -1,7 +1,7 @@
 class Apel < Formula
   desc "Emacs Lisp library to help write portable Emacs programs"
   homepage "http://git.chise.org/elisp/apel/"
-  url "http://git.chise.org/elisp/dist/apel/apel-10.8.tar.gz"
+  url "https://web.archive.org/web/20160318001002/http://git.chise.org/elisp/dist/apel/apel-10.8.tar.gz"
   sha256 "a511cc36bb51dc32b4915c9e03c67a994060b3156ceeab6fafa0be7874b9ccfe"
 
   def install

--- a/Library/Formula/apg.rb
+++ b/Library/Formula/apg.rb
@@ -1,7 +1,7 @@
 class Apg < Formula
   desc "Tool set for random password generation"
   homepage "http://www.adel.nursat.kz/apg/"
-  url "http://www.adel.nursat.kz/apg/download/apg-2.2.3.tar.gz"
+  url "https://web.archive.org/web/20140709074522/http://www.adel.nursat.kz/apg/download/apg-2.2.3.tar.gz"
   sha256 "69c9facde63958ad0a7630055f34d753901733d55ee759d08845a4eda2ba7dba"
 
   bottle do

--- a/Library/Formula/aqbanking.rb
+++ b/Library/Formula/aqbanking.rb
@@ -2,7 +2,7 @@ class Aqbanking < Formula
   desc "Generic online banking interface"
   homepage "http://www.aqbanking.de/"
   head "http://devel.aqbanking.de/svn/aqbanking/trunk"
-  url "http://www2.aquamaniac.de/sites/download/download.php?package=03&release=118&file=01&dummy=aqbanking-5.5.1.tar.gz"
+  url "https://web.archive.org/web/20151108044753/http://www2.aquamaniac.de/sites/download/download.php?package=03&release=118&file=01&dummy=aqbanking-5.5.1.tar.gz"
   sha256 "238f17d27d86e0cef239479c4be152cb98f5be9d6b87fca38741d32e762faddf"
 
   bottle do

--- a/Library/Formula/argyll-cms.rb
+++ b/Library/Formula/argyll-cms.rb
@@ -1,7 +1,7 @@
 class ArgyllCms < Formula
   desc "ICC compatible color management system"
   homepage "http://www.argyllcms.com/"
-  url "http://www.argyllcms.com/Argyll_V1.8.2_src.zip"
+  url "https://web.archive.org/web/20151009105931/http://www.argyllcms.com/Argyll_V1.8.2_src.zip"
   version "1.8.2"
   sha256 "59bdfaeace35d2007c90fc53234ba33bf8a64cffc08f7b27a297fc5f85455377"
   revision 1

--- a/Library/Formula/arp-sk.rb
+++ b/Library/Formula/arp-sk.rb
@@ -1,7 +1,7 @@
 class ArpSk < Formula
   desc "ARP traffic generation tool"
   homepage "http://sid.rstack.org/arp-sk/"
-  url "http://sid.rstack.org/arp-sk/files/arp-sk-0.0.16.tgz"
+  url "https://web.archive.org/web/20150802042005/http://sid.rstack.org/arp-sk/files/arp-sk-0.0.16.tgz"
   sha256 "6e1c98ff5396dd2d1c95a0d8f08f85e51cf05b1ed85ea7b5bcf73c4ca5d301dd"
 
   depends_on "libnet"

--- a/Library/Formula/asm6.rb
+++ b/Library/Formula/asm6.rb
@@ -1,7 +1,7 @@
 class Asm6 < Formula
   desc "6502 assembler"
   homepage "http://home.comcast.net/~olimar/NES/"
-  url "http://home.comcast.net/~olimar/NES/asm6.zip"
+  url "https://web.archive.org/web/20150802135329/http://home.comcast.net/~olimar/NES/asm6.zip"
   version "1.6"
   sha256 "b37956f37815a75a6712c0d1f8eea06d1207411921c2e7ff46a133f35f0b3e1d"
 

--- a/Library/Formula/aterm.rb
+++ b/Library/Formula/aterm.rb
@@ -1,7 +1,7 @@
 class Aterm < Formula
   desc "AfterStep terminal emulator"
   homepage "http://strategoxt.org/Tools/ATermFormat"
-  url "http://www.meta-environment.org/releases/aterm-2.8.tar.gz"
+  url "https://web.archive.org/web/20150503094402/http://www.meta-environment.org/releases/aterm-2.8.tar.gz"
   sha256 "bab69c10507a16f61b96182a06cdac2f45ecc33ff7d1b9ce4e7670ceeac504ef"
 
   bottle do

--- a/Library/Formula/aws-cloudsearch.rb
+++ b/Library/Formula/aws-cloudsearch.rb
@@ -1,7 +1,7 @@
 class AwsCloudsearch < Formula
   desc "Client for Amazon CloudSearch web service"
   homepage "https://aws.amazon.com/developertools/9054800585729911"
-  url "https://s3.amazonaws.com/amazon-cloudsearch-data/cloud-search-tools-v2-2.0.1.0-2014.10.27.tar.gz"
+  url "https://web.archive.org/web/20160809122222/https://s3.amazonaws.com/amazon-cloudsearch-data/cloud-search-tools-v2-2.0.1.0-2014.10.27.tar.gz"
   version "2.0.1.0-2014.10.27"
   sha256 "882a6442172957b27c0b3cd1f271531112092d4d227b528ce912b2e7ea886d51"
   revision 1

--- a/Library/Formula/backupninja.rb
+++ b/Library/Formula/backupninja.rb
@@ -2,7 +2,7 @@ class Backupninja < Formula
   desc "Backup automation tool"
   homepage "https://labs.riseup.net/code/projects/backupninja"
   head "git://labs.riseup.net/backupninja.git"
-  url "https://labs.riseup.net/code/attachments/download/275/backupninja-1.0.1.tar.gz"
+  url "https://web.archive.org/web/20150803170304/https://labs.riseup.net/code/attachments/download/275/backupninja-1.0.1.tar.gz"
   sha256 "10fa5dbcd569a082b8164cd30276dd04a238c7190d836bcba006ea3d1235e525"
 
   depends_on "dialog"

--- a/Library/Formula/baresip.rb
+++ b/Library/Formula/baresip.rb
@@ -1,7 +1,7 @@
 class Baresip < Formula
   desc "Modular SIP useragent"
   homepage "http://www.creytiv.com/"
-  url "http://www.creytiv.com/pub/baresip-0.4.13.tar.gz"
+  url "https://web.archive.org/web/20151011004124/http://www.creytiv.com/pub/baresip-0.4.13.tar.gz"
   sha256 "4f02079ae58085e61bb9363adc7139ead5865e3c032e274ba598954b19bbcdd6"
 
   bottle do

--- a/Library/Formula/bibtexconv.rb
+++ b/Library/Formula/bibtexconv.rb
@@ -1,7 +1,7 @@
 class Bibtexconv < Formula
   desc "BibTeX file converter"
   homepage "https://www.uni-due.de/~be0001/bibtexconv/"
-  url "https://www.uni-due.de/~be0001/bibtexconv/download/bibtexconv-1.1.3.tar.gz"
+  url "https://web.archive.org/web/20241220122359/https://www.nntb.no/~dreibh/bibtexconv/download/bibtexconv-1.1.3.tar.gz"
   sha256 "f7fd69ff99cd48a77e53aed4219defaf1f45485a07978faec01c2b9074886e03"
   revision 1
 

--- a/Library/Formula/blazeblogger.rb
+++ b/Library/Formula/blazeblogger.rb
@@ -1,7 +1,7 @@
 class Blazeblogger < Formula
   desc "CMS for the command-line"
   homepage "http://blaze.blackened.cz/"
-  url "https://blazeblogger.googlecode.com/files/blazeblogger-1.2.0.tar.gz"
+  url "https://web.archive.org/web/20151219000642/https://blazeblogger.googlecode.com/files/blazeblogger-1.2.0.tar.gz"
   sha256 "39024b70708be6073e8aeb3943eb3b73d441fbb7b8113e145c0cf7540c4921aa"
 
   bottle do

--- a/Library/Formula/bokken.rb
+++ b/Library/Formula/bokken.rb
@@ -1,7 +1,7 @@
 class Bokken < Formula
   desc "GUI for the Pyew and Radare projects"
   homepage "https://inguma.eu/projects/bokken"
-  url "https://inguma.eu/attachments/download/197/bokken-1.6.tar.gz"
+  url "https://web.archive.org/web/20140621065153/https://inguma.eu/attachments/download/197/bokken-1.6.tar.gz"
   sha256 "4770602585b3e77b2977a8a6906c91ae0d64373eae328f42688106224c8bbc12"
 
   bottle do

--- a/Library/Formula/bsdiff.rb
+++ b/Library/Formula/bsdiff.rb
@@ -1,7 +1,7 @@
 class Bsdiff < Formula
   desc "Generate and apply patches to binary files"
   homepage "http://www.daemonology.net/bsdiff"
-  url "http://www.daemonology.net/bsdiff/bsdiff-4.3.tar.gz"
+  url "https://web.archive.org/web/20191231064036/http://www.daemonology.net/bsdiff/bsdiff-4.3.tar.gz"
   sha256 "18821588b2dc5bf159aa37d3bcb7b885d85ffd1e19f23a0c57a58723fea85f48"
 
   depends_on "bsdmake" => :build

--- a/Library/Formula/btparse.rb
+++ b/Library/Formula/btparse.rb
@@ -1,7 +1,7 @@
 class Btparse < Formula
   desc "BibTeX utility libraries"
   homepage "http://www.gerg.ca/software/btOOL/"
-  url "http://www.gerg.ca/software/btOOL/btparse-0.34.tar.gz"
+  url "https://web.archive.org/web/20240805005210/http://www.gerg.ca/software/btOOL/btparse-0.34.tar.gz"
   sha256 "e8e2b6ae5de85d1c6f0dc52e8210aec51faebeee6a6ddc9bd975b110cec62698"
 
   bottle do

--- a/Library/Formula/cadubi.rb
+++ b/Library/Formula/cadubi.rb
@@ -1,7 +1,7 @@
 class Cadubi < Formula
   desc "Creative ASCII drawing utility"
   homepage "http://langworth.com/pub/cadubi/"
-  url "http://langworth.com/pub/cadubi-1.3.tar.gz"
+  url "https://web.archive.org/web/20051217142307/https://langworth.com/pub/cadubi-1.3.tar.gz"
   sha256 "ca8b6ea305e0eccb11add7fc165beeee7ef33f9f0106e84efa1b364f082df0ab"
 
   def install

--- a/Library/Formula/camlp5.rb
+++ b/Library/Formula/camlp5.rb
@@ -1,7 +1,7 @@
 class Camlp5 < Formula
   desc "Camlp5 is a preprocessor and pretty-printer for OCaml"
   homepage "http://camlp5.gforge.inria.fr/"
-  url "http://camlp5.gforge.inria.fr/distrib/src/camlp5-6.14.tgz"
+  url "https://web.archive.org/web/20161224175010/http://camlp5.gforge.inria.fr/distrib/src/camlp5-6.14.tgz"
   sha256 "09f9ed12893d2ec39c88106af2306865c966096bedce0250f2fe52b67d2480e2"
 
   bottle do

--- a/Library/Formula/caudec.rb
+++ b/Library/Formula/caudec.rb
@@ -1,7 +1,7 @@
 class Caudec < Formula
   desc "Covert audio files from one format to another"
   homepage "http://caudec.net"
-  url "http://caudec.net/downloads/caudec-1.7.5.tar.gz"
+  url "https://web.archive.org/web/20150803012222/http://caudec.net/downloads/caudec-1.7.5.tar.gz"
   sha256 "5d1f5ab3286bb748bd29cbf45df2ad2faf5ed86070f90deccf71c60be832f3d5"
   bottle do
     sha1 "e225732d654439421126d0c4192a0a778dc5c031" => :yosemite

--- a/Library/Formula/cconv.rb
+++ b/Library/Formula/cconv.rb
@@ -1,7 +1,7 @@
 class Cconv < Formula
   desc "Iconv based simplified-traditional Chinese conversion tool"
   homepage "https://code.google.com/p/cconv/"
-  url "https://cconv.googlecode.com/files/cconv-0.6.2.tar.gz"
+  url "https://web.archive.org/web/20150802073135/https://cconv.googlecode.com/files/cconv-0.6.2.tar.gz"
   sha256 "f463da66c2ae18407441e12716f5f1c6cdea4e417ebfd475ec4c6dc6ad250c9d"
 
   bottle do

--- a/Library/Formula/cgal.rb
+++ b/Library/Formula/cgal.rb
@@ -1,7 +1,7 @@
 class Cgal < Formula
   desc "CGAL: Computational Geometry Algorithm Library"
   homepage "http://www.cgal.org/"
-  url "https://gforge.inria.fr/frs/download.php/file/35138/CGAL-4.6.3.tar.gz"
+  url "https://web.archive.org/web/20170318012431/https://gforge.inria.fr/frs/download.php/file/35138/CGAL-4.6.3.tar.gz"
   sha256 "f90fc9d319a0bdb66b09570a8a0399671c25caeb5db1dc8c555f876d795c74ff"
 
   bottle do

--- a/Library/Formula/cgvg.rb
+++ b/Library/Formula/cgvg.rb
@@ -1,7 +1,7 @@
 class Cgvg < Formula
   desc "Command-line source browsing tool"
   homepage "http://www.uzix.org/cgvg.html"
-  url "http://www.uzix.org/cgvg/cgvg-1.6.3.tar.gz"
+  url "https://web.archive.org/web/20241214063952/https://www.uzix.org/cgvg/cgvg-1.6.3.tar.gz"
   sha256 "d879f541abcc988841a8d86f0c0781ded6e70498a63c9befdd52baf4649a12f3"
 
   bottle do

--- a/Library/Formula/cifer.rb
+++ b/Library/Formula/cifer.rb
@@ -1,7 +1,7 @@
 class Cifer < Formula
   desc "Work on automating classical cipher cracking in C"
   homepage "https://code.google.com/p/cifer/"
-  url "https://cifer.googlecode.com/files/cifer-1.2.0.tar.gz"
+  url "https://web.archive.org/web/20151229155239/https://cifer.googlecode.com/files/cifer-1.2.0.tar.gz"
   sha256 "436816c1f9112b8b80cf974596095648d60ffd47eca8eb91fdeb19d3538ea793"
 
   bottle do

--- a/Library/Formula/cityhash.rb
+++ b/Library/Formula/cityhash.rb
@@ -1,7 +1,7 @@
 class Cityhash < Formula
   desc "Hash functions for strings"
   homepage "https://code.google.com/p/cityhash/"
-  url "https://cityhash.googlecode.com/files/cityhash-1.1.1.tar.gz"
+  url "https://web.archive.org/web/20150608162837/https://cityhash.googlecode.com/files/cityhash-1.1.1.tar.gz"
   sha256 "76a41e149f6de87156b9a9790c595ef7ad081c321f60780886b520aecb7e3db4"
 
   def install

--- a/Library/Formula/clamz.rb
+++ b/Library/Formula/clamz.rb
@@ -1,7 +1,7 @@
 class Clamz < Formula
   desc "Download MP3 files from Amazon's music store"
   homepage "https://code.google.com/p/clamz/"
-  url "https://clamz.googlecode.com/files/clamz-0.5.tar.gz"
+  url "https://web.archive.org/web/20160101093820/https://clamz.googlecode.com/files/clamz-0.5.tar.gz"
   sha256 "5a63f23f15dfa6c2af00ff9531ae9bfcca0facfe5b1aa82790964f050a09832b"
   revision 1
 

--- a/Library/Formula/cln.rb
+++ b/Library/Formula/cln.rb
@@ -1,7 +1,7 @@
 class Cln < Formula
   desc "CLN: Class Library for Numbers"
   homepage "http://www.ginac.de/CLN/"
-  url "http://www.ginac.de/CLN/cln-1.3.4.tar.bz2"
+  url "https://web.archive.org/web/20180627172742/https://www.ginac.de/CLN/cln-1.3.4.tar.bz2"
   sha256 "2d99d7c433fb60db1e28299298a98354339bdc120d31bb9a862cafc5210ab748"
 
   bottle do

--- a/Library/Formula/clockywock.rb
+++ b/Library/Formula/clockywock.rb
@@ -1,7 +1,7 @@
 class Clockywock < Formula
   desc "Ncurses analog clock"
   homepage "http://soomka.com/"
-  url "http://soomka.com/clockywock-0.3.1a.tar.gz"
+  url "https://web.archive.org/web/20160205085241/http://soomka.com/clockywock-0.3.1a.tar.gz"
   sha256 "278c01e0adf650b21878e593b84b3594b21b296d601ee0f73330126715a4cce4"
 
   def install

--- a/Library/Formula/cloudbees-sdk.rb
+++ b/Library/Formula/cloudbees-sdk.rb
@@ -1,7 +1,7 @@
 class CloudbeesSdk < Formula
   desc "Command-line tools to make use of the CloudBees Platform"
   homepage "http://wiki.cloudbees.com/bin/view/RUN/BeesSDK"
-  url "http://cloudbees-downloads.s3.amazonaws.com/sdk/cloudbees-sdk-1.5.2-bin.zip"
+  url "https://web.archive.org/web/20131112010850/http://cloudbees-downloads.s3.amazonaws.com/sdk/cloudbees-sdk-1.5.2-bin.zip"
   sha256 "48deb95a01e314c24ffa84b7ac99f98bfa24d9eea8e5883a18c7bd09a240ea8b"
 
   def shim_script(target)

--- a/Library/Formula/cmigemo.rb
+++ b/Library/Formula/cmigemo.rb
@@ -3,7 +3,7 @@ class Cmigemo < Formula
   homepage "http://www.kaoriya.net/software/cmigemo"
 
   stable do
-    url "https://cmigemo.googlecode.com/files/cmigemo-default-src-20110227.zip"
+  url "https://web.archive.org/web/20151231170526/https://cmigemo.googlecode.com/files/cmigemo-default-src-20110227.zip"
     sha256 "4aa759b2e055ef3c3fbeb9e92f7f0aacc1fd1f8602fdd2f122719793ee14414c"
 
     # Patch per discussion at: https://github.com/Homebrew/homebrew/pull/7005

--- a/Library/Formula/cmockery.rb
+++ b/Library/Formula/cmockery.rb
@@ -1,7 +1,7 @@
 class Cmockery < Formula
   desc "Unit testing and mocking library for C"
   homepage "https://code.google.com/p/cmockery/"
-  url "https://cmockery.googlecode.com/files/cmockery-0.1.2.tar.gz"
+  url "https://web.archive.org/web/20160529000312/https://cmockery.googlecode.com/files/cmockery-0.1.2.tar.gz"
   sha256 "b9e04bfbeb45ceee9b6107aa5db671c53683a992082ed2828295e83dc84a8486"
 
   # This patch will be integrated upstream in 0.1.3, this is due to malloc.h being already in stdlib on OSX

--- a/Library/Formula/colordiff.rb
+++ b/Library/Formula/colordiff.rb
@@ -1,7 +1,7 @@
 class Colordiff < Formula
   desc "Color-highlighted diff(1) output"
   homepage "http://www.colordiff.org/"
-  url "http://www.colordiff.org/colordiff-1.0.15.tar.gz"
+  url "https://web.archive.org/web/20150813181636/https://www.colordiff.org/colordiff-1.0.15.tar.gz"
   sha256 "595ee4e9796ba02fad0b181e21df3ee34ae71d1611e301e146c0bf00c5269d45"
 
   bottle do

--- a/Library/Formula/colorsvn.rb
+++ b/Library/Formula/colorsvn.rb
@@ -1,7 +1,7 @@
 class Colorsvn < Formula
   desc "Subversion output colorizer"
   homepage "http://colorsvn.tigris.org/"
-  url "http://colorsvn.tigris.org/files/documents/4414/49311/colorsvn-0.3.3.tar.gz"
+  url "https://web.archive.org/web/20150802015113/http://colorsvn.tigris.org/files/documents/4414/49311/colorsvn-0.3.3.tar.gz"
   sha256 "db58d5b8f60f6d4def14f8f102ff137b87401257680c1acf2bce5680b801394e"
 
   bottle do

--- a/Library/Formula/cpp-netlib.rb
+++ b/Library/Formula/cpp-netlib.rb
@@ -1,7 +1,7 @@
 class CppNetlib < Formula
   desc "C++ libraries for high level network programming"
   homepage "http://cpp-netlib.org"
-  url "http://downloads.cpp-netlib.org/0.11.2/cpp-netlib-0.11.2-final.tar.gz"
+  url "https://web.archive.org/web/20160416122746/http://downloads.cpp-netlib.org/0.11.2/cpp-netlib-0.11.2-final.tar.gz"
   version "0.11.2"
   sha256 "71953379c5a6fab618cbda9ac6639d87b35cab0600a4450a7392bc08c930f2b1"
 

--- a/Library/Formula/cputhrottle.rb
+++ b/Library/Formula/cputhrottle.rb
@@ -1,7 +1,7 @@
 class Cputhrottle < Formula
   desc "Limit the CPU usage of a process"
   homepage "http://www.willnolan.com/cputhrottle/cputhrottle.html"
-  url "http://www.willnolan.com/cputhrottle/cputhrottle.tar.gz"
+  url "https://web.archive.org/web/20160307153059/http://www.willnolan.com/cputhrottle/cputhrottle.tar.gz"
   sha256 "fdf284e1c278e4a98417bbd3eeeacf40db684f4e79a9d4ae030632957491163b"
   version "20100515"
 

--- a/Library/Formula/crm114.rb
+++ b/Library/Formula/crm114.rb
@@ -1,7 +1,7 @@
 class Crm114 < Formula
   desc "Examine, sort, filter or alter logs or data streams"
   homepage "http://crm114.sourceforge.net/"
-  url "http://crm114.sourceforge.net/tarballs/crm114-20100106-BlameMichelson.src.tar.gz"
+  url "https://web.archive.org/web/20150804034806/https://crm114.sourceforge.net/tarballs/crm114-20100106-BlameMichelson.src.tar.gz"
   sha256 "fb626472eca43ac2bc03526d49151c5f76b46b92327ab9ee9c9455210b938c2b"
 
   depends_on "tre"

--- a/Library/Formula/csmith.rb
+++ b/Library/Formula/csmith.rb
@@ -1,7 +1,7 @@
 class Csmith < Formula
   desc "Generates random C programs conforming to the C99 standard"
   homepage "https://embed.cs.utah.edu/csmith/"
-  url "https://embed.cs.utah.edu/csmith/csmith-2.2.0.tar.gz"
+  url "https://web.archive.org/web/20230316072811/https://embed.cs.utah.edu/csmith/csmith-2.2.0.tar.gz"
   sha256 "62fd96d3a5228241d4f3159511ad3ff5b8c4cedb9e9a82adc935830b421c8e37"
 
   bottle do

--- a/Library/Formula/cvc4.rb
+++ b/Library/Formula/cvc4.rb
@@ -1,7 +1,7 @@
 class Cvc4 < Formula
   desc "Open-source automatic theorem prover for SMT "
   homepage "https://cvc4.cs.nyu.edu/"
-  url "https://cvc4.cs.nyu.edu/builds/src/cvc4-1.4.tar.gz"
+  url "https://web.archive.org/web/20150803003203/https://cvc4.cs.nyu.edu/builds/src/cvc4-1.4.tar.gz"
   sha256 "76fe4ff9eb9ad7d65589efb47d41aae95f3191bd0d0c3940698a7cb2df3f7024"
 
   bottle do

--- a/Library/Formula/cvs2svn.rb
+++ b/Library/Formula/cvs2svn.rb
@@ -17,7 +17,7 @@ end
 class Cvs2svn < Formula
   desc "Tool for converting from CVS to Subversion"
   homepage "http://cvs2svn.tigris.org/"
-  url "http://cvs2svn.tigris.org/files/documents/1462/49237/cvs2svn-2.4.0.tar.gz"
+  url "https://web.archive.org/web/20150802093003/http://cvs2svn.tigris.org/files/documents/1462/49237/cvs2svn-2.4.0.tar.gz"
   sha256 "a6677fc3e7b4374020185c61c998209d691de0c1b01b53e59341057459f6f116"
 
   depends_on PythonWithGdbmRequirement

--- a/Library/Formula/darkhttpd.rb
+++ b/Library/Formula/darkhttpd.rb
@@ -1,7 +1,7 @@
 class Darkhttpd < Formula
   desc "Small static webserver without CGI"
   homepage "http://unix4lyfe.org/darkhttpd/"
-  url "http://unix4lyfe.org/darkhttpd/darkhttpd-1.10.tar.bz2"
+  url "https://web.archive.org/web/20140702211639/https://unix4lyfe.org/darkhttpd/darkhttpd-1.10.tar.bz2"
   sha256 "b5a9bcfe6e65a3fc20f96e6badb5da7ba776a792f13fe90015fe9f63b3c2eb63"
 
   def install

--- a/Library/Formula/darkice.rb
+++ b/Library/Formula/darkice.rb
@@ -1,7 +1,7 @@
 class Darkice < Formula
   desc "Live audio streamer"
   homepage "https://code.google.com/p/darkice/"
-  url "https://darkice.googlecode.com/files/darkice-1.2.tar.gz"
+  url "https://web.archive.org/web/20151226113315/https://darkice.googlecode.com/files/darkice-1.2.tar.gz"
   sha256 "b3fba9be2d9c72f36b0659cd9ce0652c8f973b5c6498407f093da9a364fdb254"
 
   head "http://darkice.googlecode.com/svn/darkice/branches/darkice-macosx"

--- a/Library/Formula/dcal.rb
+++ b/Library/Formula/dcal.rb
@@ -1,7 +1,7 @@
 class Dcal < Formula
   desc "dcal(1) is to cal(1) what ddate(1) is to date(1)"
   homepage "http://alexeyt.freeshell.org/"
-  url "http://alexeyt.freeshell.org/code/dcal.c"
+  url "https://web.archive.org/web/20150325065543/http://alexeyt.freeshell.org/code/dcal.c"
   version "0.1.0"
   sha256 "d637fd27fc8d2a3c567b215fc05ee0fd9d88ba9fc5ddd5f0b07af3b8889dcba7"
 

--- a/Library/Formula/di.rb
+++ b/Library/Formula/di.rb
@@ -1,7 +1,7 @@
 class Di < Formula
   desc "Advanced df-like disk information utility"
   homepage "http://www.gentoo.com/di/"
-  url "http://gentoo.com/di/di-4.36.tar.gz"
+  url "https://web.archive.org/web/20150919194332/https://gentoo.com/di/di-4.36.tar.gz"
   sha256 "eb03d2ac0a3df531cdcb64b3667dbaebede60a4d3a4626393639cecb954c6d86"
 
   bottle do

--- a/Library/Formula/dieharder.rb
+++ b/Library/Formula/dieharder.rb
@@ -1,7 +1,7 @@
 class Dieharder < Formula
   desc "Random number test suite"
   homepage "https://www.phy.duke.edu/~rgb/General/dieharder.php"
-  url "https://www.phy.duke.edu/~rgb/General/dieharder/dieharder-3.31.1.tgz"
+  url "https://web.archive.org/web/20250517215916/https://webhome.phy.duke.edu/~rgb/General/dieharder/dieharder-3.31.1.tgz"
   sha256 "6cff0ff8394c553549ac7433359ccfc955fb26794260314620dfa5e4cd4b727f"
 
   bottle do

--- a/Library/Formula/dircproxy.rb
+++ b/Library/Formula/dircproxy.rb
@@ -1,7 +1,7 @@
 class Dircproxy < Formula
   desc "IRC proxy server (AKA 'bouncer')"
   homepage "https://code.google.com/p/dircproxy/"
-  url "https://dircproxy.googlecode.com/files/dircproxy-1.2.0-RC1.tar.gz"
+  url "https://web.archive.org/web/20140626073021/https://dircproxy.googlecode.com/files/dircproxy-1.2.0-RC1.tar.gz"
   sha256 "40ad50ffd13681114f995519dc3f65f48cb5eac41e780ad14ce8ffd49463757f"
 
   def install

--- a/Library/Formula/distcc.rb
+++ b/Library/Formula/distcc.rb
@@ -10,7 +10,7 @@ end
 class Distcc < Formula
   desc "Distributed compiler client and server"
   homepage "https://code.google.com/p/distcc/"
-  url "https://distcc.googlecode.com/files/distcc-3.2rc1.tar.gz"
+  url "https://web.archive.org/web/20160107225818/https://distcc.googlecode.com/files/distcc-3.2rc1.tar.gz"
   sha256 "8cf474b9e20f5f3608888c6bff1b5f804a9dfc69ae9704e3d5bdc92f0487760a"
 
   depends_on PythonWithoutPPCRequirement

--- a/Library/Formula/dnscrypt-proxy.rb
+++ b/Library/Formula/dnscrypt-proxy.rb
@@ -1,7 +1,7 @@
 class DnscryptProxy < Formula
   desc "Secure communications between a client and a DNS resolver"
   homepage "http://dnscrypt.org"
-  url "https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.6.0/dnscrypt-proxy-1.6.0.tar.bz2"
+  url "https://web.archive.org/web/20160320075136/https://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-proxy-1.6.0.tar.bz2"
   mirror "https://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-proxy-1.6.0.tar.bz2"
   sha256 "e0cce91dc6ab4ed76478579a899b2abb888b1d7ed133cb55294c2f9ce24edc7d"
 

--- a/Library/Formula/dnsmap.rb
+++ b/Library/Formula/dnsmap.rb
@@ -1,7 +1,7 @@
 class Dnsmap < Formula
   desc "Passive DNS network mapper (a.k.a. subdomains bruteforcer)"
   homepage "https://code.google.com/p/dnsmap/"
-  url "https://dnsmap.googlecode.com/files/dnsmap-0.30.tar.gz"
+  url "https://web.archive.org/web/20160208212819/https://dnsmap.googlecode.com/files/dnsmap-0.30.tar.gz"
   sha256 "fcf03a7b269b51121920ac49f7d450241306cfff23c76f3da94b03792f6becbc"
 
   def install

--- a/Library/Formula/dnsrend.rb
+++ b/Library/Formula/dnsrend.rb
@@ -1,7 +1,7 @@
 class Dnsrend < Formula
   desc "DNS message dissector"
   homepage "http://romana.now.ie/dnsrend"
-  url "http://romana.now.ie/software/dnsrend-0.08.tar.gz"
+  url "https://web.archive.org/web/20160305185927/https://romana.now.ie/software/dnsrend-0.08.tar.gz"
   sha256 "32fa6965f68e7090af7e4a9a06de53d12f40397f644a76cf97b6b4cb138da93a"
 
   bottle do

--- a/Library/Formula/dvd+rw-tools.rb
+++ b/Library/Formula/dvd+rw-tools.rb
@@ -1,7 +1,7 @@
 class DvdxrwTools < Formula
   desc "DVD+-RW/R tools"
   homepage "http://fy.chalmers.se/~appro/linux/DVD+RW/"
-  url "http://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-7.1.tar.gz"
+  url "https://web.archive.org/web/20241229001828/https://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-7.1.tar.gz"
   sha256 "f8d60f822e914128bcbc5f64fbe3ed131cbff9045dca7e12c5b77b26edde72ca"
 
   # Respect $PREFIX

--- a/Library/Formula/dwarf.rb
+++ b/Library/Formula/dwarf.rb
@@ -1,7 +1,7 @@
 class Dwarf < Formula
   desc "Object file manipulation tool"
   homepage "https://code.google.com/p/dwarf-ng/"
-  url "https://dwarf-ng.googlecode.com/files/dwarf-0.3.0.tar.gz"
+  url "https://web.archive.org/web/20160108071240/https://dwarf-ng.googlecode.com/files/dwarf-0.3.0.tar.gz"
   sha256 "85062d0d3e8aa31374dd085cb79ce02c2b8737e9b143f640a262556233715763"
   revision 1
 

--- a/Library/Formula/eet.rb
+++ b/Library/Formula/eet.rb
@@ -1,7 +1,7 @@
 class Eet < Formula
   desc "Library for writing arbitrary chunks of data to a file using compression"
   homepage "https://docs.enlightenment.org/auto/eet/eet_main.html"
-  url "https://download.enlightenment.org/releases/eet-1.7.10.tar.gz"
+  url "https://web.archive.org/web/20150401042413/https://download.enlightenment.org/releases/eet-1.7.10.tar.gz"
   sha256 "c424821eb8ba09884d3011207b1ecec826bc45a36969cd4978b78f298daae1ee"
   revision 1
 

--- a/Library/Formula/eigen.rb
+++ b/Library/Formula/eigen.rb
@@ -1,7 +1,7 @@
 class Eigen < Formula
   desc "C++ template library for linear algebra"
   homepage "http://eigen.tuxfamily.org/"
-  url "https://bitbucket.org/eigen/eigen/get/3.2.5.tar.bz2"
+  url "https://web.archive.org/web/20170331153103/https://bitbucket.org/eigen/eigen/get/3.2.5.tar.bz2"
   sha256 "5f6e6cb88188e34185f43cb819d7dab9b48ef493774ff834e568f4805d3dc2f9"
 
   bottle do

--- a/Library/Formula/eina.rb
+++ b/Library/Formula/eina.rb
@@ -1,7 +1,7 @@
 class Eina < Formula
   desc "Eina is a core data structure and common utility library"
   homepage "https://docs.enlightenment.org/auto/eina/eina_main.html"
-  url "https://download.enlightenment.org/releases/eina-1.7.10.tar.gz"
+  url "https://web.archive.org/web/20150330161731/https://download.enlightenment.org/releases/eina-1.7.10.tar.gz"
   sha256 "3f33ae45c927faedf8d342106136ef1269cf8dde6648c8165ce55e72341146e9"
 
   bottle do

--- a/Library/Formula/embryo.rb
+++ b/Library/Formula/embryo.rb
@@ -1,7 +1,7 @@
 class Embryo < Formula
   desc "Version of the original Small abstract machine"
   homepage "https://docs.enlightenment.org/auto/embryo/embryo_main.html"
-  url "https://download.enlightenment.org/releases/embryo-1.7.10.tar.gz"
+  url "https://web.archive.org/web/20150330161833/https://download.enlightenment.org/releases/embryo-1.7.10.tar.gz"
   sha256 "d6700ba34d7903f53695246ca3edd3fe463ed1acbadd283219ec9678bc4989a0"
 
   bottle do

--- a/Library/Formula/evas-generic-loaders.rb
+++ b/Library/Formula/evas-generic-loaders.rb
@@ -1,7 +1,7 @@
 class EvasGenericLoaders < Formula
   desc "Extra image loaders for complex image types for Enlightenment"
   homepage "https://enlightenment.org"
-  url "https://download.enlightenment.org/rel/libs/evas_generic_loaders/evas_generic_loaders-1.14.0.tar.gz"
+  url "https://web.archive.org/web/20150924084134/https://download.enlightenment.org/rel/libs/evas_generic_loaders/evas_generic_loaders-1.14.0.tar.gz"
   sha256 "943b25427c4e77a3aeae72811557a0b1b7ec4c61aa53922a4c4faf17b3dea812"
 
   bottle do

--- a/Library/Formula/exiftool.rb
+++ b/Library/Formula/exiftool.rb
@@ -1,7 +1,7 @@
 class Exiftool < Formula
   desc "Perl lib for reading and writing EXIF metadata"
   homepage "https://exiftool.org/index.html"
-  url "https://exiftool.org/Image-ExifTool-12.74.tar.gz"
+  url "https://web.archive.org/web/20240123213025/https://exiftool.org/Image-ExifTool-12.74.tar.gz"
   sha256 "aedb28b1427c53205ab261fa31ff3feda73e7f17a0c181453651680e5666c48a"
 
   bottle do

--- a/Library/Formula/exiv2.rb
+++ b/Library/Formula/exiv2.rb
@@ -1,7 +1,7 @@
 class Exiv2 < Formula
   desc "EXIF and IPTC metadata manipulation library and tools"
   homepage "http://www.exiv2.org"
-  url "https://www.exiv2.org/releases/exiv2-0.25.tar.gz"
+  url "https://web.archive.org/web/20171226212612/https://www.exiv2.org/releases/exiv2-0.25.tar.gz"
   sha256 "c80bfc778a15fdb06f71265db2c3d49d8493c382e516cb99b8c9f9cbde36efa4"
 
   bottle do

--- a/Library/Formula/fastbit.rb
+++ b/Library/Formula/fastbit.rb
@@ -1,7 +1,7 @@
 class Fastbit < Formula
   desc "Open-source data processing library in NoSQL spirit"
   homepage "https://sdm.lbl.gov/fastbit/"
-  url "https://codeforge.lbl.gov/frs/download.php/416/fastbit-2.0.2.tar.gz"
+  url "https://web.archive.org/web/20161223165118/https://codeforge.lbl.gov/frs/download.php/416/fastbit-2.0.2.tar.gz"
   sha256 "a9d6254fcc32da6b91bf00285c7820869950bed25d74c993da49e1336fd381b4"
 
   bottle do

--- a/Library/Formula/fcgi.rb
+++ b/Library/Formula/fcgi.rb
@@ -1,7 +1,7 @@
 class Fcgi < Formula
   desc "Protocol for interfacing interactive programs with a web server"
   homepage "http://www.fastcgi.com/"
-  url "http://www.fastcgi.com/dist/fcgi-2.4.0.tar.gz"
+  url "https://web.archive.org/web/20150530054306/http://www.fastcgi.com/dist/fcgi-2.4.0.tar.gz"
   sha256 "66fc45c6b36a21bf2fbbb68e90f780cc21a9da1fffbae75e76d2b4402d3f05b9"
 
   # Fixes "dyld: Symbol not found: _environ"

--- a/Library/Formula/fex.rb
+++ b/Library/Formula/fex.rb
@@ -1,7 +1,7 @@
 class Fex < Formula
   desc "Powerful field extraction tool"
   homepage "http://www.semicomplete.com/projects/fex/"
-  url "https://semicomplete.googlecode.com/files/fex-2.0.0.tar.gz"
+  url "https://web.archive.org/web/20160617092037/https://semicomplete.googlecode.com/files/fex-2.0.0.tar.gz"
   sha256 "03043c8eac74f43173068a2e693b6f73d5b45f453a063e6da11f34455d0e374e"
 
   bottle do

--- a/Library/Formula/ffmpeg2theora.rb
+++ b/Library/Formula/ffmpeg2theora.rb
@@ -4,7 +4,7 @@ class Ffmpeg2theora < Formula
   revision 1
 
   stable do
-    url "http://v2v.cc/~j/ffmpeg2theora/downloads/ffmpeg2theora-0.29.tar.bz2"
+  url "https://web.archive.org/web/20230127154155/http://v2v.cc/~j/ffmpeg2theora/downloads/ffmpeg2theora-0.29.tar.bz2"
     sha256 "214110e2a5afdd8ff8e0be18152e893dbff5dabc1ae1d1124e64d9f93eae946d"
 
     # Fixes build with ffmpeg 2.x by removing use of deprecated constant

--- a/Library/Formula/flow-tools.rb
+++ b/Library/Formula/flow-tools.rb
@@ -1,7 +1,7 @@
 class FlowTools < Formula
   desc "Collect, send, process, and generate NetFlow data reports"
   homepage "https://code.google.com/p/flow-tools/"
-  url "https://flow-tools.googlecode.com/files/flow-tools-0.68.5.1.tar.bz2"
+  url "https://web.archive.org/web/20160102010657/https://flow-tools.googlecode.com/files/flow-tools-0.68.5.1.tar.bz2"
   sha256 "80bbd3791b59198f0d20184761d96ba500386b0a71ea613c214a50aa017a1f67"
 
   bottle do

--- a/Library/Formula/fossil.rb
+++ b/Library/Formula/fossil.rb
@@ -1,7 +1,7 @@
 class Fossil < Formula
   desc "Distributed software configuration management"
   homepage "https://www.fossil-scm.org/"
-  url "https://www.fossil-scm.org/download/fossil-src-1.33.tar.gz"
+  url "https://web.archive.org/web/20160412153946/https://www.fossil-scm.org/download/fossil-src-1.33.tar.gz"
   sha256 "6295c48289456f09e86099988058a12148dbe0051b72d413b4dff7216d6a7f3e"
 
   head "https://www.fossil-scm.org/", :using => :fossil

--- a/Library/Formula/fourstore.rb
+++ b/Library/Formula/fourstore.rb
@@ -1,7 +1,7 @@
 class Fourstore < Formula
   desc "Efficient, stable RDF database"
   homepage "http://4store.org/"
-  url "http://4store.org/download/4store-v1.1.5.tar.gz"
+  url "https://web.archive.org/web/20150801201624/http://4store.org/download/4store-v1.1.5.tar.gz"
   sha256 "2bdd6fb804288802187c5779e365eea2b3ddebce419b3da0609be38edc9e8c5b"
 
   bottle do

--- a/Library/Formula/freediameter.rb
+++ b/Library/Formula/freediameter.rb
@@ -1,7 +1,7 @@
 class Freediameter < Formula
   desc "Open source Diameter (Authentication) protocol implementation"
   homepage "http://www.freediameter.net"
-  url "http://www.freediameter.net/hg/freeDiameter/archive/1.2.0.tar.gz"
+  url "https://web.archive.org/web/20221006024529/http://www.freediameter.net/hg/freeDiameter/archive/1.2.0.tar.gz"
   sha256 "0601a7f559af6596dff8e18f5c9b17bc66de50d8e05640aa64a3403a841cb228"
   revision 2
 

--- a/Library/Formula/freeling.rb
+++ b/Library/Formula/freeling.rb
@@ -1,7 +1,7 @@
 class Freeling < Formula
   desc "Suite of language analyzers"
   homepage "http://nlp.lsi.upc.edu/freeling/"
-  url "http://devel.cpl.upc.edu/freeling/downloads/32"
+  url "https://web.archive.org/web/20170420185215/http://devel.cpl.upc.edu/freeling/downloads/32"
   version "3.1"
   sha256 "e98471ceb3f58afbe70369584d8d316323d13fcc51d09b2fd7f431a3220982ba"
   revision 4

--- a/Library/Formula/game-music-emu.rb
+++ b/Library/Formula/game-music-emu.rb
@@ -1,7 +1,7 @@
 class GameMusicEmu < Formula
   desc "Videogame music file emulator collection"
   homepage "https://code.google.com/p/game-music-emu/"
-  url "https://game-music-emu.googlecode.com/files/game-music-emu-0.6.0.tar.bz2"
+  url "https://web.archive.org/web/20160107001048/https://game-music-emu.googlecode.com/files/game-music-emu-0.6.0.tar.bz2"
   sha256 "506e81d0c61e1a26d503fbf5351503e0b31f9fbb374cb1f09979758b46a24987"
 
   head "http://game-music-emu.googlecode.com/svn/trunk/"

--- a/Library/Formula/gbdfed.rb
+++ b/Library/Formula/gbdfed.rb
@@ -1,7 +1,7 @@
 class Gbdfed < Formula
   desc "Bitmap Font Editor"
   homepage "http://sofia.nmsu.edu/~mleisher/Software/gbdfed/"
-  url "http://sofia.nmsu.edu/~mleisher/Software/gbdfed/gbdfed-1.6.tar.gz"
+  url "https://web.archive.org/web/20180628004313/http://sofia.nmsu.edu/~mleisher/Software/gbdfed/gbdfed-1.6.tar.gz"
   sha256 "8042575d23a55a3c38192e67fcb5eafd8f7aa8d723012c374acb2e0a36022943"
   revision 1
 

--- a/Library/Formula/gcore.rb
+++ b/Library/Formula/gcore.rb
@@ -1,7 +1,7 @@
 class Gcore < Formula
   desc "Produce a snapshot (core dump) of a running process"
   homepage "http://osxbook.com/book/bonus/chapter8/core/"
-  url "http://osxbook.com/book/bonus/chapter8/core/download/gcore-1.3.tar.gz"
+  url "https://web.archive.org/web/20180924035938/http://osxbook.com/book/bonus/chapter8/core/download/gcore-1.3.tar.gz"
   sha256 "6b58095c80189bb5848a4178f282102024bbd7b985f9543021a3bf1c1a36aa2a"
 
   bottle do

--- a/Library/Formula/gdal-grass.rb
+++ b/Library/Formula/gdal-grass.rb
@@ -1,7 +1,7 @@
 class GdalGrass < Formula
   desc "Geospatial Data Abstraction Library"
   homepage "http://www.gdal.org"
-  url "http://download.osgeo.org/gdal/gdal-grass-1.4.3.tar.gz"
+  url "https://web.archive.org/web/20160809053224/http://download.osgeo.org/gdal/gdal-grass-1.4.3.tar.gz"
   sha256 "ea18d1e773e8875aaf3261a6ccd2a5fa22d998f064196399dfe73d991688f1dd"
 
   depends_on "gdal"

--- a/Library/Formula/gecode.rb
+++ b/Library/Formula/gecode.rb
@@ -1,7 +1,7 @@
 class Gecode < Formula
   desc "Toolkit for developing constraint-based systems and applications"
   homepage "http://www.gecode.org/"
-  url "http://www.gecode.org/download/gecode-4.4.0.tar.gz"
+  url "https://web.archive.org/web/20150801234546/https://www.gecode.org/download/gecode-4.4.0.tar.gz"
   sha256 "430398d6900b999f92c6329636f3855f2d4e985fed420a6c4d42b46bfc97782a"
 
   bottle do

--- a/Library/Formula/get-flash-videos.rb
+++ b/Library/Formula/get-flash-videos.rb
@@ -1,7 +1,7 @@
 class GetFlashVideos < Formula
   desc "Download or play videos from various Flash-based websites"
   homepage "https://github.com/monsieurvideo/get-flash-videos"
-  url "https://get-flash-videos.googlecode.com/files/combined-get_flash_videos-1.24", :using => :nounzip
+  url "https://web.archive.org/web/20160113214146/https://get-flash-videos.googlecode.com/files/combined-get_flash_videos-1.24"
   version "1.24"
   sha256 "e41da715f817bfa1a65ae82cc4f5a82268b6e72a7f4d90ffabf89b3a522cbb91"
 

--- a/Library/Formula/git-multipush.rb
+++ b/Library/Formula/git-multipush.rb
@@ -1,7 +1,7 @@
 class GitMultipush < Formula
   desc "Push a branch to multiple remotes in one command"
   homepage "https://code.google.com/p/git-multipush/"
-  url "https://git-multipush.googlecode.com/files/git-multipush-2.3.tar.bz2"
+  url "https://web.archive.org/web/20160113225422/https://git-multipush.googlecode.com/files/git-multipush-2.3.tar.bz2"
   sha256 "1f3b51e84310673045c3240048b44dd415a8a70568f365b6b48e7970afdafb67"
 
   devel do

--- a/Library/Formula/gmail-backup.rb
+++ b/Library/Formula/gmail-backup.rb
@@ -1,7 +1,7 @@
 class GmailBackup < Formula
   desc "Backup and restore the content of your Gmail account"
   homepage "http://www.gmail-backup.com/"
-  url "https://gmail-backup-com.googlecode.com/files/gmail-backup-20110307.tar.gz"
+  url "https://web.archive.org/web/20160320143448/https://gmail-backup-com.googlecode.com/files/gmail-backup-20110307.tar.gz"
   head "http://gmail-backup-com.googlecode.com/svn/trunk"
   sha256 "caf7cb40ea580e506f90a6029a64fedaf1234093c729ca7e6e36efbd709deb93"
 

--- a/Library/Formula/gnu-prolog.rb
+++ b/Library/Formula/gnu-prolog.rb
@@ -1,7 +1,7 @@
 class GnuProlog < Formula
   desc "Prolog compiler with constraint solving"
   homepage "http://www.gprolog.org/"
-  url "http://gprolog.univ-paris1.fr/gprolog-1.4.4.tar.gz"
+  url "https://web.archive.org/web/20160305113802/http://gprolog.univ-paris1.fr/gprolog-1.4.4.tar.gz"
   sha256 "18c0e9644b33afd4dd3cdf29f94c099ad820d65e0c99da5495b1ae43b4f2b18e"
 
   bottle do

--- a/Library/Formula/google-sparsehash.rb
+++ b/Library/Formula/google-sparsehash.rb
@@ -1,7 +1,7 @@
 class GoogleSparsehash < Formula
   desc "Extremely memory-efficient hash_map implementation"
   homepage "https://code.google.com/p/google-sparsehash/"
-  url "https://sparsehash.googlecode.com/files/sparsehash-2.0.2.tar.gz"
+  url "https://web.archive.org/web/20120624134900/https://sparsehash.googlecode.com/files/sparsehash-2.0.2.tar.gz"
   sha256 "2ed639a7155607c097c2029af5f4287296595080b2e5dd2e2ebd9bbb7450b87c"
 
   bottle do

--- a/Library/Formula/gwenhywfar.rb
+++ b/Library/Formula/gwenhywfar.rb
@@ -1,7 +1,7 @@
 class Gwenhywfar < Formula
   desc "Utility library required by aqbanking and related software"
   homepage "http://www.aqbanking.de/"
-  url "http://www.aquamaniac.de/sites/download/download.php?package=01&release=78&file=01&dummy=gwenhywfar-4.13.1.tar.gz"
+  url "https://web.archive.org/web/20160518092545/https://www.aquamaniac.de/sites/download/download.php?package=01&release=78&file=01&dummy=gwenhywfar-4.13.1.tar.gz"
   sha256 "4beca892c1235548ea0ae30132a6d2e57911c22340746585395ccb01d84ec72b"
   head "http://git.aqbanking.de/git/gwenhywfar.git"
 

--- a/Library/Formula/hexedit.rb
+++ b/Library/Formula/hexedit.rb
@@ -1,7 +1,7 @@
 class Hexedit < Formula
   desc "View and edit files in hexadecimal or ASCII"
   homepage "http://rigaux.org/hexedit.html"
-  url "http://rigaux.org/hexedit-1.2.13.src.tgz"
+  url "https://web.archive.org/web/20230707062046/http://rigaux.org/hexedit-1.2.13.src.tgz"
   sha256 "6a126da30a77f5c0b08038aa7a881d910e3b65d13767fb54c58c983963b88dd7"
 
   bottle do

--- a/Library/Formula/hostdb.rb
+++ b/Library/Formula/hostdb.rb
@@ -1,7 +1,7 @@
 class Hostdb < Formula
   desc "Generate DNS zones and DHCP configuration from hostlist.txt"
   homepage "https://code.google.com/p/hostdb/"
-  url "https://hostdb.googlecode.com/files/hostdb-1.004.tgz"
+  url "https://web.archive.org/web/20160115122234/https://hostdb.googlecode.com/files/hostdb-1.004.tgz"
   sha256 "beea7cfcdc384eb40d0bc8b3ad2eb094ee81ca75e8eef7c07ea4a47e9f0da350"
 
   def install

--- a/Library/Formula/hqx.rb
+++ b/Library/Formula/hqx.rb
@@ -1,7 +1,7 @@
 class Hqx < Formula
   desc "Magnification filter designed for pixel art"
   homepage "https://code.google.com/p/hqx/"
-  url "https://hqx.googlecode.com/files/hqx-1.1.tar.gz"
+  url "https://web.archive.org/web/20160110193931/https://hqx.googlecode.com/files/hqx-1.1.tar.gz"
   sha256 "cc18f571fb4bc325317892e39ecd5711c4901831926bc93296de9ebb7b2f317b"
 
   depends_on "devil"

--- a/Library/Formula/html2text.rb
+++ b/Library/Formula/html2text.rb
@@ -1,13 +1,13 @@
 class Html2text < Formula
   desc "Advanced HTML-to-text converter"
   homepage "http://www.mbayer.de/html2text/"
-  url "http://www.mbayer.de/html2text/downloads/html2text-1.3.2a.tar.gz"
+  url "https://web.archive.org/web/20160603010554/http://www.mbayer.de/html2text/downloads/html2text-1.3.2a.tar.gz"
   sha256 "000b39d5d910b867ff7e087177b470a1e26e2819920dcffd5991c33f6d480392"
 
   # Patch provided by author. See:
   # http://www.mbayer.de/html2text/faq.shtml#sect6
   patch do
-    url "http://www.mbayer.de/html2text/downloads/patch-utf8-html2text-1.3.2a.diff"
+    url "https://web.archive.org/web/20210729215918/http://www.mbayer.de/html2text/downloads/patch-utf8-html2text-1.3.2a.diff"
     sha256 "be4e90094d2854059924cb2c59ca31a5e9e0e22d2245fa5dc0c03f604798c5d1"
   end
 

--- a/Library/Formula/htmlcompressor.rb
+++ b/Library/Formula/htmlcompressor.rb
@@ -1,7 +1,7 @@
 class Htmlcompressor < Formula
   desc "Minify HTML or XML"
   homepage "https://code.google.com/p/htmlcompressor/"
-  url "https://htmlcompressor.googlecode.com/files/htmlcompressor-1.5.3.jar"
+  url "https://web.archive.org/web/20160110234627/https://htmlcompressor.googlecode.com/files/htmlcompressor-1.5.3.jar"
   sha256 "88894e330cdb0e418e805136d424f4c262236b1aa3683e51037cdb66310cb0f9"
 
   option "with-yuicompressor", "Use YUICompressor for JS/CSS compression"

--- a/Library/Formula/htmldoc.rb
+++ b/Library/Formula/htmldoc.rb
@@ -1,7 +1,7 @@
 class Htmldoc < Formula
   desc "Convert HTML to PDF or PostScript"
   homepage "http://www.msweet.org/projects.php?Z1"
-  url "http://www.msweet.org/files/project1/htmldoc-1.8.28-source.tar.bz2"
+  url "https://web.archive.org/web/20140403153849/https://www.msweet.org/files/project1/htmldoc-1.8.28-source.tar.bz2"
   sha256 "2a688bd820ad6f7bdebb274716102dafbf4d5fcfa20a5b8d87a56b030d184732"
   revision 2
 

--- a/Library/Formula/httperf.rb
+++ b/Library/Formula/httperf.rb
@@ -1,7 +1,7 @@
 class Httperf < Formula
   desc "Tool for measuring webserver performance"
   homepage "https://code.google.com/p/httperf/"
-  url "https://httperf.googlecode.com/files/httperf-0.9.0.tar.gz"
+  url "https://web.archive.org/web/20160624002400/https://httperf.googlecode.com/files/httperf-0.9.0.tar.gz"
   sha256 "e1a0bf56bcb746c04674c47b6cfa531fad24e45e9c6de02aea0d1c5f85a2bf1c"
   revision 1
 

--- a/Library/Formula/hydra.rb
+++ b/Library/Formula/hydra.rb
@@ -1,7 +1,7 @@
 class Hydra < Formula
   desc "Network logon cracker which supports many services"
   homepage "https://www.thc.org/thc-hydra/"
-  url "https://www.thc.org/releases/hydra-8.1.tar.gz"
+  url "https://web.archive.org/web/20161116211438/https://www.thc.org/releases/hydra-8.1.tar.gz"
   sha256 "e4bc2fd11f97a8d985a38a31785c86d38cc60383e47a8f4a5c436351e5135f19"
 
   head "https://github.com/vanhauser-thc/thc-hydra.git"

--- a/Library/Formula/hyperestraier.rb
+++ b/Library/Formula/hyperestraier.rb
@@ -56,7 +56,7 @@ end
 class Hyperestraier < Formula
   desc "Full-text search system for communities"
   homepage "http://fallabs.com/hyperestraier/index.html"
-  url "http://fallabs.com/hyperestraier/hyperestraier-1.4.13.tar.gz"
+  url "https://web.archive.org/web/20160326194449/http://fallabs.com/hyperestraier/hyperestraier-1.4.13.tar.gz"
   sha256 "496f21190fa0e0d8c29da4fd22cf5a2ce0c4a1d0bd34ef70f9ec66ff5fbf63e2"
 
   depends_on "qdbm"

--- a/Library/Formula/i2p.rb
+++ b/Library/Formula/i2p.rb
@@ -1,7 +1,7 @@
 class I2p < Formula
   desc "I2P is an anonymous overlay network - a network within a network"
   homepage "https://geti2p.net"
-  url "https://download.i2p2.de/releases/0.9.21/i2pinstall_0.9.21.jar"
+  url "https://web.archive.org/web/20150903211654/https://download.i2p2.de/releases/0.9.21/i2pinstall_0.9.21.jar"
   sha256 "0238ffc6ea44099ef4fe6c20913cb4eec675c2760aea07dfe7d499addcc89cf2"
 
   depends_on :java => "1.6+"

--- a/Library/Formula/ideviceinstaller.rb
+++ b/Library/Formula/ideviceinstaller.rb
@@ -1,7 +1,7 @@
 class Ideviceinstaller < Formula
   desc "Cross-platform library and tools for communicating with iOS devices"
   homepage "http://www.libimobiledevice.org/"
-  url "http://www.libimobiledevice.org/downloads/ideviceinstaller-1.1.0.tar.bz2"
+  url "https://web.archive.org/web/20160305030748/https://libimobiledevice.org/downloads/ideviceinstaller-1.1.0.tar.bz2"
   sha256 "0821b8d3ca6153d9bf82ceba2706f7bd0e3f07b90a138d79c2448e42362e2f53"
   revision 1
 

--- a/Library/Formula/idnits.rb
+++ b/Library/Formula/idnits.rb
@@ -1,7 +1,7 @@
 class Idnits < Formula
   desc "Looks for problems in internet draft formatting"
   homepage "https://tools.ietf.org/tools/idnits/"
-  url "https://tools.ietf.org/tools/idnits/idnits-2.13.02.tgz"
+  url "https://web.archive.org/web/20160305194833/https://tools.ietf.org/tools/idnits/idnits-2.13.02.tgz"
   sha256 "6e42b044c79dc4e616d10ee9e283c20acc741601811a6acfc0c0d310afdf0823"
 
   depends_on "aspell"

--- a/Library/Formula/ike-scan.rb
+++ b/Library/Formula/ike-scan.rb
@@ -1,7 +1,7 @@
 class IkeScan < Formula
   desc "Discover and fingerprint IKE hosts"
   homepage "http://www.nta-monitor.com/tools-resources/security-tools/ike-scan"
-  url "http://www.nta-monitor.com/tools/ike-scan/download/ike-scan-1.9.tar.gz"
+  url "https://web.archive.org/web/20110925140715/http://www.nta-monitor.com/tools/ike-scan/download/ike-scan-1.9.tar.gz"
   sha256 "05d15c7172034935d1e46b01dacf1101a293ae0d06c0e14025a4507656f1a7b6"
   revision 1
 

--- a/Library/Formula/innotop.rb
+++ b/Library/Formula/innotop.rb
@@ -1,7 +1,7 @@
 class Innotop < Formula
   desc "Top clone for MySQL"
   homepage "https://code.google.com/p/innotop/"
-  url "https://innotop.googlecode.com/files/innotop-1.9.1.tar.gz"
+  url "https://web.archive.org/web/20160110222934/https://innotop.googlecode.com/files/innotop-1.9.1.tar.gz"
   sha256 "117e5af58a83af79b6cf99877b25b1479197597be5a7d51b245a0ad9c69f4d3d"
 
   depends_on :mysql

--- a/Library/Formula/ipbt.rb
+++ b/Library/Formula/ipbt.rb
@@ -1,7 +1,7 @@
 class Ipbt < Formula
   desc "Program for recording a UNIX terminal session"
   homepage "http://www.chiark.greenend.org.uk/~sgtatham/ipbt/"
-  url "http://www.chiark.greenend.org.uk/~sgtatham/ipbt/ipbt-20141026.2197432.tar.gz"
+  url "https://web.archive.org/web/20160513031554/https://www.chiark.greenend.org.uk/~sgtatham/ipbt/ipbt-20141026.2197432.tar.gz"
   sha256 "151da94da378cc88e979df8eb5f9a05c4e663bd1299c191d24c10128bae879b0"
 
   bottle do

--- a/Library/Formula/iphotoexport.rb
+++ b/Library/Formula/iphotoexport.rb
@@ -1,7 +1,7 @@
 class Iphotoexport < Formula
   desc "Export and synchronize iPhoto library to a folder tree"
   homepage "https://code.google.com/p/iphotoexport/"
-  url "https://iphotoexport.googlecode.com/files/iphotoexport-1.6.4.zip"
+  url "https://web.archive.org/web/20160114084450/https://iphotoexport.googlecode.com/files/iphotoexport-1.6.4.zip"
   sha256 "85644b5be1541580a35f1ea6144d832267f1284ac3ca23fe9bcd9eda5aaea5d3"
 
   depends_on "exiftool"

--- a/Library/Formula/ircii.rb
+++ b/Library/Formula/ircii.rb
@@ -1,7 +1,7 @@
 class Ircii < Formula
   desc "IRC and ICB client"
   homepage "http://www.eterna.com.au/ircii/"
-  url "http://ircii.warped.com/ircii-20150903.tar.bz2"
+  url "https://web.archive.org/web/20160328062029/http://ircii.warped.com/ircii-20150903.tar.bz2"
   sha256 "617502e17788d619510f3f5efc1217e6c9d3a55e8227ece591c56981b0901324"
 
   bottle do

--- a/Library/Formula/jack.rb
+++ b/Library/Formula/jack.rb
@@ -8,7 +8,7 @@
 class Jack < Formula
   desc "Jack Audio Connection Kit (JACK)"
   homepage "http://jackaudio.org"
-  url "http://jackaudio.org/downloads/jack-audio-connection-kit-0.124.1.tar.gz"
+  url "https://web.archive.org/web/20160315075626/https://jackaudio.org/downloads/jack-audio-connection-kit-0.124.1.tar.gz"
   sha256 "eb42df6065576f08feeeb60cb9355dce4eb53874534ad71534d7aa31bae561d6"
 
   bottle do

--- a/Library/Formula/jam.rb
+++ b/Library/Formula/jam.rb
@@ -1,7 +1,7 @@
 class Jam < Formula
   desc "Make-like build tool"
   homepage "http://www.perforce.com/resources/documentation/jam"
-  url "https://swarm.workshop.perforce.com/projects/perforce_software-jam/download/main/jam-2.6.zip"
+  url "https://web.archive.org/web/20180408170939/https://swarm.workshop.perforce.com/projects/perforce_software-jam/download/main/jam-2.6.zip"
   sha256 "7c510be24dc9d0912886c4364dc17a013e042408386f6b937e30bd9928d5223c"
 
   conflicts_with "ftjam", :because => "both install a `jam` binary"

--- a/Library/Formula/jemalloc.rb
+++ b/Library/Formula/jemalloc.rb
@@ -1,7 +1,7 @@
 class Jemalloc < Formula
   desc "malloc implementation emphasizing fragmentation avoidance"
   homepage "http://www.canonware.com/jemalloc/download.html"
-  url "http://www.canonware.com/download/jemalloc/jemalloc-3.6.0.tar.bz2"
+  url "https://web.archive.org/web/20150802112041/http://www.canonware.com/download/jemalloc/jemalloc-3.6.0.tar.bz2"
   sha256 "e16c2159dd3c81ca2dc3b5c9ef0d43e1f2f45b04548f42db12e7c12d7bdf84fe"
   head "https://github.com/jemalloc/jemalloc.git"
   revision 1

--- a/Library/Formula/jerm.rb
+++ b/Library/Formula/jerm.rb
@@ -1,7 +1,7 @@
 class Jerm < Formula
   desc "Communication terminal through serial and TCP/IP interfaces"
   homepage "http://www.bsddiary.net/jerm/"
-  url "http://www.bsddiary.net/jerm/jerm-8096.tar.gz"
+  url "https://web.archive.org/web/20161229162748/http://www.bsddiary.net/jerm/jerm-8096.tar.gz"
   version "0.8096"
   sha256 "8a63e34a2c6a95a67110a7a39db401f7af75c5c142d86d3ba300a7b19cbcf0e9"
 

--- a/Library/Formula/jigdo.rb
+++ b/Library/Formula/jigdo.rb
@@ -1,7 +1,7 @@
 class Jigdo < Formula
   desc "Tool to distribute very large files over the internet"
   homepage "http://atterer.org/jigdo/"
-  url "http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-0.7.3.tar.bz2"
+  url "https://web.archive.org/web/20250221145919/http://atterer.org/sites/atterer/files/2009-08/jigdo/jigdo-0.7.3.tar.bz2"
   sha256 "875c069abad67ce67d032a9479228acdb37c8162236c0e768369505f264827f0"
   revision 2
 

--- a/Library/Formula/jing.rb
+++ b/Library/Formula/jing.rb
@@ -1,7 +1,7 @@
 class Jing < Formula
   desc "RELAX NG validator"
   homepage "https://code.google.com/p/jing-trang/"
-  url "https://jing-trang.googlecode.com/files/jing-20091111.zip"
+  url "https://web.archive.org/web/20160603203949/https://jing-trang.googlecode.com/files/jing-20091111.zip"
   sha256 "57690280aa6b5521b570aaa5fe77e1b48d84b2a1b0a24da62f9b982c4416908c"
 
   def install

--- a/Library/Formula/jnettop.rb
+++ b/Library/Formula/jnettop.rb
@@ -1,7 +1,7 @@
 class Jnettop < Formula
   desc "View hosts/ports taking up the most network traffic"
   homepage "http://jnettop.kubs.info/"
-  url "http://jnettop.kubs.info/dist/jnettop-0.13.0.tar.gz"
+  url "https://web.archive.org/web/20161221100811/http://jnettop.kubs.info/dist/jnettop-0.13.0.tar.gz"
   sha256 "e987a1a9325595c8a0543ab61cf3b6d781b4faf72dd0e0e0c70b2cc2ceb5a5a0"
 
   bottle do

--- a/Library/Formula/js-test-driver.rb
+++ b/Library/Formula/js-test-driver.rb
@@ -1,7 +1,7 @@
 class JsTestDriver < Formula
   desc "JavaScript test runner"
   homepage "https://code.google.com/p/js-test-driver/"
-  url "https://js-test-driver.googlecode.com/files/JsTestDriver-1.3.5.jar"
+  url "https://web.archive.org/web/20160119105939/https://js-test-driver.googlecode.com/files/JsTestDriver-1.3.5.jar"
   sha256 "78c0ff60a76bea38db0fa6f9c9f8e003d1bfd07517f44c3879f484abfbe87a68"
 
   def install

--- a/Library/Formula/jsdoc-toolkit.rb
+++ b/Library/Formula/jsdoc-toolkit.rb
@@ -1,7 +1,7 @@
 class JsdocToolkit < Formula
   desc "Generate documentation from JavaScript source code"
   homepage "https://code.google.com/p/jsdoc-toolkit/"
-  url "https://jsdoc-toolkit.googlecode.com/files/jsdoc_toolkit-2.4.0.zip"
+  url "https://web.archive.org/web/20160119085418/https://jsdoc-toolkit.googlecode.com/files/jsdoc_toolkit-2.4.0.zip"
   sha256 "82c79957b37b193bc64cc4363220517f1c76700863f1430aef8c94ecd4917b44"
 
   conflicts_with "jsdoc3", :because => "both install jsdoc"

--- a/Library/Formula/jshon.rb
+++ b/Library/Formula/jshon.rb
@@ -1,7 +1,7 @@
 class Jshon < Formula
   desc "Parse, read, and create JSON from the shell"
   homepage "http://kmkeen.com/jshon/"
-  url "http://kmkeen.com/jshon/jshon.tar.gz"
+  url "https://web.archive.org/web/20231101165748/http://kmkeen.com/jshon/jshon.tar.gz"
   version "8"
   sha256 "bb8ffdbda89a24f15d23af06d23fc4a9a4319503eb631cc64a5eb4c25afd45fb"
 

--- a/Library/Formula/jslint4java.rb
+++ b/Library/Formula/jslint4java.rb
@@ -1,7 +1,7 @@
 class Jslint4java < Formula
   desc "Java wrapper for JavaScript Lint (jsl)"
   homepage "https://code.google.com/p/jslint4java/"
-  url "https://jslint4java.googlecode.com/files/jslint4java-2.0.5-dist.zip"
+  url "https://web.archive.org/web/20160120065334/https://jslint4java.googlecode.com/files/jslint4java-2.0.5-dist.zip"
   sha256 "078240b17256a0472f9981d68f11556238658ebaa67be49ea49958adafc96a81"
 
   def install

--- a/Library/Formula/jvmtop.rb
+++ b/Library/Formula/jvmtop.rb
@@ -1,7 +1,7 @@
 class Jvmtop < Formula
   desc "Console application for monitoring all running JVMs on a machine"
   homepage "https://code.google.com/p/jvmtop/"
-  url "https://jvmtop.googlecode.com/files/jvmtop-0.8.0.tar.gz"
+  url "https://web.archive.org/web/20160117174527/https://jvmtop.googlecode.com/files/jvmtop-0.8.0.tar.gz"
   sha256 "f9de8159240b400a51b196520b4c4f0ddbcaa8e587fab1f0a59be8a00dc128c4"
 
   def install

--- a/Library/Formula/kestrel.rb
+++ b/Library/Formula/kestrel.rb
@@ -1,7 +1,7 @@
 class Kestrel < Formula
   desc "Distributed message queue"
   homepage "https://twitter.github.io/kestrel/"
-  url "https://twitter.github.io/kestrel/download/kestrel-2.4.1.zip"
+  url "https://web.archive.org/web/20160325222003/https://twitter.github.io/kestrel/download/kestrel-2.4.1.zip"
   sha256 "5d72a301737cc6cc3908483ce73d4bdb6e96521f3f8c96f93b732d740aaea80c"
 
   def install

--- a/Library/Formula/knock.rb
+++ b/Library/Formula/knock.rb
@@ -1,7 +1,7 @@
 class Knock < Formula
   desc "Port-knock server"
   homepage "http://www.zeroflux.org/projects/knock"
-  url "http://www.zeroflux.org/proj/knock/files/knock-0.7.tar.gz"
+  url "https://web.archive.org/web/20190228180646/https://zeroflux.org/proj/knock/files/knock-0.7.tar.gz"
   sha256 "9938479c321066424f74c61f6bee46dfd355a828263dc89561a1ece3f56578a4"
 
   bottle do

--- a/Library/Formula/kstart.rb
+++ b/Library/Formula/kstart.rb
@@ -1,7 +1,7 @@
 class Kstart < Formula
   desc "Modified version of kinit that can use keytabs to authenticate"
   homepage "http://www.eyrie.org/~eagle/software/kstart/"
-  url "http://archives.eyrie.org/software/kerberos/kstart-4.1.tar.gz"
+  url "https://web.archive.org/web/20150920110240/https://archives.eyrie.org/software/kerberos/kstart-4.1.tar.gz"
   sha256 "ad1a71be149d56473319bf3b9bca83a60caa3af463d52c134e8f187103700224"
 
   def install

--- a/Library/Formula/kyoto-cabinet.rb
+++ b/Library/Formula/kyoto-cabinet.rb
@@ -1,7 +1,7 @@
 class KyotoCabinet < Formula
   desc "Library of routines for managing a database"
   homepage "http://fallabs.com/kyotocabinet/"
-  url "http://fallabs.com/kyotocabinet/pkg/kyotocabinet-1.2.76.tar.gz"
+  url "https://web.archive.org/web/20230623120636/http://fallabs.com/kyotocabinet/pkg/kyotocabinet-1.2.76.tar.gz"
   sha256 "812a2d3f29c351db4c6f1ff29d94d7135f9e601d7cc1872ec1d7eed381d0d23c"
 
   fails_with :clang do

--- a/Library/Formula/kyoto-tycoon.rb
+++ b/Library/Formula/kyoto-tycoon.rb
@@ -1,7 +1,7 @@
 class KyotoTycoon < Formula
   desc "Database server with interface to Kyoto Cabinet"
   homepage "http://fallabs.com/kyototycoon/"
-  url "http://fallabs.com/kyototycoon/pkg/kyototycoon-0.9.56.tar.gz"
+  url "https://web.archive.org/web/20161022001726/http://fallabs.com/kyototycoon/pkg/kyototycoon-0.9.56.tar.gz"
   sha256 "553e4ea83237d9153cc5e17881092cefe0b224687f7ebcc406b061b2f31c75c6"
   revision 1
 

--- a/Library/Formula/lablgtk.rb
+++ b/Library/Formula/lablgtk.rb
@@ -1,7 +1,7 @@
 class Lablgtk < Formula
   desc "Objective Caml interface to gtk+"
   homepage "http://lablgtk.forge.ocamlcore.org"
-  url "https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
+  url "https://web.archive.org/web/20160402233105/https://forge.ocamlcore.org/frs/download.php/1479/lablgtk-2.18.3.tar.gz"
   sha256 "975bebf2f9ca74dc3bf7431ebb640ff6a924bb80c8ee5f4467c475a7e4b0cbaf"
   revision 1
 

--- a/Library/Formula/languagetool.rb
+++ b/Library/Formula/languagetool.rb
@@ -1,7 +1,7 @@
 class Languagetool < Formula
   desc "Style and grammar checker"
   homepage "https://www.languagetool.org/"
-  url "https://www.languagetool.org/download/LanguageTool-3.0.zip"
+  url "https://web.archive.org/web/20230408153027/https://www.languagetool.org/download/LanguageTool-3.0.zip"
   sha256 "52f7b27a7c040db3e824bf115302ea0737a5f0b4573b0c012c2a26a96680fc3d"
 
   def server_script(server_jar); <<-EOS.undent

--- a/Library/Formula/lastfmlib.rb
+++ b/Library/Formula/lastfmlib.rb
@@ -1,7 +1,7 @@
 class Lastfmlib < Formula
   desc "Implements Last.fm v1.2 submissions protocol for scrobbling"
   homepage "https://code.google.com/p/lastfmlib/"
-  url "https://lastfmlib.googlecode.com/files/lastfmlib-0.4.0.tar.gz"
+  url "https://web.archive.org/web/20160121130748/https://lastfmlib.googlecode.com/files/lastfmlib-0.4.0.tar.gz"
   sha256 "28ecaffe2efecd5ac6ac00ba8e0a07b08e7fb35b45dfe384d88392ad6428309a"
 
   bottle do

--- a/Library/Formula/launch.rb
+++ b/Library/Formula/launch.rb
@@ -5,7 +5,7 @@ class Launch < Formula
   head "https://github.com/nriley/launch.git"
 
   stable do
-    url "http://sabi.net/nriley/software/launch-1.2.2.tar.gz"
+  url "https://web.archive.org/web/20140624180514/https://sabi.net/nriley/software/launch-1.2.2.tar.gz"
     sha256 "94509ce5b55a768f3f8da9996193ae01baf78f239a4d0fca637735f2684eed87"
 
     # Upstream commits to fix the build on 10.10+

--- a/Library/Formula/leptonica.rb
+++ b/Library/Formula/leptonica.rb
@@ -1,7 +1,7 @@
 class Leptonica < Formula
   desc "Image processing and image analysis library"
   homepage "http://www.leptonica.org/"
-  url "http://www.leptonica.org/source/leptonica-1.72.tar.gz"
+  url "https://web.archive.org/web/20160415134642/http://www.leptonica.org/source/leptonica-1.72.tar.gz"
   sha256 "79d5eadd32658c9fea38700c975d60aa3d088eaa3e307659f004d40834de1f56"
   revision 1
 

--- a/Library/Formula/lib3ds.rb
+++ b/Library/Formula/lib3ds.rb
@@ -1,7 +1,7 @@
 class Lib3ds < Formula
   desc "Library for managing 3D-Studio Release 3 and 4 '.3DS' files"
   homepage "https://code.google.com/p/lib3ds/"
-  url "https://lib3ds.googlecode.com/files/lib3ds-1.3.0.zip"
+  url "https://web.archive.org/web/20160121070418/https://lib3ds.googlecode.com/files/lib3ds-1.3.0.zip"
   sha256 "f5b00c302955a67fa5fb1f2d3f2583767cdc61fdbc6fd843c0c7c9d95c5629e3"
 
   bottle do

--- a/Library/Formula/libav.rb
+++ b/Library/Formula/libav.rb
@@ -1,7 +1,7 @@
 class Libav < Formula
   desc "Audio and video processing tools"
   homepage "https://libav.org/"
-  url "https://libav.org/releases/libav-11.4.tar.xz"
+  url "https://web.archive.org/web/20221204024951/https://libav.org/releases/libav-11.4.tar.xz"
   sha256 "0b7dabc2605f3a254ee410bb4b1a857945696aab495fe21b34c3b6544ff5d525"
   revision 1
 

--- a/Library/Formula/libb2.rb
+++ b/Library/Formula/libb2.rb
@@ -1,7 +1,7 @@
 class Libb2 < Formula
   desc "Secure hashing function"
   homepage "https://blake2.net/"
-  url "https://blake2.net/libb2-0.97.tar.gz"
+  url "https://web.archive.org/web/20150801153422/https://blake2.net/libb2-0.97.tar.gz"
   sha256 "7829c7309347650239c76af7f15d9391af2587b38f0a65c250104a2efef99051"
 
   bottle do

--- a/Library/Formula/libcaca.rb
+++ b/Library/Formula/libcaca.rb
@@ -1,7 +1,7 @@
 class Libcaca < Formula
   desc "Convert pixel information into colored ASCII art"
   homepage "http://caca.zoy.org/wiki/libcaca"
-  url "https://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz"
+  url "https://web.archive.org/web/20150317030955/https://fossies.org/linux/privat/libcaca-0.99.beta19.tar.gz"
   version "0.99b19"
   sha256 "128b467c4ed03264c187405172a4e83049342cc8cc2f655f53a2d0ee9d3772f4"
 

--- a/Library/Formula/libdap.rb
+++ b/Library/Formula/libdap.rb
@@ -1,7 +1,7 @@
 class Libdap < Formula
   desc "Framework for scientific data networking"
   homepage "http://www.opendap.org"
-  url "http://www.opendap.org/pub/source/libdap-3.12.1.tar.gz"
+  url "https://web.archive.org/web/20140815100646/http://www.opendap.org/pub/source/libdap-3.12.1.tar.gz"
   sha256 "10926129fefa9cb7050a7e501f3dc5c75b63709196b2c9e1e158b28b2dc098f2"
   revision 1
 

--- a/Library/Formula/libechonest.rb
+++ b/Library/Formula/libechonest.rb
@@ -1,7 +1,7 @@
 class Libechonest < Formula
   desc "Qt library for communicating with The Echo Nest"
   homepage "https://projects.kde.org/projects/playground/libs/libechonest"
-  url "http://files.lfranchi.com/libechonest-2.3.1.tar.bz2"
+  url "https://web.archive.org/web/20160512180410/http://files.lfranchi.com/libechonest-2.3.1.tar.bz2"
   sha256 "56756545fd1cb3d9067479f52215b6157c1ced2bc82b895e72fdcd9bebb47889"
 
   bottle do

--- a/Library/Formula/libflowmanager.rb
+++ b/Library/Formula/libflowmanager.rb
@@ -1,7 +1,7 @@
 class Libflowmanager < Formula
   desc "Flow-based measurement tasks with packet-based inputs"
   homepage "http://research.wand.net.nz/software/libflowmanager.php"
-  url "http://research.wand.net.nz/software/libflowmanager/libflowmanager-2.0.4.tar.gz"
+  url "https://web.archive.org/web/20160123055228/http://research.wand.net.nz/software/libflowmanager/libflowmanager-2.0.4.tar.gz"
   sha256 "80fbb93113fab98727b42c9b96ea09c0d817a49f884717dd27f27325e93b733c"
 
   bottle do

--- a/Library/Formula/libghthash.rb
+++ b/Library/Formula/libghthash.rb
@@ -1,7 +1,7 @@
 class Libghthash < Formula
   desc "Generic hash table for C++"
   homepage "https://www.bth.se/people/ska/sim_home/libghthash.html"
-  url "https://www.bth.se/people/ska/sim_home/filer/libghthash-0.6.2.tar.gz"
+  url "https://web.archive.org/web/20150805223850/https://www.bth.se/people/ska/sim_home/filer/libghthash-0.6.2.tar.gz"
   sha256 "d1ccbb81f4c8afd7008f56ecb874f5cf497de480f49ee06929b4303d5852a7dd"
 
   bottle do

--- a/Library/Formula/libhdhomerun.rb
+++ b/Library/Formula/libhdhomerun.rb
@@ -1,7 +1,7 @@
 class Libhdhomerun < Formula
   desc "C library for controlling SiliconDust HDHomeRun TV tuners"
   homepage "https://www.silicondust.com/support/downloads/linux/"
-  url "https://download.silicondust.com/hdhomerun/libhdhomerun_20150406.tgz"
+  url "https://web.archive.org/web/20150801132248/https://download.silicondust.com/hdhomerun/libhdhomerun_20150406.tgz"
   sha256 "fa6da8ab4461bca6cd852c41ba98bad3b58235477ed64cd96fb27aa3cea67d5a"
 
   bottle do

--- a/Library/Formula/libimobiledevice.rb
+++ b/Library/Formula/libimobiledevice.rb
@@ -1,7 +1,7 @@
 class Libimobiledevice < Formula
   desc "Library to communicate with iOS devices natively"
   homepage "http://www.libimobiledevice.org/"
-  url "http://www.libimobiledevice.org/downloads/libimobiledevice-1.2.0.tar.bz2"
+  url "https://web.archive.org/web/20160305030735/https://libimobiledevice.org/downloads/libimobiledevice-1.2.0.tar.bz2"
   sha256 "786b0de0875053bf61b5531a86ae8119e320edab724fc62fe2150cc931f11037"
 
   bottle do

--- a/Library/Formula/libiomp.rb
+++ b/Library/Formula/libiomp.rb
@@ -1,7 +1,7 @@
 class Libiomp < Formula
   desc "Manage multiple threads in an OpenMP program as it executes"
   homepage "https://www.openmprtl.org/download"
-  url "https://www.openmprtl.org/sites/default/files/libomp_20150701_oss.tgz"
+  url "https://web.archive.org/web/20151006122342/https://www.openmprtl.org/sites/default/files/libomp_20150701_oss.tgz"
   sha256 "d0c1fcb5997c53e0c9ff4eec1de3392a21308731c06e6663f9d32ceb15f14e88"
 
   depends_on :arch => :intel

--- a/Library/Formula/libkml.rb
+++ b/Library/Formula/libkml.rb
@@ -3,7 +3,7 @@ class Libkml < Formula
   homepage "https://code.google.com/p/libkml/"
 
   stable do
-    url "https://libkml.googlecode.com/files/libkml-1.2.0.tar.gz"
+  url "https://web.archive.org/web/20160316033814/https://libkml.googlecode.com/files/libkml-1.2.0.tar.gz"
     sha256 "fae9085e4cd9f0d4ae0d0626be7acf4ad5cbb37991b9d886df29daf72df37cbc"
 
     # Correct an issue where internal third-party libs (libminizip and liburiparser)

--- a/Library/Formula/liblunar.rb
+++ b/Library/Formula/liblunar.rb
@@ -1,7 +1,7 @@
 class Liblunar < Formula
   desc "Lunar date calendar"
   homepage "https://code.google.com/p/liblunar/"
-  url "https://liblunar.googlecode.com/files/liblunar-2.2.5.tar.gz"
+  url "https://web.archive.org/web/20160117090229/https://liblunar.googlecode.com/files/liblunar-2.2.5.tar.gz"
   sha256 "c24a7cd3ccbf7ab739d752a437f1879f62b975b95abcf9eb9e1dd623982bc167"
 
   bottle do

--- a/Library/Formula/libmarisa.rb
+++ b/Library/Formula/libmarisa.rb
@@ -1,7 +1,7 @@
 class Libmarisa < Formula
   desc "Static and space-efficient trie data structure"
   homepage "https://code.google.com/p/marisa-trie/"
-  url "https://marisa-trie.googlecode.com/files/marisa-0.2.4.tar.gz"
+  url "https://web.archive.org/web/20160305032243/https://marisa-trie.googlecode.com/files/marisa-0.2.4.tar.gz"
   sha256 "67a7a4f70d3cc7b0a85eb08f10bc3eaf6763419f0c031f278c1f919121729fb3"
 
   bottle do

--- a/Library/Formula/libmpeg2.rb
+++ b/Library/Formula/libmpeg2.rb
@@ -1,7 +1,7 @@
 class Libmpeg2 < Formula
   desc "Library to decode mpeg-2 and mpeg-1 video streams"
   homepage "http://libmpeg2.sourceforge.net/"
-  url "http://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
+  url "https://web.archive.org/web/20161014132830/https://libmpeg2.sourceforge.net/files/libmpeg2-0.5.1.tar.gz"
   sha256 "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
 
   bottle do

--- a/Library/Formula/libmxml.rb
+++ b/Library/Formula/libmxml.rb
@@ -1,7 +1,7 @@
 class Libmxml < Formula
   desc "Mini-XML library"
   homepage "http://www.minixml.org/"
-  url "https://www.msweet.org/files/project3/mxml-2.9.tar.gz"
+  url "https://web.archive.org/web/20160616223104/https://www.msweet.org/files/project3/mxml-2.9.tar.gz"
   sha256 "cded54653c584b24c4a78a7fa1b3b4377d49ac4f451ddf170ebbc8161d85ff92"
 
   head "http://svn.msweet.org/mxml/"

--- a/Library/Formula/libnfc.rb
+++ b/Library/Formula/libnfc.rb
@@ -1,7 +1,7 @@
 class Libnfc < Formula
   desc "Low level NFC SDK and Programmers API"
   homepage "http://www.libnfc.org/"
-  url "https://libnfc.googlecode.com/files/libnfc-1.7.0.tar.bz2"
+  url "https://web.archive.org/web/20140815093123/https://libnfc.googlecode.com/files/libnfc-1.7.0.tar.bz2"
   sha256 "f14df0727c301f9149608dc6e1fbad81ec48372dcd7a364ac1cb805a7a2b2b8b"
 
   bottle do

--- a/Library/Formula/libntlm.rb
+++ b/Library/Formula/libntlm.rb
@@ -1,7 +1,7 @@
 class Libntlm < Formula
   desc "Implements Microsoft's NTLM authentication"
   homepage "http://www.nongnu.org/libntlm/"
-  url "http://www.nongnu.org/libntlm/releases/libntlm-1.4.tar.gz"
+  url "https://web.archive.org/web/20150804071738/http://www.nongnu.org/libntlm/releases/libntlm-1.4.tar.gz"
   sha256 "8415d75e31d3135dc7062787eaf4119b984d50f86f0d004b964cdc18a3182589"
 
   bottle do

--- a/Library/Formula/libpcl.rb
+++ b/Library/Formula/libpcl.rb
@@ -1,7 +1,7 @@
 class Libpcl < Formula
   desc "C library and API for coroutines"
   homepage "http://xmailserver.org/libpcl.html"
-  url "http://xmailserver.org/pcl-1.12.tar.gz"
+  url "https://web.archive.org/web/20240805014726/http://xmailserver.org/pcl-1.12.tar.gz"
   sha256 "e7b30546765011575d54ae6b44f9d52f138f5809221270c815d2478273319e1a"
 
   bottle do

--- a/Library/Formula/libplist.rb
+++ b/Library/Formula/libplist.rb
@@ -1,7 +1,7 @@
 class Libplist < Formula
   desc "Library for Apple Binary- and XML-Property Lists"
   homepage "http://www.libimobiledevice.org"
-  url "http://www.libimobiledevice.org/downloads/libplist-1.12.tar.bz2"
+  url "https://web.archive.org/web/20160305024510/https://libimobiledevice.org/downloads/libplist-1.12.tar.bz2"
   sha256 "0effdedcb3de128c4930d8c03a3854c74c426c16728b8ab5f0a5b6bdc0b644be"
 
   bottle do
@@ -27,7 +27,7 @@ class Libplist < Formula
   depends_on :python => :optional
 
   resource "cython" do
-    url "http://cython.org/release/Cython-0.21.tar.gz"
+    url "https://web.archive.org/web/20150921100327/http://cython.org/release/Cython-0.21.tar.gz"
     sha256 "0cd5787fb3f1eaf8326b21bdfcb90aabd3eca7c214c5b7b503fbb82da97bbaa0"
   end
 

--- a/Library/Formula/libpoker-eval.rb
+++ b/Library/Formula/libpoker-eval.rb
@@ -1,7 +1,7 @@
 class LibpokerEval < Formula
   desc "C library to evaluate poker hands"
   homepage "http://pokersource.sourceforge.net"
-  url "http://download.gna.org/pokersource/sources/poker-eval-138.0.tar.gz"
+  url "https://web.archive.org/web/20170327004207/http://download.gna.org/pokersource/sources/poker-eval-138.0.tar.gz"
   sha256 "92659e4a90f6856ebd768bad942e9894bd70122dab56f3b23dd2c4c61bdbcf68"
 
   bottle do

--- a/Library/Formula/libpqxx.rb
+++ b/Library/Formula/libpqxx.rb
@@ -1,7 +1,7 @@
 class Libpqxx < Formula
   desc "C++ connector for PostgreSQL"
   homepage "http://pqxx.org/development/libpqxx/"
-  url "http://pqxx.org/download/software/libpqxx/libpqxx-4.0.1.tar.gz"
+  url "https://web.archive.org/web/20220412173253/https://pqxx.org/download/software/libpqxx/libpqxx-4.0.1.tar.gz"
   sha256 "097ceda2797761ce517faa5bee186c883df1c407cb2aada613a16773afeedc38"
 
   bottle do

--- a/Library/Formula/libprotoident.rb
+++ b/Library/Formula/libprotoident.rb
@@ -1,7 +1,7 @@
 class Libprotoident < Formula
   desc "Libprotoident performs application layer protocol identification"
   homepage "http://research.wand.net.nz/software/libprotoident.php"
-  url "http://research.wand.net.nz/software/libprotoident/libprotoident-2.0.7.tar.gz"
+  url "https://web.archive.org/web/20160319225438/http://research.wand.net.nz/software/libprotoident/libprotoident-2.0.7.tar.gz"
   sha256 "5063497274e546b01b0606c8906a292cbe1e2ba8d6f3b6cd25de16a91fef635e"
 
   bottle do

--- a/Library/Formula/libraw.rb
+++ b/Library/Formula/libraw.rb
@@ -1,7 +1,7 @@
 class Libraw < Formula
   desc "Library for reading RAW files from digital photo cameras"
   homepage "http://www.libraw.org/"
-  url "http://www.libraw.org/data/LibRaw-0.16.0.tar.gz"
+  url "https://web.archive.org/web/20161005132045/https://www.libraw.org/data/LibRaw-0.16.0.tar.gz"
   sha256 "71f43871ec2535345c5c9b748f07813e49915170f9510b721a2be6478426cf96"
 
   bottle do

--- a/Library/Formula/libre.rb
+++ b/Library/Formula/libre.rb
@@ -1,7 +1,7 @@
 class Libre < Formula
   desc "Toolkit library for asynchronous network I/O with protocol stacks"
   homepage "http://www.creytiv.com"
-  url "http://www.creytiv.com/pub/re-0.4.12.tar.gz"
+  url "https://web.archive.org/web/20150505113432/http://www.creytiv.com/pub/re-0.4.12.tar.gz"
   sha256 "0d44028ce9c156b2ca34ec7ead8f44a59d3dca57b048edb3410d94cc8b634df2"
 
   bottle do

--- a/Library/Formula/librem.rb
+++ b/Library/Formula/librem.rb
@@ -1,7 +1,7 @@
 class Librem < Formula
   desc "Toolkit library for real-time audio and video processing"
   homepage "http://www.creytiv.com"
-  url "http://www.creytiv.com/pub/rem-0.4.6.tar.gz"
+  url "https://web.archive.org/web/20150802170718/http://www.creytiv.com/pub/rem-0.4.6.tar.gz"
   sha256 "7ce86f1eb8a3ba8cb14c490b80abe4d2389de306f385bfbb8c601c8b6ff2f865"
 
   bottle do

--- a/Library/Formula/libsvm.rb
+++ b/Library/Formula/libsvm.rb
@@ -1,7 +1,7 @@
 class Libsvm < Formula
   desc "Library for support vector machines"
   homepage "https://www.csie.ntu.edu.tw/~cjlin/libsvm/"
-  url "https://www.csie.ntu.edu.tw/~cjlin/libsvm/libsvm-3.20.tar.gz"
+  url "https://web.archive.org/web/20150805024258/https://www.csie.ntu.edu.tw/~cjlin/libsvm/libsvm-3.20.tar.gz"
   sha256 "0f122480bef44dec4df6dae056f468c208e4e08c00771ec1b6dae2707fd945be"
 
   bottle do

--- a/Library/Formula/libtess2.rb
+++ b/Library/Formula/libtess2.rb
@@ -1,7 +1,7 @@
 class Libtess2 < Formula
   desc "Refactored version of GLU tesselator"
   homepage "https://code.google.com/p/libtess2/"
-  url "https://libtess2.googlecode.com/files/libtess2-1.0.zip"
+  url "https://web.archive.org/web/20160315084649/https://libtess2.googlecode.com/files/libtess2-1.0.zip"
   sha256 "1938805e1859cbc4459797920743def39fd04154fe60da2ee3ee2198143b96bb"
 
   bottle do

--- a/Library/Formula/libtextcat.rb
+++ b/Library/Formula/libtextcat.rb
@@ -1,7 +1,7 @@
 class Libtextcat < Formula
   desc "N-gram-based text categorization library"
   homepage "http://software.wise-guys.nl/libtextcat/"
-  url "http://software.wise-guys.nl/download/libtextcat-2.2.tar.gz"
+  url "https://web.archive.org/web/20210410082754/http://software.wise-guys.nl/download/libtextcat-2.2.tar.gz"
   sha256 "5677badffc48a8d332e345ea4fe225e3577f53fc95deeec8306000b256829655"
 
   bottle do

--- a/Library/Formula/libtrace.rb
+++ b/Library/Formula/libtrace.rb
@@ -1,7 +1,7 @@
 class Libtrace < Formula
   desc "Library for trace processing supporting multiple inputs"
   homepage "http://research.wand.net.nz/software/libtrace.php"
-  url "http://research.wand.net.nz/software/libtrace/libtrace-3.0.22.tar.bz2"
+  url "https://web.archive.org/web/20220126150431/http://research.wand.net.nz/software/libtrace/libtrace-3.0.22.tar.bz2"
   sha256 "b8bbaa2054c69cc8f93066143e2601c09c8ed56e75c6e5e4e2c115d07952f8f8"
 
   bottle do

--- a/Library/Formula/libusrsctp.rb
+++ b/Library/Formula/libusrsctp.rb
@@ -1,7 +1,7 @@
 class Libusrsctp < Formula
   desc "User-land SCTP stack"
   homepage "http://sctp.fh-muenster.de/sctp-user-land-stack.html"
-  url "http://sctp.fh-muenster.de/download/libusrsctp-0.9.1.tar.gz"
+  url "https://web.archive.org/web/20140408053209/http://sctp.fh-muenster.de/download/libusrsctp-0.9.1.tar.gz"
   sha256 "63a3abe5f1cb7ddde36cba09d32579b05a98badb06ff88fca87d024925c3ff16"
 
   bottle do

--- a/Library/Formula/libwandevent.rb
+++ b/Library/Formula/libwandevent.rb
@@ -1,7 +1,7 @@
 class Libwandevent < Formula
   desc "Libwandevent provides an API for developing event-driven programs"
   homepage "http://research.wand.net.nz/software/libwandevent.php"
-  url "http://research.wand.net.nz/software/libwandevent/libwandevent-3.0.1.tar.gz"
+  url "https://web.archive.org/web/20160123055932/http://research.wand.net.nz/software/libwandevent/libwandevent-3.0.1.tar.gz"
   sha256 "317b2cc39f912f8e5875b9dd05658cd48ead98bf20a1d89855e5a435381bee24"
 
   bottle do

--- a/Library/Formula/libxmlsec1.rb
+++ b/Library/Formula/libxmlsec1.rb
@@ -1,7 +1,7 @@
 class Libxmlsec1 < Formula
   desc "XML security library"
   homepage "https://www.aleksey.com/xmlsec/"
-  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.20.tar.gz"
+  url "https://web.archive.org/web/20150909200526/https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.20.tar.gz"
   sha256 "3221593ca50f362b546a0888a1431ad24be1470f96b2469c0e0df5e1c55e7305"
 
   bottle do

--- a/Library/Formula/luajit.rb
+++ b/Library/Formula/luajit.rb
@@ -1,7 +1,7 @@
 class Luajit < Formula
   desc "Just-In-Time Compiler (JIT) for the Lua programming language"
   homepage "http://luajit.org/luajit.html"
-  url "http://luajit.org/download/LuaJIT-2.0.4.tar.gz"
+  url "https://web.archive.org/web/20240804224314/http://luajit.org/download/LuaJIT-2.0.4.tar.gz"
   sha256 "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
   head "http://luajit.org/git/luajit-2.0.git"
 

--- a/Library/Formula/lv.rb
+++ b/Library/Formula/lv.rb
@@ -1,7 +1,7 @@
 class Lv < Formula
   desc "Powerful multi-lingual file viewer/grep"
   homepage "http://www.ff.iij4u.or.jp/~nrt/lv/"
-  url "http://www.ff.iij4u.or.jp/~nrt/freeware/lv451.tar.gz"
+  url "https://web.archive.org/web/20150801134353/http://www.ff.iij4u.or.jp/~nrt/freeware/lv451.tar.gz"
   version "4.51"
   sha256 "e1cd2e27109fbdbc6d435f2c3a99c8a6ef2898941f5d2f7bacf0c1ad70158bcf"
 

--- a/Library/Formula/lynis.rb
+++ b/Library/Formula/lynis.rb
@@ -1,7 +1,7 @@
 class Lynis < Formula
   desc "Security and system auditing tool to harden systems"
   homepage "https://cisofy.com/lynis/"
-  url "https://cisofy.com/files/lynis-2.1.1.tar.gz"
+  url "https://web.archive.org/web/20160623235619/https://cisofy.com/files/lynis-2.1.1.tar.gz"
   sha256 "d17b3cbbd305c52b9cd0d5141f41954882f398db44f26c10cb45fdaaa46a99d2"
 
   bottle do

--- a/Library/Formula/memcache-top.rb
+++ b/Library/Formula/memcache-top.rb
@@ -1,7 +1,7 @@
 class MemcacheTop < Formula
   desc "Grab real-time stats from memcache"
   homepage "https://code.google.com/p/memcache-top/"
-  url "https://memcache-top.googlecode.com/files/memcache-top-v0.6"
+  url "https://web.archive.org/web/20160611142102/https://memcache-top.googlecode.com/files/memcache-top-v0.6"
   version "0.6"
   sha256 "d5f896a9e46a92988b782e340416312cc480261ce8a5818db45ccd0da8a0f22a"
 

--- a/Library/Formula/memcacheq.rb
+++ b/Library/Formula/memcacheq.rb
@@ -1,7 +1,7 @@
 class Memcacheq < Formula
   desc "Queue service for memcache"
   homepage "http://memcachedb.org/memcacheq"
-  url "https://memcacheq.googlecode.com/files/memcacheq-0.2.0.tar.gz"
+  url "https://web.archive.org/web/20160317043808/https://memcacheq.googlecode.com/files/memcacheq-0.2.0.tar.gz"
   sha256 "b314c46e1fb80d33d185742afe3b9a4fadee5575155cb1a63292ac2f28393046"
 
   depends_on "berkeley-db"

--- a/Library/Formula/memtester.rb
+++ b/Library/Formula/memtester.rb
@@ -1,7 +1,7 @@
 class Memtester < Formula
   desc "Utility for testing the memory subsystem"
   homepage "http://pyropus.ca/software/memtester/"
-  url "http://pyropus.ca/software/memtester/old-versions/memtester-4.3.0.tar.gz"
+  url "https://web.archive.org/web/20190615132526/https://pyropus.ca./software/memtester/old-versions/memtester-4.3.0.tar.gz"
   sha256 "f9dfe2fd737c38fad6535bbab327da9a21f7ce4ea6f18c7b3339adef6bf5fd88"
 
   bottle do

--- a/Library/Formula/mercury.rb
+++ b/Library/Formula/mercury.rb
@@ -1,7 +1,7 @@
 class Mercury < Formula
   desc "Logic/functional programming language"
   homepage "http://mercurylang.org/"
-  url "http://dl.mercurylang.org/release/mercury-srcdist-14.01.1.tar.gz"
+  url "https://web.archive.org/web/20190926162313/http://dl.mercurylang.org/release/mercury-srcdist-14.01.1.tar.gz"
   sha256 "98f7cbde7a7425365400feef3e69f1d6a848b25dc56ba959050523d546c4e88b"
 
   bottle do

--- a/Library/Formula/mfcuk.rb
+++ b/Library/Formula/mfcuk.rb
@@ -1,7 +1,7 @@
 class Mfcuk < Formula
   desc "MiFare Classic Universal toolKit"
   homepage "https://code.google.com/p/mfcuk/"
-  url "https://mfcuk.googlecode.com/files/mfcuk-0.3.8.tar.gz"
+  url "https://web.archive.org/web/20150805084617/https://mfcuk.googlecode.com/files/mfcuk-0.3.8.tar.gz"
   sha256 "977595765b4b46e4f47817e9500703aaf5c1bcad39cb02661f862f9d83f13a55"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/mfoc.rb
+++ b/Library/Formula/mfoc.rb
@@ -1,7 +1,7 @@
 class Mfoc < Formula
   desc "Implementation of 'offline nested' attack by Nethemba"
   homepage "https://code.google.com/p/mfoc/"
-  url "https://mfoc.googlecode.com/files/mfoc-0.10.7.tar.bz2"
+  url "https://web.archive.org/web/20140310212800/https://mfoc.googlecode.com/files/mfoc-0.10.7.tar.bz2"
   sha256 "93d8ac4cb0aa6ed94855ca9732a2ffd898a9095c087f12f9402205443c2eb98c"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/mg.rb
+++ b/Library/Formula/mg.rb
@@ -1,7 +1,7 @@
 class Mg < Formula
   desc "Small Emacs-like editor"
   homepage "http://homepage.boetes.org/software/mg/"
-  url "http://homepage.boetes.org/software/mg/mg-20131118.tar.gz"
+  url "https://web.archive.org/web/20160321043854/http://homepage.boetes.org/software/mg/mg-20131118.tar.gz"
   sha256 "b99fe10cb8473e035ff43bf3fbf94a24035e4ebb89484d48e5b33075d22d79f3"
 
   depends_on "clens"

--- a/Library/Formula/mitmproxy.rb
+++ b/Library/Formula/mitmproxy.rb
@@ -1,7 +1,7 @@
 class Mitmproxy < Formula
   desc "Intercept, modify, replay, save HTTP/S traffic"
   homepage "https://mitmproxy.org"
-  url "https://mitmproxy.org/download/mitmproxy-0.13.tar.gz"
+  url "https://web.archive.org/web/20150909021206/https://mitmproxy.org/download/mitmproxy-0.13.tar.gz"
   sha256 "f35b90d836693dbb02a589ddee056bb4fdb7b679a1dfe230b0492216a8e3dcfa"
   head "https://github.com/mitmproxy/mitmproxy.git"
 

--- a/Library/Formula/mmsrip.rb
+++ b/Library/Formula/mmsrip.rb
@@ -1,7 +1,7 @@
 class Mmsrip < Formula
   desc "Client for the MMS:// protocol"
   homepage "http://nbenoit.tuxfamily.org/index.php?page=MMSRIP"
-  url "http://nbenoit.tuxfamily.org/projects/mmsrip/mmsrip-0.7.0.tar.gz"
+  url "https://web.archive.org/web/20161207201859/http://nbenoit.tuxfamily.org/projects/mmsrip/mmsrip-0.7.0.tar.gz"
   sha256 "5aed3cf17bfe50e2628561b46e12aec3644cfbbb242d738078e8b8fce6c23ed6"
 
   def install

--- a/Library/Formula/mobile-shell.rb
+++ b/Library/Formula/mobile-shell.rb
@@ -1,7 +1,7 @@
 class MobileShell < Formula
   desc "Remote terminal application"
   homepage "https://mosh.mit.edu/"
-  url "https://mosh.mit.edu/mosh-1.2.5.tar.gz"
+  url "https://web.archive.org/web/20190722130937/https://mosh.org/mosh-1.2.5.tar.gz"
   sha256 "1af809e5d747c333a852fbf7acdbf4d354dc4bbc2839e3afe5cf798190074be3"
 
   bottle do

--- a/Library/Formula/mp3check.rb
+++ b/Library/Formula/mp3check.rb
@@ -1,7 +1,7 @@
 class Mp3check < Formula
   desc "Tool to check mp3 files for consistency"
   homepage "https://code.google.com/p/mp3check/"
-  url "https://mp3check.googlecode.com/files/mp3check-0.8.7.tgz"
+  url "https://web.archive.org/web/20160315135934/https://mp3check.googlecode.com/files/mp3check-0.8.7.tgz"
   sha256 "27d976ad8495671e9b9ce3c02e70cb834d962b6fdf1a7d437bb0e85454acdd0e"
 
   def install

--- a/Library/Formula/mupdf-tools.rb
+++ b/Library/Formula/mupdf-tools.rb
@@ -1,7 +1,7 @@
 class MupdfTools < Formula
   desc "Lightweight PDF and XPS viewer"
   homepage "http://mupdf.com"
-  url "http://mupdf.com/downloads/mupdf-1.7a-source.tar.gz"
+  url "https://web.archive.org/web/20150706061322/https://mupdf.com/downloads/mupdf-1.7a-source.tar.gz"
   sha256 "8c035ffa011fc44f8a488f70da3e6e51889508bbf66fe6b90a63e0cfa6c17d1c"
   head "git://git.ghostscript.com/mupdf.git"
 

--- a/Library/Formula/mvptree.rb
+++ b/Library/Formula/mvptree.rb
@@ -1,7 +1,7 @@
 class Mvptree < Formula
   desc "Perceptual hash library"
   homepage "http://www.phash.org"
-  url "http://www.phash.org/releases/mvptree-1.0.tar.gz"
+  url "https://web.archive.org/web/20160409192545/http://www.phash.org/releases/mvptree-1.0.tar.gz"
   sha256 "cbb89e7368785f4823200d4ba81975cdabe77797d736047b1ea14b02e6a61839"
 
   bottle do

--- a/Library/Formula/namebench.rb
+++ b/Library/Formula/namebench.rb
@@ -1,7 +1,7 @@
 class Namebench < Formula
   desc "DNS benchmark utility"
   homepage "https://code.google.com/p/namebench/"
-  url "https://namebench.googlecode.com/files/namebench-1.3.1-source.tgz"
+  url "https://web.archive.org/web/20160206013628/https://namebench.googlecode.com/files/namebench-1.3.1-source.tgz"
   sha256 "30ccf9e870c1174c6bf02fca488f62bba280203a0b1e8e4d26f3756e1a5b9425"
 
   option "no-third-party", "Do not install bundled third-party modules"

--- a/Library/Formula/nikto.rb
+++ b/Library/Formula/nikto.rb
@@ -1,7 +1,7 @@
 class Nikto < Formula
   desc "Web server scanner"
   homepage "http://cirt.net/nikto2"
-  url "https://www.cirt.net/nikto/nikto-2.1.5.tar.bz2"
+  url "https://web.archive.org/web/20180808014232/https://www.cirt.net/nikto/nikto-2.1.5.tar.bz2"
   sha256 "65b99c1fdec14d1d5e7cbc964f70fce162cbec50aee878e1500e2d22df079b34"
 
   def install

--- a/Library/Formula/olsrd.rb
+++ b/Library/Formula/olsrd.rb
@@ -1,7 +1,7 @@
 class Olsrd < Formula
   desc "Implementation of the optimized link state routing protocol"
   homepage "http://www.olsr.org"
-  url "http://www.olsr.org/releases/0.9/olsrd-0.9.0.2.tar.bz2"
+  url "https://web.archive.org/web/20151009102948/http://www.olsr.org/releases/0.9/olsrd-0.9.0.2.tar.bz2"
   sha256 "cc464b29c7740354d815d5faa753fd27c0677d71e8eb42e78abc382996892845"
 
   bottle do

--- a/Library/Formula/open-scene-graph.rb
+++ b/Library/Formula/open-scene-graph.rb
@@ -1,7 +1,7 @@
 class OpenSceneGraph < Formula
   desc "3D graphics toolkit"
   homepage "http://www.openscenegraph.org/projects/osg"
-  url "http://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.4.0.zip"
+  url "https://web.archive.org/web/20160429031235/https://trac.openscenegraph.org/downloads/developer_releases/OpenSceneGraph-3.4.0.zip"
   sha256 "5c727d84755da276adf8c4a4a3a8ba9c9570fc4b4969f06f1d2e9f89b1e3040e"
   revision 1
 

--- a/Library/Formula/open-zwave.rb
+++ b/Library/Formula/open-zwave.rb
@@ -1,7 +1,7 @@
 class OpenZwave < Formula
   desc "Library for selected Z-Wave PC controllers"
   homepage "http://www.openzwave.com"
-  url "http://old.openzwave.com/downloads/openzwave-1.2.919.tar.gz"
+  url "https://web.archive.org/web/20150801235615/http://old.openzwave.com/downloads/openzwave-1.2.919.tar.gz"
   sha256 "473229f3dd3d6b260e6584b17e5c5f2e09e61805f89763f486a9f7aa2b4181ba"
 
   bottle do

--- a/Library/Formula/openal-soft.rb
+++ b/Library/Formula/openal-soft.rb
@@ -1,7 +1,7 @@
 class OpenalSoft < Formula
   desc "Implementation of the OpenAL 3D audio API"
   homepage "http://kcat.strangesoft.net/openal.html"
-  url "http://kcat.strangesoft.net/openal-releases/openal-soft-1.16.0.tar.bz2"
+  url "https://web.archive.org/web/20150803063450/http://kcat.strangesoft.net/openal-releases/openal-soft-1.16.0.tar.bz2"
   sha256 "2f3dcd313fe26391284fbf8596863723f99c65d6c6846dccb48e79cadaf40d5f"
   revision 1
 

--- a/Library/Formula/opendetex.rb
+++ b/Library/Formula/opendetex.rb
@@ -1,7 +1,7 @@
 class Opendetex < Formula
   desc "Tool to strip TeX or LaTeX commands from documents"
   homepage "https://code.google.com/p/opendetex/"
-  url "https://opendetex.googlecode.com/files/opendetex-2.8.1.tar.bz2"
+  url "https://web.archive.org/web/20160730230748/https://opendetex.googlecode.com/files/opendetex-2.8.1.tar.bz2"
   sha256 "8a47e4c7052672dfe5e0a4214dd5db42ac4322eb382efe6fd1fb271b409d051e"
 
   patch :DATA

--- a/Library/Formula/orpie.rb
+++ b/Library/Formula/orpie.rb
@@ -1,7 +1,7 @@
 class Orpie < Formula
   desc "RPN calculator for the terminal"
   homepage "http://pessimization.com/software/orpie/"
-  url "http://pessimization.com/software/orpie/orpie-1.5.2.tar.gz"
+  url "https://web.archive.org/web/20160320035927/http://pessimization.com/software/orpie/orpie-1.5.2.tar.gz"
   sha256 "de557fc7f608c6cb1f44a965d3ae07fc6baf2b02a0d7994b89d6a0e0d87d3d6d"
 
   bottle do

--- a/Library/Formula/oscats.rb
+++ b/Library/Formula/oscats.rb
@@ -1,7 +1,7 @@
 class Oscats < Formula
   desc "Computerized adaptive testing system"
   homepage "https://code.google.com/p/oscats/"
-  url "https://oscats.googlecode.com/files/oscats-0.6.tar.gz"
+  url "https://web.archive.org/web/20160803193550/https://oscats.googlecode.com/files/oscats-0.6.tar.gz"
   sha256 "2f7c88cdab6a2106085f7a3e5b1073c74f7d633728c76bd73efba5dc5657a604"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/pdf2json.rb
+++ b/Library/Formula/pdf2json.rb
@@ -1,7 +1,7 @@
 class Pdf2json < Formula
   desc "PDF to JSON and XML converter"
   homepage "https://code.google.com/p/pdf2json/"
-  url "https://pdf2json.googlecode.com/files/pdf2json-0.68.tar.gz"
+  url "https://web.archive.org/web/20160822110306/https://pdf2json.googlecode.com/files/pdf2json-0.68.tar.gz"
   sha256 "34907954b2029a51a0b372b9db86d6c5112e4a1648201352e514ca5606050673"
 
   bottle do

--- a/Library/Formula/pdksh.rb
+++ b/Library/Formula/pdksh.rb
@@ -1,7 +1,7 @@
 class Pdksh < Formula
   desc "Public domain version of the Korn shell"
   homepage "http://www.cs.mun.ca/~michael/pdksh/"
-  url "http://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14.tar.gz"
+  url "https://web.archive.org/web/20160331133800/http://www.cs.mun.ca/~michael/pdksh/files/pdksh-5.2.14.tar.gz"
   sha256 "ab15bcdd50f291edc632bca351b2edce5405d4f2ce3854d3d548d721ab9bbfa6"
 
   bottle do

--- a/Library/Formula/pdnsd.rb
+++ b/Library/Formula/pdnsd.rb
@@ -1,7 +1,7 @@
 class Pdnsd < Formula
   desc "Proxy DNS server with permanent caching"
   homepage "http://members.home.nl/p.a.rombouts/pdnsd/"
-  url "http://members.home.nl/p.a.rombouts/pdnsd/releases/pdnsd-1.2.9a-par.tar.gz"
+  url "https://web.archive.org/web/20200323100335/http://members.home.nl/p.a.rombouts/pdnsd/releases/pdnsd-1.2.9a-par.tar.gz"
   version "1.2.9a-par"
   sha256 "bb5835d0caa8c4b31679d6fd6a1a090b71bdf70950db3b1d0cea9cf9cb7e2a7b"
 

--- a/Library/Formula/pg_top.rb
+++ b/Library/Formula/pg_top.rb
@@ -1,7 +1,7 @@
 class PgTop < Formula
   desc "Monitor PostgreSQL processes"
   homepage "http://ptop.projects.postgresql.org/"
-  url "http://pgfoundry.org/frs/download.php/3504/pg_top-3.7.0.tar.bz2"
+  url "https://web.archive.org/web/20150803025422/https://pgfoundry.org/frs/download.php/3504/pg_top-3.7.0.tar.bz2"
   sha256 "c48d726e8cd778712e712373a428086d95e2b29932e545ff2a948d043de5a6a2"
 
   depends_on :postgresql

--- a/Library/Formula/pgtune.rb
+++ b/Library/Formula/pgtune.rb
@@ -1,7 +1,7 @@
 class Pgtune < Formula
   desc "Tuning wizard for postgresql.conf"
   homepage "http://pgfoundry.org/projects/pgtune"
-  url "http://pgfoundry.org/frs/download.php/2449/pgtune-0.9.3.tar.gz"
+  url "https://web.archive.org/web/20190803130831/https://pgfoundry.org/frs/download.php/2449/pgtune-0.9.3.tar.gz"
   sha256 "31ac5774766dd9793d8d2d3681d1edb45760897c8eda3afc48b8d59350dee0ea"
 
   # 0.9.3 does not have settings for PostgreSQL 9.x, but the trunk does

--- a/Library/Formula/picoc.rb
+++ b/Library/Formula/picoc.rb
@@ -1,7 +1,7 @@
 class Picoc < Formula
   desc "C interpreter for scripting"
   homepage "https://code.google.com/p/picoc/"
-  url "https://picoc.googlecode.com/files/picoc-2.1.tar.bz2"
+  url "https://web.archive.org/web/20160804073832/https://picoc.googlecode.com/files/picoc-2.1.tar.bz2"
   sha256 "bfed355fab810b337ccfa9e3215679d0b9886c00d9cb5e691f7e7363fd388b7e"
 
   def install

--- a/Library/Formula/picocom.rb
+++ b/Library/Formula/picocom.rb
@@ -1,7 +1,7 @@
 class Picocom < Formula
   desc "Minimal dump-terminal emulation program"
   homepage "https://code.google.com/p/picocom/"
-  url "https://picocom.googlecode.com/files/picocom-1.7.tar.gz"
+  url "https://web.archive.org/web/20140709170957/https://picocom.googlecode.com/files/picocom-1.7.tar.gz"
   sha256 "d0f31c8f7a215a76922d30c81a52b9a2348c89e02a84935517002b3bc2c1129e"
 
   patch :DATA # HIGH_BAUD is not defined

--- a/Library/Formula/pjproject.rb
+++ b/Library/Formula/pjproject.rb
@@ -1,7 +1,7 @@
 class Pjproject < Formula
   desc "C library for multimedia protocols such as SIP, SDP, RTP and more"
   homepage "http://www.pjsip.org/"
-  url "http://www.pjsip.org/release/2.3/pjproject-2.3.tar.bz2"
+  url "https://web.archive.org/web/20150806050811/https://www.pjsip.org/release/2.3/pjproject-2.3.tar.bz2"
   sha256 "e7fa60a3b59424430145af90372282ca778449f7b68b77bb24a9cf75d94d5765"
 
   bottle do

--- a/Library/Formula/plan9port.rb
+++ b/Library/Formula/plan9port.rb
@@ -1,7 +1,7 @@
 class Plan9port < Formula
   desc "Many Plan 9 programs ported to UNIX-like operating systems"
   homepage "http://swtch.com/plan9port/"
-  url "https://plan9port.googlecode.com/files/plan9port-20140306.tgz"
+  url "https://web.archive.org/web/20160731162544/https://plan9port.googlecode.com/files/plan9port-20140306.tgz"
   sha256 "cbb826cde693abdaa2051c49e7ebf75119bf2a4791fe3b3229f1ac36a408eaeb"
 
   def install

--- a/Library/Formula/plod.rb
+++ b/Library/Formula/plod.rb
@@ -1,7 +1,7 @@
 class Plod < Formula
   desc "Keep an online journal of what you're working on"
   homepage "http://www.deer-run.com/~hal/"
-  url "http://www.deer-run.com/~hal/plod/plod.shar"
+  url "https://web.archive.org/web/20110109134831/http://www.deer-run.com/~hal/plod/plod.shar"
   version "1.9"
   sha256 "1b7b8267c41b11c2f5413a8d6850099e0547b7506031b0c733121ed5e8d182f5"
 

--- a/Library/Formula/prips.rb
+++ b/Library/Formula/prips.rb
@@ -1,7 +1,7 @@
 class Prips < Formula
   desc "Print the IP addresses in a given range"
   homepage "http://devel.ringlet.net/sysutils/prips/"
-  url "http://devel.ringlet.net/sysutils/prips/prips-0.9.9.tar.gz"
+  url "https://web.archive.org/web/20150908194220/http://devel.ringlet.net/sysutils/prips/prips-0.9.9.tar.gz"
   sha256 "ad9d8e63cd69ed682ea87c154a19e5c58a3eb4bb3a118d5f458fd86eadb3bef8"
 
   def install

--- a/Library/Formula/probatron4j.rb
+++ b/Library/Formula/probatron4j.rb
@@ -1,7 +1,7 @@
 class Probatron4j < Formula
   desc "Schematron validator (use with Java 1.5 or later)"
   homepage "http://www.probatron.org"
-  url "https://probatron4j.googlecode.com/files/probatron4j-0.7.4.zip"
+  url "https://web.archive.org/web/20160809190207/https://probatron4j.googlecode.com/files/probatron4j-0.7.4.zip"
   sha256 "53f1d28d5adbc0abe8a12015a4da3a2da000e56cb1328212870d0e6fe4fe941c"
 
   def install

--- a/Library/Formula/proof-general.rb
+++ b/Library/Formula/proof-general.rb
@@ -1,7 +1,7 @@
 class ProofGeneral < Formula
   desc "Emacs-based generic interface for theorem provers"
   homepage "http://proofgeneral.inf.ed.ac.uk"
-  url "http://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz"
+  url "https://web.archive.org/web/20160414054158/https://proofgeneral.inf.ed.ac.uk/releases/ProofGeneral-4.2.tgz"
   sha256 "3567b68077798396ccd55c501b7ea7bd2c4d6300e4c74ff609dc19837d050b27"
 
   devel do

--- a/Library/Formula/ps2eps.rb
+++ b/Library/Formula/ps2eps.rb
@@ -1,7 +1,7 @@
 class Ps2eps < Formula
   desc "Convert PostScript to EPS files"
   homepage "https://www.tm.uka.de/~bless/ps2eps"
-  url "https://www.tm.uka.de/~bless/ps2eps-1.68.tar.gz"
+  url "https://web.archive.org/web/20160402120002/https://www.tm.uka.de/~bless/ps2eps-1.68.tar.gz"
   sha256 "b08f12eed88965d1891261fb70e87c7e3a3f3172ebc31bdb7994a7ce854dd925"
 
   bottle do

--- a/Library/Formula/psgrep.rb
+++ b/Library/Formula/psgrep.rb
@@ -2,7 +2,7 @@ class Psgrep < Formula
   desc "Shortcut for the 'ps aux | grep' idiom"
   homepage "https://github.com/jvz/psgrep"
   # might be dead soon: https://github.com/jvz/psgrep/issues/2
-  url "https://psgrep.googlecode.com/files/psgrep-1.0.6.tar.bz2"
+  url "https://web.archive.org/web/20160729044001/https://psgrep.googlecode.com/files/psgrep-1.0.6.tar.bz2"
   sha256 "6da723575c768e5a2a61f67eb7fdf57ca942b897496ede524d19ea75e2c4ddac"
 
   head "https://github.com/jvz/psgrep.git"

--- a/Library/Formula/psqlodbc.rb
+++ b/Library/Formula/psqlodbc.rb
@@ -3,7 +3,7 @@ class Psqlodbc < Formula
   homepage "https://odbc.postgresql.org"
 
   stable do
-    url "https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-09.03.0400.tar.gz"
+  url "https://web.archive.org/web/20151004141001/https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-09.03.0400.tar.gz"
     sha256 "de77dfa89dba0a159afc57b2e312ca6e9075dd92b761c7cc700c0450ba02b56b"
 
     # fixes error "conflicting types for '__builtin___strlcat_chk'"

--- a/Library/Formula/pssh.rb
+++ b/Library/Formula/pssh.rb
@@ -1,7 +1,7 @@
 class Pssh < Formula
   desc "Parallel versions of OpenSSH and related tools"
   homepage "https://code.google.com/p/parallel-ssh/"
-  url "https://parallel-ssh.googlecode.com/files/pssh-2.3.1.tar.gz"
+  url "https://web.archive.org/web/20160809140922/https://parallel-ssh.googlecode.com/files/pssh-2.3.1.tar.gz"
   sha256 "539f8d8363b722712310f3296f189d1ae8c690898eca93627fc89a9cb311f6b4"
 
   conflicts_with "putty", :because => "both install `pscp` binaries"

--- a/Library/Formula/pulledpork.rb
+++ b/Library/Formula/pulledpork.rb
@@ -1,7 +1,7 @@
 class Pulledpork < Formula
   desc "Snort rule management"
   homepage "https://code.google.com/p/pulledpork/"
-  url "https://pulledpork.googlecode.com/files/pulledpork-0.7.0.tar.gz"
+  url "https://web.archive.org/web/20160815215805/https://pulledpork.googlecode.com/files/pulledpork-0.7.0.tar.gz"
   sha256 "f60c005043850bb65a72582b9d6d68a7e7d51107f30f2b3fc67e607c995aa1a8"
   head "http://pulledpork.googlecode.com/svn/trunk/"
 

--- a/Library/Formula/pushpin.rb
+++ b/Library/Formula/pushpin.rb
@@ -1,7 +1,7 @@
 class Pushpin < Formula
   desc "Reverse proxy for realtime web services"
   homepage "http://pushpin.org"
-  url "https://dl.bintray.com/fanout/source/pushpin-1.5.0.tar.bz2"
+  url "https://web.archive.org/web/20210501185818/https://dl.bintray.com/fanout/source/pushpin-1.5.0.tar.bz2"
   sha256 "9e9a05da706260bc4c96a36f9af5fdc38b78699709c83538663f00f59104ba2b"
 
   head "https://github.com/fanout/pushpin.git"

--- a/Library/Formula/pwsafe.rb
+++ b/Library/Formula/pwsafe.rb
@@ -1,7 +1,7 @@
 class Pwsafe < Formula
   desc "Generate passwords and manage encrypted password databases"
   homepage "http://nsd.dyndns.org/pwsafe/"
-  url "http://nsd.dyndns.org/pwsafe/releases/pwsafe-0.2.0.tar.gz"
+  url "https://web.archive.org/web/20160604031349/http://nsd.dyndns.org/pwsafe/releases/pwsafe-0.2.0.tar.gz"
   sha256 "61e91dc5114fe014a49afabd574eda5ff49b36c81a6d492c03fcb10ba6af47b7"
   revision 2
 
@@ -17,7 +17,7 @@ class Pwsafe < Formula
 
   # A password database for testing is provided upstream. How nice!
   resource "test-pwsafe-db" do
-    url "http://nsd.dyndns.org/pwsafe/test.dat"
+    url "https://web.archive.org/web/20181014074859/http://nsd.dyndns.org/pwsafe/test.dat"
     sha256 "7ecff955871e6e58e55e0794d21dfdea44a962ff5925c2cd0683875667fbcc79"
   end
 

--- a/Library/Formula/qca.rb
+++ b/Library/Formula/qca.rb
@@ -4,7 +4,7 @@ class Qca < Formula
   head "git://anongit.kde.org/qca.git"
 
   stable do
-    url "http://delta.affinix.com/download/qca/2.0/qca-2.1.0.tar.gz"
+  url "https://web.archive.org/web/20160412200215/http://delta.affinix.com/download/qca/2.0/qca-2.1.0.tar.gz"
     sha256 "226dcd76138c3738cdc15863607a96b3758a4c3efd3c47295939bcea4e7a9284"
 
     # Fixes build with Qt 5.5 by adding a missing include (already fixed in HEAD).

--- a/Library/Formula/qdbm.rb
+++ b/Library/Formula/qdbm.rb
@@ -1,7 +1,7 @@
 class Qdbm < Formula
   desc "QDBM is a library of routines for managing a database"
   homepage "http://fallabs.com/qdbm"
-  url "http://fallabs.com/qdbm/qdbm-1.8.78.tar.gz"
+  url "https://web.archive.org/web/20230518234834/http://fallabs.com/qdbm/qdbm-1.8.78.tar.gz"
   sha256 "b466fe730d751e4bfc5900d1f37b0fb955f2826ac456e70012785e012cdcb73e"
 
   bottle do

--- a/Library/Formula/qrencode.rb
+++ b/Library/Formula/qrencode.rb
@@ -1,7 +1,7 @@
 class Qrencode < Formula
   desc "QR Code generation"
   homepage "https://fukuchi.org/works/qrencode/index.html.en"
-  url "https://fukuchi.org/works/qrencode/qrencode-3.4.4.tar.gz"
+  url "https://web.archive.org/web/20240910005455/https://fukuchi.org/works/qrencode/qrencode-3.4.4.tar.gz"
   sha256 "e794e26a96019013c0e3665cb06b18992668f352c5553d0a553f5d144f7f2a72"
 
   bottle do

--- a/Library/Formula/qtfaststart.rb
+++ b/Library/Formula/qtfaststart.rb
@@ -1,7 +1,7 @@
 class Qtfaststart < Formula
   desc "Utility for Quicktime files"
   homepage "https://libav.org/"
-  url "https://libav.org/releases/libav-11.2.tar.gz"
+  url "https://web.archive.org/web/20150315060552/https://libav.org/releases/libav-11.2.tar.gz"
   sha256 "1f1448e1245444a1fae2f077f6846fedb47dfb294bef797e6742c095a6b4d769"
 
   bottle do

--- a/Library/Formula/quantlib.rb
+++ b/Library/Formula/quantlib.rb
@@ -1,7 +1,7 @@
 class Quantlib < Formula
   desc "Library for quantitative finance"
   homepage "http://quantlib.org/"
-  url "https://downloads.sourceforge.net/project/quantlib/QuantLib/1.6.1/QuantLib-1.6.1.tar.gz"
+  url "https://web.archive.org/web/20151229104509/https://distfiles.macports.org/QuantLib/QuantLib-1.6.1.tar.gz"
   mirror "https://distfiles.macports.org/QuantLib/QuantLib-1.6.1.tar.gz"
   sha256 "4f90994671173ef20d2bfd34cefc79f753370d79eccafaec926db8c4b6c37870"
 

--- a/Library/Formula/radamsa.rb
+++ b/Library/Formula/radamsa.rb
@@ -1,7 +1,7 @@
 class Radamsa < Formula
   desc "Test case generator for robustness testing (a.k.a. a \"fuzzer\")"
   homepage "https://code.google.com/p/ouspg/wiki/Radamsa"
-  url "https://ouspg.googlecode.com/files/radamsa-0.3.tar.gz"
+  url "https://web.archive.org/web/20160728040845/https://ouspg.googlecode.com/files/radamsa-0.3.tar.gz"
   sha256 "17131a19fb28e5c97c28bf0b407a82744c251aa8aedfa507967a92438cd803be"
 
   def install

--- a/Library/Formula/rakudo-star.rb
+++ b/Library/Formula/rakudo-star.rb
@@ -1,7 +1,7 @@
 class RakudoStar < Formula
   desc "Perl 6 compiler"
   homepage "http://rakudo.org/"
-  url "http://rakudo.org/downloads/star/rakudo-star-2015.07.tar.gz"
+  url "https://web.archive.org/web/20160423172150/https://rakudo.org/downloads/star/rakudo-star-2015.07.tar.gz"
   sha256 "84d7812a735eedc39d7c0898d4fd15ecd82563971744b2bc6ff0a1c581c82910"
 
   bottle do

--- a/Library/Formula/rarian.rb
+++ b/Library/Formula/rarian.rb
@@ -1,7 +1,7 @@
 class Rarian < Formula
   desc "Documentation metadata library"
   homepage "http://rarian.freedesktop.org/"
-  url "http://rarian.freedesktop.org/Releases/rarian-0.8.1.tar.bz2"
+  url "https://web.archive.org/web/20160411073220/https://rarian.freedesktop.org/Releases/rarian-0.8.1.tar.bz2"
   sha256 "aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577"
 
   bottle do

--- a/Library/Formula/rats.rb
+++ b/Library/Formula/rats.rb
@@ -1,7 +1,7 @@
 class Rats < Formula
   desc "Rough auditing tool for security"
   homepage "https://security.web.cern.ch/security/recommendations/en/codetools/rats.shtml"
-  url "https://rough-auditing-tool-for-security.googlecode.com/files/rats-2.4.tgz"
+  url "https://web.archive.org/web/20160609175825/https://rough-auditing-tool-for-security.googlecode.com/files/rats-2.4.tgz"
   sha256 "2163ad111070542d941c23b98d3da231f13cf065f50f2e4ca40673996570776a"
 
   def install

--- a/Library/Formula/rdup.rb
+++ b/Library/Formula/rdup.rb
@@ -1,7 +1,7 @@
 class Rdup < Formula
   desc "Utility to create a file list suitable for making backups"
   homepage "http://archive.miek.nl/projects/rdup/index.html"
-  url "http://archive.miek.nl/projects/rdup/rdup-1.1.14.tar.bz2"
+  url "https://web.archive.org/web/20150802054947/http://archive.miek.nl/projects/rdup/rdup-1.1.14.tar.bz2"
   sha256 "b25e2b0656d2e6a9cb97a37f493913c4156468d4c21cea15a9a0c7b353e3742a"
   revision 1
 

--- a/Library/Formula/readosm.rb
+++ b/Library/Formula/readosm.rb
@@ -1,7 +1,7 @@
 class Readosm < Formula
   desc "Extract valid data from an Open Street Map input file"
   homepage "https://www.gaia-gis.it/fossil/readosm/index"
-  url "https://www.gaia-gis.it/gaia-sins/readosm-1.0.0e.tar.gz"
+  url "https://web.archive.org/web/20160809133239/https://www.gaia-gis.it/gaia-sins/readosm-1.0.0e.tar.gz"
   sha256 "1fd839e05b411db6ba1ca6199bf3334ab9425550a58e129c07ad3c6d39299acf"
 
   bottle do

--- a/Library/Formula/reaver.rb
+++ b/Library/Formula/reaver.rb
@@ -1,7 +1,7 @@
 class Reaver < Formula
   desc "Implements brute force attack to recover WPA/WPA2 passkeys"
   homepage "https://code.google.com/p/reaver-wps/"
-  url "https://reaver-wps.googlecode.com/files/reaver-1.4.tar.gz"
+  url "https://web.archive.org/web/20160616210012/https://reaver-wps.googlecode.com/files/reaver-1.4.tar.gz"
   sha256 "add3050a4a05fe0ab6bfb291ee2de8e9b8a85f1e64ced93ee27a75744954b22d"
 
   # Adds general support for Mac OS X in reaver:

--- a/Library/Formula/remctl.rb
+++ b/Library/Formula/remctl.rb
@@ -1,7 +1,7 @@
 class Remctl < Formula
   desc "Client/server application for remote execution of tasks"
   homepage "http://www.eyrie.org/~eagle/software/remctl/"
-  url "http://archives.eyrie.org/software/kerberos/remctl-3.9.tar.gz"
+  url "https://web.archive.org/web/20150920110236/https://archives.eyrie.org/software/kerberos/remctl-3.9.tar.gz"
   sha256 "7652a38008386a2cab4ba6f596ab0620a83a2b076dd56e74d01bbb9cddaed20e"
 
   depends_on "pcre"

--- a/Library/Formula/remind.rb
+++ b/Library/Formula/remind.rb
@@ -1,7 +1,7 @@
 class Remind < Formula
   desc "Sophisticated calendar and alarm"
   homepage "https://www.roaringpenguin.com/products/remind"
-  url "https://www.roaringpenguin.com/files/download/remind-03.01.15.tar.gz"
+  url "https://web.archive.org/web/20160913044130/https://www.roaringpenguin.com/files/download/remind-03.01.15.tar.gz"
   sha256 "8adab4c0b30a556c34223094c5c74779164d5f3b8be66b8039f44b577e678ec1"
 
   bottle do

--- a/Library/Formula/restund.rb
+++ b/Library/Formula/restund.rb
@@ -1,7 +1,7 @@
 class Restund < Formula
   desc "Modular STUN/TURN server"
   homepage "http://www.creytiv.com"
-  url "http://www.creytiv.com/pub/restund-0.4.11.tar.gz"
+  url "https://web.archive.org/web/20150505075901/http://www.creytiv.com/pub/restund-0.4.11.tar.gz"
   sha256 "d4630dfb8777f12cc48ed118da0ea6445bc60e94ff916ab0ca5d436c74bdc2d7"
 
   bottle do

--- a/Library/Formula/rethinkdb.rb
+++ b/Library/Formula/rethinkdb.rb
@@ -1,7 +1,7 @@
 class Rethinkdb < Formula
   desc "The open-source database for the realtime web"
   homepage "https://www.rethinkdb.com/"
-  url "https://download.rethinkdb.com/dist/rethinkdb-2.1.4.tgz"
+  url "https://web.archive.org/web/20170612204405/https://download.rethinkdb.com/dist/rethinkdb-2.1.4.tgz"
   sha256 "2553ad4a31b5f09522fc651fd2cfa98d76bccfebd6db87ef929eda54220f70b2"
 
   bottle do

--- a/Library/Formula/riak.rb
+++ b/Library/Formula/riak.rb
@@ -1,7 +1,7 @@
 class Riak < Formula
   desc "Distributed database"
   homepage "http://basho.com/riak/"
-  url "https://s3.amazonaws.com/downloads.basho.com/riak/2.1/2.1.1/osx/10.8/riak-2.1.1-OSX-x86_64.tar.gz"
+  url "https://web.archive.org/web/20201206072933/https://s3.amazonaws.com/downloads.basho.com/riak/2.1/2.1.1/osx/10.8/riak-2.1.1-OSX-x86_64.tar.gz"
   version "2.1.1"
   sha256 "ee06193b5fc4bb56746f8f648794b732b96879369835a94f22235e0561d652d7"
 

--- a/Library/Formula/rlog.rb
+++ b/Library/Formula/rlog.rb
@@ -1,7 +1,7 @@
 class Rlog < Formula
   desc "Flexible message logging facility for C++"
   homepage "http://www.arg0.net/rlog"
-  url "https://rlog.googlecode.com/files/rlog-1.4.tar.gz"
+  url "https://web.archive.org/web/20160603170425/https://rlog.googlecode.com/files/rlog-1.4.tar.gz"
   sha256 "a938eeedeb4d56f1343dc5561bc09ae70b24e8f70d07a6f8d4b6eed32e783f79"
 
   patch :DATA

--- a/Library/Formula/rlwrap.rb
+++ b/Library/Formula/rlwrap.rb
@@ -1,7 +1,7 @@
 class Rlwrap < Formula
   desc "Readline wrapper: adds readline support to tools that lack it"
   homepage "http://utopia.knoware.nl/~hlub/rlwrap/"
-  url "http://utopia.knoware.nl/~hlub/rlwrap/rlwrap-0.42.tar.gz"
+  url "https://web.archive.org/web/20160410134918/http://utopia.knoware.nl/~hlub/rlwrap/rlwrap-0.42.tar.gz"
   sha256 "5a70d8469db9d0a6630628f2d5d2972ad16c092400b7fbbdf699693ec0f87e44"
   revision 1
 

--- a/Library/Formula/rpl.rb
+++ b/Library/Formula/rpl.rb
@@ -1,7 +1,7 @@
 class Rpl < Formula
   desc "Text replacement utility"
   homepage "http://www.laffeycomputer.com/rpl.html"
-  url "http://downloads.laffeycomputer.com/current_builds/rpl-1.4.1.tar.gz"
+  url "https://web.archive.org/web/20161118172343/http://downloads.laffeycomputer.com/current_builds/rpl-1.4.1.tar.gz"
   sha256 "291055dc8763c855bab76142b5f7e9625392bcefa524b796bc4ddbcf941a1310"
 
   bottle do

--- a/Library/Formula/rsense.rb
+++ b/Library/Formula/rsense.rb
@@ -1,7 +1,7 @@
 class Rsense < Formula
   desc "Ruby development tools for Emacs and Vim"
   homepage "http://cx4a.org/software/rsense/"
-  url "http://cx4a.org/pub/rsense/rsense-0.3.tar.bz2"
+  url "https://web.archive.org/web/20150805143641/https://www.cx4a.org/pub/rsense/rsense-0.3.tar.bz2"
   sha256 "508795d2f11784e708cbbc39c3e4149a3e87baab7161db3df60b68a321bb534b"
 
   def install

--- a/Library/Formula/sam2p.rb
+++ b/Library/Formula/sam2p.rb
@@ -1,7 +1,7 @@
 class Sam2p < Formula
   desc "Convert raster images to EPS, PDF, and other formats"
   homepage "https://code.google.com/p/sam2p/"
-  url "https://sam2p.googlecode.com/files/sam2p-0.49.2.tar.gz"
+  url "https://web.archive.org/web/20160524062352/https://sam2p.googlecode.com/files/sam2p-0.49.2.tar.gz"
   sha256 "0e75d94bed380f8d8bd629f7797a0ca533b5d0b40eba2dab339146dedc1f79bf"
 
   fails_with :clang do

--- a/Library/Formula/sdf.rb
+++ b/Library/Formula/sdf.rb
@@ -1,7 +1,7 @@
 class Sdf < Formula
   desc "Syntax Definition Formalism: high-level description of grammars"
   homepage "http://strategoxt.org/Sdf/WebHome"
-  url "http://www.meta-environment.org/releases/sdf-2.6.3.tar.gz"
+  url "https://web.archive.org/web/20150503114503/http://www.meta-environment.org/releases/sdf-2.6.3.tar.gz"
   sha256 "181ae979118d75c6163f2acec8e455952f3033378a4518b0b829d26a96e10b3d"
 
   bottle do
@@ -22,72 +22,72 @@ class Sdf < Formula
   end
 
   resource "c-library" do
-    url "http://www.meta-environment.org/releases/c-library-1.2.tar.gz"
+    url "https://web.archive.org/web/20150503100605/http://www.meta-environment.org/releases/c-library-1.2.tar.gz"
     sha256 "08fdec0faf3c941203ff3decaf518117f49f62a42b111bac39d88e62c453b066"
   end
 
   resource "toolbuslib" do
-    url "http://www.meta-environment.org/releases/toolbuslib-1.1.tar.gz"
+    url "https://web.archive.org/web/20150503102354/http://www.meta-environment.org/releases/toolbuslib-1.1.tar.gz"
     sha256 "20f3d55b71b1e1ccf52b62e705a7dd7097ede764885d7ffd1030d27342069838"
   end
 
   resource "error-support" do
-    url "http://www.meta-environment.org/releases/error-support-1.6.tar.gz"
+    url "https://web.archive.org/web/20150503095500/http://www.meta-environment.org/releases/error-support-1.6.tar.gz"
     sha256 "634c0a1b5da8ef3b277d785d5df458dd7526da79aedd7d0537678204731dbc69"
   end
 
   resource "pt-support" do
-    url "http://www.meta-environment.org/releases/pt-support-2.4.tar.gz"
+    url "https://web.archive.org/web/20150504100441/http://www.meta-environment.org/releases/pt-support-2.4.tar.gz"
     sha256 "85c8702cc96941f4190e01ceb6cf0ba61f8bc00cedd3776f01e6bc5c21847992"
   end
 
   resource "sdf-support" do
-    url "http://www.meta-environment.org/releases/sdf-support-2.5.tar.gz"
+    url "https://web.archive.org/web/20150503112330/http://www.meta-environment.org/releases/sdf-support-2.5.tar.gz"
     sha256 "40b324d4a20f31cc4e2393fb8009125a2307d10a2ba1017ac30fd5ed859e5f7d"
   end
 
   resource "asf-support" do
-    url "http://www.meta-environment.org/releases/asf-support-1.8.tar.gz"
+    url "https://web.archive.org/web/20150504100341/http://www.meta-environment.org/releases/asf-support-1.8.tar.gz"
     sha256 "cc42fe4245b12f1ca8bcc69a36963dca4145ed6474279d89881ae0a65c7ec711"
   end
 
   resource "tide-support" do
-    url "http://www.meta-environment.org/releases/tide-support-1.3.1.tar.gz"
+    url "https://web.archive.org/web/20150503100528/http://www.meta-environment.org/releases/tide-support-1.3.1.tar.gz"
     sha256 "4bd8228fee08f84332ab6d5e2cc7dae26ddcdf92c924d477864d48066306c81a"
   end
 
   resource "rstore-support" do
-    url "http://www.meta-environment.org/releases/rstore-support-1.0.tar.gz"
+    url "https://web.archive.org/web/20150503094552/http://www.meta-environment.org/releases/rstore-support-1.0.tar.gz"
     sha256 "86bc1fa5b83718255f5f7a40b83c62f73dbbf614cb21f05df551b57548c25039"
   end
 
   resource "config-support" do
-    url "http://www.meta-environment.org/releases/config-support-1.4.tar.gz"
+    url "https://web.archive.org/web/20150503104300/http://www.meta-environment.org/releases/config-support-1.4.tar.gz"
     sha256 "b1e6e696a4a3318c6cd688291dbb9b543d68f54196df71bca6530173f661904e"
   end
 
   resource "ptable-support" do
-    url "http://www.meta-environment.org/releases/ptable-support-1.2.tar.gz"
+    url "https://web.archive.org/web/20150503112057/http://www.meta-environment.org/releases/ptable-support-1.2.tar.gz"
     sha256 "c9d219a477392e8ee7b08c2e51195190fe5c4c195e5b2cb0c13bb91a750f1d2f"
   end
 
   resource "sglr" do
-    url "http://www.meta-environment.org/releases/sglr-4.5.3.tar.gz"
+    url "https://web.archive.org/web/20150503104544/http://www.meta-environment.org/releases/sglr-4.5.3.tar.gz"
     sha256 "e748695bb97c7954da0279a2ec8d871bd810b403002c3307e4229a2cc64c78cc"
   end
 
   resource "asc-support" do
-    url "http://www.meta-environment.org/releases/asc-support-2.6.tar.gz"
+    url "https://web.archive.org/web/20150503101942/http://www.meta-environment.org/releases/asc-support-2.6.tar.gz"
     sha256 "acf5f93374d348e9aeba9590cb70392c199d2c031a6bb45d93d5f636911978eb"
   end
 
   resource "pgen" do
-    url "http://www.meta-environment.org/releases/pgen-2.8.1.tar.gz"
+    url "https://web.archive.org/web/20150503120201/http://www.meta-environment.org/releases/pgen-2.8.1.tar.gz"
     sha256 "8140d07d7512a7e963d16325427f8acaecc1dd12a23ef67593629cab6d36bd7c"
   end
 
   resource "pandora" do
-    url "http://www.meta-environment.org/releases/pandora-1.6.tar.gz"
+    url "https://web.archive.org/web/20150503104159/http://www.meta-environment.org/releases/pandora-1.6.tar.gz"
     sha256 "d62156efc4c2a921da9e1390423c72416f1d65e2ce0c97b9fbd372e51c2df28a"
   end
 

--- a/Library/Formula/sfml.rb
+++ b/Library/Formula/sfml.rb
@@ -5,7 +5,7 @@ class Sfml < Formula
 
   # SFML 2.2+ require Lion or newer
   if MacOS.version < :lion
-    url "http://www.sfml-dev.org/download/sfml/2.1/SFML-2.1-sources.zip"
+  url "https://web.archive.org/web/20140702234408/https://www.sfml-dev.org/download/sfml/2.1/SFML-2.1-sources.zip"
     sha256 "5f46d7748223be3f0c6a9fcf18c0016d227f7b1903cdbcd85f61ddbc82ef95bf"
     revision 1
   else

--- a/Library/Formula/sgrep.rb
+++ b/Library/Formula/sgrep.rb
@@ -1,7 +1,7 @@
 class Sgrep < Formula
   desc "Search SGML, XML, and HTML"
   homepage "https://www.cs.helsinki.fi/u/jjaakkol/sgrep.html"
-  url "ftp://ftp.cs.helsinki.fi/pub/Software/Local/Sgrep/sgrep-1.94a.tar.gz"
+  url "https://web.archive.org/web/20150317002621/https://fossies.org/linux/misc/sgrep-1.94a.tar.gz"
   mirror "https://fossies.org/linux/misc/sgrep-1.94a.tar.gz"
   sha256 "d5b16478e3ab44735e24283d2d895d2c9c80139c95228df3bdb2ac446395faf9"
 

--- a/Library/Formula/shakespeare.rb
+++ b/Library/Formula/shakespeare.rb
@@ -1,7 +1,7 @@
 class Shakespeare < Formula
   desc "Write programs in Shakespearean English"
   homepage "http://shakespearelang.sourceforge.net/"
-  url "http://shakespearelang.sf.net/download/spl-1.2.1.tar.gz"
+  url "https://web.archive.org/web/20210506141732/https://shakespearelang.sourceforge.net/download/spl-1.2.1.tar.gz"
   sha256 "1206ef0a2c853b8b40ca0c682bc9d9e0a157cc91a7bf4e28f19ccd003674b7d3"
 
   depends_on "flex" if MacOS.version >= :mountain_lion

--- a/Library/Formula/shellinabox.rb
+++ b/Library/Formula/shellinabox.rb
@@ -1,7 +1,7 @@
 class Shellinabox < Formula
   desc "Export command-line tools to web based terminal emulator"
   homepage "https://code.google.com/p/shellinabox/"
-  url "https://shellinabox.googlecode.com/files/shellinabox-2.14.tar.gz"
+  url "https://web.archive.org/web/20160606224622/https://shellinabox.googlecode.com/files/shellinabox-2.14.tar.gz"
   sha256 "4126eb7070869787c161102cc2781d24d1d50c8aef4e5a3e1b5446e65d691071"
 
   def install

--- a/Library/Formula/shunit2.rb
+++ b/Library/Formula/shunit2.rb
@@ -1,7 +1,7 @@
 class Shunit2 < Formula
   desc "xUnit unit testing framework for Bourne-based shell scripts"
   homepage "https://code.google.com/p/shunit2/"
-  url "https://shunit2.googlecode.com/files/shunit2-2.1.6.tgz"
+  url "https://web.archive.org/web/20160524161002/https://shunit2.googlecode.com/files/shunit2-2.1.6.tgz"
   sha256 "65a313a76fd5cc1c58c9e19fbc80fc0e418a4cbfbd46d54b35ed5b6e0025d4ee"
 
   def install

--- a/Library/Formula/simgrid.rb
+++ b/Library/Formula/simgrid.rb
@@ -1,7 +1,7 @@
 class Simgrid < Formula
   desc "Studies behavior of large-scale distributed systems"
   homepage "http://simgrid.gforge.inria.fr"
-  url "http://gforge.inria.fr/frs/download.php/file/33686/SimGrid-3.11.1.tar.gz"
+  url "https://web.archive.org/web/20160324154858/https://gforge.inria.fr/frs/download.php/file/33686/SimGrid-3.11.1.tar.gz"
   sha256 "7796ef6d4288462fdabdf5696c453ea6aabc433a813a384db2950ae26eff7956"
 
   bottle do

--- a/Library/Formula/simh.rb
+++ b/Library/Formula/simh.rb
@@ -1,7 +1,7 @@
 class Simh < Formula
   desc "Portable, multi-system simulator"
   homepage "http://simh.trailing-edge.com/"
-  url "http://simh.trailing-edge.com/sources/simhv39-0.zip"
+  url "https://web.archive.org/web/20160824043205/http://simh.trailing-edge.com/sources/simhv39-0.zip"
   sha256 "e49b259b66ad6311ca9066dee3d3693cd915106a6938a52ed685cdbada8eda3b"
   version "3.9-0"
 

--- a/Library/Formula/skipfish.rb
+++ b/Library/Formula/skipfish.rb
@@ -1,7 +1,7 @@
 class Skipfish < Formula
   desc "Web application security scanner"
   homepage "https://code.google.com/p/skipfish/"
-  url "https://skipfish.googlecode.com/files/skipfish-2.10b.tgz"
+  url "https://web.archive.org/web/20160603142927/https://skipfish.googlecode.com/files/skipfish-2.10b.tgz"
   sha256 "1a4fbc9d013f1f9b970946ea7228d943266127b7f4100c994ad26c82c5352a9e"
   revision 1
 

--- a/Library/Formula/skytools.rb
+++ b/Library/Formula/skytools.rb
@@ -1,7 +1,7 @@
 class Skytools < Formula
   desc "Database management tools from Skype to PostgreSQL"
   homepage "http://pgfoundry.org/projects/skytools/"
-  url "http://pgfoundry.org/frs/download.php/3622/skytools-3.2.tar.gz"
+  url "https://web.archive.org/web/20140811132901/https://pgfoundry.org/frs/download.php/3622/skytools-3.2.tar.gz"
   sha256 "0fa9c819ab50ca2cbcc5e71cd80ab734120c9d628667af08f9a95ca62086ab5f"
 
   # Works only with homebrew postgres:

--- a/Library/Formula/slowhttptest.rb
+++ b/Library/Formula/slowhttptest.rb
@@ -1,7 +1,7 @@
 class Slowhttptest < Formula
   desc "Simulates application layer denial of service attacks"
   homepage "https://code.google.com/p/slowhttptest/"
-  url "https://slowhttptest.googlecode.com/files/slowhttptest-1.6.tar.gz"
+  url "https://web.archive.org/web/20150802145356/https://slowhttptest.googlecode.com/files/slowhttptest-1.6.tar.gz"
   sha256 "77c54a64cfa5f12a84729833d9b98d5f27f828f51a5e42ad5914482d0b2bd0d6"
   revision 1
 

--- a/Library/Formula/snownews.rb
+++ b/Library/Formula/snownews.rb
@@ -1,7 +1,7 @@
 class Snownews < Formula
   desc "Text mode RSS newsreader"
   homepage "https://kiza.eu/software/snownews"
-  url "https://kiza.eu/media/software/snownews/snownews-1.5.12.tar.gz"
+  url "https://web.archive.org/web/20141125130412/https://kiza.eu/media/software/snownews/snownews-1.5.12.tar.gz"
   sha256 "26dd96e9345d9cbc1c0c9470417080dd0c3eb31e7ea944f78f3302d7060ecb90"
   revision 1
 

--- a/Library/Formula/softhsm.rb
+++ b/Library/Formula/softhsm.rb
@@ -1,7 +1,7 @@
 class Softhsm < Formula
   desc "Cryptographic store accessible through a PKCS#11 interface"
   homepage "https://www.opendnssec.org/softhsm/"
-  url "https://dist.opendnssec.org/source/softhsm-2.0.0.tar.gz"
+  url "https://web.archive.org/web/20150928180930/https://dist.opendnssec.org/source/softhsm-2.0.0.tar.gz"
   sha256 "eae8065f6c472af24f4c056d6728edda0fd34306f41a818697f765a6a662338d"
 
   bottle do

--- a/Library/Formula/somagic-tools.rb
+++ b/Library/Formula/somagic-tools.rb
@@ -1,7 +1,7 @@
 class SomagicTools < Formula
   desc "Tools to extract firmware from EasyCAP"
   homepage "https://code.google.com/p/easycap-somagic-linux/"
-  url "https://easycap-somagic-linux.googlecode.com/files/somagic-easycap-tools_1.1.tar.gz"
+  url "https://web.archive.org/web/20160103065754/https://easycap-somagic-linux.googlecode.com/files/somagic-easycap-tools_1.1.tar.gz"
   sha256 "b091723c55e6910cbf36c88f8d37a8d69856868691899683ec70c83b122a0715"
 
   depends_on "libusb"

--- a/Library/Formula/somagic.rb
+++ b/Library/Formula/somagic.rb
@@ -1,7 +1,7 @@
 class Somagic < Formula
   desc "Linux capture program for the Somagic variants of EasyCAP"
   homepage "https://code.google.com/p/easycap-somagic-linux/"
-  url "https://easycap-somagic-linux.googlecode.com/files/somagic-easycap_1.1.tar.gz"
+  url "https://web.archive.org/web/20160103065757/https://easycap-somagic-linux.googlecode.com/files/somagic-easycap_1.1.tar.gz"
   sha256 "3a9dd78a47335a6d041cd5465d28124612dad97939c56d7c10e000484d78a320"
 
   depends_on "libusb"

--- a/Library/Formula/sonar-runner.rb
+++ b/Library/Formula/sonar-runner.rb
@@ -1,7 +1,7 @@
 class SonarRunner < Formula
   desc "Launcher to analyze a project with SonarQube"
   homepage "http://docs.sonarqube.org/display/SONAR/Installing+and+Configuring+SonarQube+Runner"
-  url "http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip"
+  url "https://web.archive.org/web/20240615223630/http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip"
   sha256 "f794545e23092c8b56d64d58ff571b2599480150b3fc41173b3761d634a16d48"
 
   head "https://github.com/SonarSource/sonar-runner.git"

--- a/Library/Formula/spring-loaded.rb
+++ b/Library/Formula/spring-loaded.rb
@@ -1,7 +1,7 @@
 class SpringLoaded < Formula
   desc "Java agent to enable class reloading in a running JVM"
   homepage "https://github.com/spring-projects/spring-loaded"
-  url "https://repo.spring.io/simple/libs-release-local/org/springframework/springloaded/1.2.3.RELEASE/springloaded-1.2.3.RELEASE.jar"
+  url "https://web.archive.org/web/20150811010434/https://repo.spring.io/simple/libs-release-local/org/springframework/springloaded/1.2.3.RELEASE/springloaded-1.2.3.RELEASE.jar"
   sha256 "c90c406c36ce077a9f76e05859d397aad7d0f427c6c395c6749cbdef697ba43f"
   version "1.2.3"
 

--- a/Library/Formula/srmio.rb
+++ b/Library/Formula/srmio.rb
@@ -1,7 +1,7 @@
 class Srmio < Formula
   desc "C library to access the PowerControl of a SRM bike power meter"
   homepage "http://www.zuto.de/project/srmio/"
-  url "http://www.zuto.de/project/files/srmio/srmio-0.1.1~git1.tar.gz"
+  url "https://web.archive.org/web/20150807030102/http://www.zuto.de/project/files/srmio/srmio-0.1.1~git1.tar.gz"
   sha256 "00b3772202034aaada94f1f1c79a1072fac1f69d10ef0afcb751cce74e5ccd31"
   version "0.1.1~git1"
 

--- a/Library/Formula/sslh.rb
+++ b/Library/Formula/sslh.rb
@@ -3,7 +3,7 @@ class Sslh < Formula
   homepage "http://www.rutschle.net/tech/sslh.shtml"
 
   stable do
-    url "http://www.rutschle.net/tech/sslh-v1.17.tar.gz"
+  url "https://web.archive.org/web/20160310111027/https://www.rutschle.net/tech/sslh-v1.17.tar.gz"
     sha256 "4f3589ed36d8a21581268d53055240eee5e5adf02894a2ca7a6c9022f24b582a"
 
     # fixes `make install`, fixed in HEAD

--- a/Library/Formula/ssreflect.rb
+++ b/Library/Formula/ssreflect.rb
@@ -1,7 +1,7 @@
 class Ssreflect < Formula
   desc "Virtual package provided by libssreflect-coq"
   homepage "http://www.msr-inria.fr/projects/mathematical-components-2/"
-  url "http://ssr.msr-inria.inria.fr/FTP/ssreflect-1.5.tar.gz"
+  url "https://web.archive.org/web/20170119011934/http://ssr.msr-inria.inria.fr/FTP/ssreflect-1.5.tar.gz"
   sha256 "bad978693d1bfd0a89586a34678bcc244e3b7efba6431e0f83d8e1ae8f82a142"
 
   depends_on "ocaml"

--- a/Library/Formula/stanford-parser.rb
+++ b/Library/Formula/stanford-parser.rb
@@ -1,7 +1,7 @@
 class StanfordParser < Formula
   desc "Statistical NLP parser"
   homepage "http://nlp.stanford.edu/software/lex-parser.shtml"
-  url "http://nlp.stanford.edu/software/stanford-parser-full-2015-04-20.zip"
+  url "https://web.archive.org/web/20220402220037/https://downloads.cs.stanford.edu/nlp/software/stanford-parser-full-2015-04-20.zip"
   sha256 "05bd11e500219bbbffa4bae004619560bc03f1481f9516c4bb51863e265333b8"
   version "3.5.2"
 

--- a/Library/Formula/stgit.rb
+++ b/Library/Formula/stgit.rb
@@ -1,7 +1,7 @@
 class Stgit < Formula
   desc "Push/pop utility built on top of Git"
   homepage "http://gna.org/projects/stgit/"
-  url "http://download.gna.org/stgit/stgit-0.17.1.tar.gz"
+  url "https://web.archive.org/web/20170225204615/http://download.gna.org/stgit/stgit-0.17.1.tar.gz"
   sha256 "d43365a0c22e41a6fb9ba1a86de164d6475e79054e7f33805d6a829eb4056ade"
 
   head "git://repo.or.cz/stgit.git"

--- a/Library/Formula/subnetcalc.rb
+++ b/Library/Formula/subnetcalc.rb
@@ -1,7 +1,7 @@
 class Subnetcalc < Formula
   desc "IPv4/IPv6 subnet calculator"
   homepage "https://www.uni-due.de/~be0001/subnetcalc/"
-  url "https://www.uni-due.de/~be0001/subnetcalc/download/subnetcalc-2.4.2.tar.gz"
+  url "https://web.archive.org/web/20241220105710/https://www.nntb.no/~dreibh/subnetcalc/download/subnetcalc-2.4.2.tar.gz"
   sha256 "910ec4f47d8d3348be9ec8d66404259c0a48d2f40db86f7a71a469dd3ecf4339"
 
   bottle do

--- a/Library/Formula/supersonic.rb
+++ b/Library/Formula/supersonic.rb
@@ -1,7 +1,7 @@
 class Supersonic < Formula
   desc "C++ library providing a column oriented query engine"
   homepage "https://code.google.com/p/supersonic/"
-  url "https://supersonic.googlecode.com/files/supersonic-0.9.4.tar.gz"
+  url "https://web.archive.org/web/20160502175033/https://supersonic.googlecode.com/files/supersonic-0.9.4.tar.gz"
   sha256 "1592dfd2dc73f0b97298e0d25e51528dc9a94e9e7f4ab525569f63db0442d769"
 
   bottle do

--- a/Library/Formula/surfraw.rb
+++ b/Library/Formula/surfraw.rb
@@ -1,7 +1,7 @@
 class Surfraw < Formula
   desc "Shell Users' Revolutionary Front Rage Against the Web"
   homepage "https://surfraw.alioth.debian.org/"
-  url "https://surfraw.alioth.debian.org/dist/surfraw-2.2.9.tar.gz"
+  url "https://web.archive.org/web/20170106220654/https://surfraw.alioth.debian.org/dist/surfraw-2.2.9.tar.gz"
   sha256 "aa97d9ac24ca4299be39fcde562b98ed556b3bf5ee9a1ae497e0ce040bbcc4bb"
 
   head do

--- a/Library/Formula/svdlibc.rb
+++ b/Library/Formula/svdlibc.rb
@@ -1,7 +1,7 @@
 class Svdlibc < Formula
   desc "C library to perform singular value decomposition"
   homepage "http://tedlab.mit.edu/~dr/SVDLIBC/"
-  url "http://tedlab.mit.edu/~dr/SVDLIBC/svdlibc.tgz"
+  url "https://web.archive.org/web/20160908172800/http://tedlab.mit.edu/~dr/SVDLIBC/svdlibc.tgz"
   version "1.4"
   sha256 "aa1a49a95209801803cc2d9f8792e482b0e8302da8c7e7c9a38e25e5beabe5f8"
 

--- a/Library/Formula/swish-e.rb
+++ b/Library/Formula/swish-e.rb
@@ -1,7 +1,7 @@
 class SwishE < Formula
   desc "System for indexing collections of web pages"
   homepage "http://swish-e.org/"
-  url "http://swish-e.org/distribution/swish-e-2.4.7.tar.gz"
+  url "https://web.archive.org/web/20160409061831/http://swish-e.org/distribution/swish-e-2.4.7.tar.gz"
   sha256 "5ddd541ff8ecb3c78ad6ca76c79e620f457fac9f7d0721ad87e9fa22fe997962"
 
   bottle do

--- a/Library/Formula/syck.rb
+++ b/Library/Formula/syck.rb
@@ -1,7 +1,7 @@
 class Syck < Formula
   desc "Extension for reading and writing YAML"
   homepage "https://wiki.github.com/indeyets/syck/"
-  url "http://cloud.github.com/downloads/indeyets/syck/syck-0.70.tar.gz"
+  url "https://web.archive.org/web/20140624230553/http://cloud.github.com/downloads/indeyets/syck/syck-0.70.tar.gz"
   sha256 "4c94c472ee8314e0d76eb2cca84f6029dc8fc58bfbc47748d50dcb289fda094e"
 
   fails_with :llvm do

--- a/Library/Formula/szip.rb
+++ b/Library/Formula/szip.rb
@@ -1,7 +1,7 @@
 class Szip < Formula
   desc "Implementation of extended-Rice lossless compression algorithm"
   homepage "http://www.hdfgroup.org/HDF5/release/obtain5.html#extlibs"
-  url "http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz"
+  url "https://web.archive.org/web/20150803144119/http://www.hdfgroup.org/ftp/lib-external/szip/2.1/src/szip-2.1.tar.gz"
   sha256 "a816d95d5662e8279625abdbea7d0e62157d7d1f028020b1075500bf483ed5ef"
 
   bottle do

--- a/Library/Formula/szl.rb
+++ b/Library/Formula/szl.rb
@@ -1,7 +1,7 @@
 class Szl < Formula
   desc "Compiler and runtime for the Sawzall language"
   homepage "https://code.google.com/p/szl/"
-  url "https://szl.googlecode.com/files/szl-1.0.tar.gz"
+  url "https://web.archive.org/web/20160503223131/https://szl.googlecode.com/files/szl-1.0.tar.gz"
   sha256 "af5c647276fd0dea658eae6016957b7ad09ac68efe13ae2a3c867043b5889f87"
   revision 5
 

--- a/Library/Formula/taskd.rb
+++ b/Library/Formula/taskd.rb
@@ -1,7 +1,7 @@
 class Taskd < Formula
   desc "Client-server synchronization for todo lists"
   homepage "http://taskwarrior.org/projects/show/taskwarrior"
-  url "http://taskwarrior.org/download/taskd-1.1.0.tar.gz"
+  url "https://web.archive.org/web/20230821020044/https://taskwarrior.org/download/taskd-1.1.0.tar.gz"
   sha256 "7b8488e687971ae56729ff4e2e5209ff8806cf8cd57718bfd7e521be130621b4"
 
   head "https://git.tasktools.org/scm/tm/taskd.git"

--- a/Library/Formula/tasksh.rb
+++ b/Library/Formula/tasksh.rb
@@ -1,7 +1,7 @@
 class Tasksh < Formula
   desc "Shell wrapper for Taskwarrior commands"
   homepage "http://tasktools.org/projects/tasksh.html"
-  url "http://taskwarrior.org/download/tasksh-1.0.0.tar.gz"
+  url "https://web.archive.org/web/20160409200455/https://taskwarrior.org/download/tasksh-1.0.0.tar.gz"
   head "https://git.tasktools.org/scm/ex/tasksh.git"
   sha256 "9accc81f5ae3a985e33be728d56aba0401889d21f856cd94734d73c221bf8652"
 

--- a/Library/Formula/tcping.rb
+++ b/Library/Formula/tcping.rb
@@ -1,7 +1,7 @@
 class Tcping < Formula
   desc "TCP connect to the given IP/port combo"
   homepage "http://www.linuxco.de/tcping/tcping.html"
-  url "http://www.linuxco.de/tcping/tcping-1.3.5.tar.gz"
+  url "https://web.archive.org/web/20170320182446/http://www.linuxco.de/tcping/tcping-1.3.5.tar.gz"
   sha256 "1ad52e904094d12b225ac4a0bc75297555e931c11a1501445faa548ff5ecdbd0"
 
   bottle do

--- a/Library/Formula/theharvester.rb
+++ b/Library/Formula/theharvester.rb
@@ -1,7 +1,7 @@
 class Theharvester < Formula
   desc "Gather materials from public sources (for pen testers)"
   homepage "https://code.google.com/p/theharvester/"
-  url "https://theharvester.googlecode.com/files/theHarvester-2.2a.tar.gz"
+  url "https://web.archive.org/web/20160424160418/https://theharvester.googlecode.com/files/theHarvester-2.2a.tar.gz"
   sha256 "40f118ef783448460aac10f1fca832fac5ac6f9df3777788ae73578580fd7a4b"
 
   def install

--- a/Library/Formula/tig.rb
+++ b/Library/Formula/tig.rb
@@ -1,13 +1,13 @@
 class Tig < Formula
   desc "Text interface for Git repositories"
   homepage "http://jonas.nitro.dk/tig/"
-  url "http://jonas.nitro.dk/tig/releases/tig-2.1.1.tar.gz"
+  url "https://web.archive.org/web/20160506110113/http://jonas.nitro.dk/tig/releases/tig-2.1.1.tar.gz"
   sha256 "50c5179fd564b829b6b2cec087e66f10cf8799601de19350df0772ae77e4852f"
   head "https://github.com/jonas/tig.git"
   revision 1
 
   stable do
-    url "http://jonas.nitro.dk/tig/releases/tig-2.1.1.tar.gz"
+    url "https://web.archive.org/web/20160506110113/http://jonas.nitro.dk/tig/releases/tig-2.1.1.tar.gz"
     sha256 "50c5179fd564b829b6b2cec087e66f10cf8799601de19350df0772ae77e4852f"
 
     # Merged in HEAD; remove in next stable release

--- a/Library/Formula/timelimit.rb
+++ b/Library/Formula/timelimit.rb
@@ -1,7 +1,7 @@
 class Timelimit < Formula
   desc "Limit a process's absolute execution time"
   homepage "http://devel.ringlet.net/sysutils/timelimit/"
-  url "http://devel.ringlet.net/sysutils/timelimit/timelimit-1.8.tar.gz"
+  url "https://web.archive.org/web/20150806151234/http://devel.ringlet.net/sysutils/timelimit/timelimit-1.8.tar.gz"
   sha256 "026e72b345f8407ebaa002036fd785b2136b2dfc4f8854f14536196ee3079996"
 
   def install

--- a/Library/Formula/tinyproxy.rb
+++ b/Library/Formula/tinyproxy.rb
@@ -1,7 +1,7 @@
 class Tinyproxy < Formula
   desc "HTTP/HTTPS proxy for POSIX systems"
   homepage "https://www.banu.com/tinyproxy/"
-  url "https://www.banu.com/pub/tinyproxy/1.8/tinyproxy-1.8.3.tar.bz2"
+  url "https://web.archive.org/web/20130129162605/https://www.banu.com/pub/tinyproxy/1.8/tinyproxy-1.8.3.tar.bz2"
   sha256 "be559b54eb4772a703ad35239d1cb59d32f7cf8a739966742622d57df88b896e"
 
   bottle do

--- a/Library/Formula/titan-server.rb
+++ b/Library/Formula/titan-server.rb
@@ -1,7 +1,7 @@
 class TitanServer < Formula
   desc "Distributed graph database"
   homepage "https://thinkaurelius.github.io/titan/"
-  url "http://s3.thinkaurelius.com/downloads/titan/titan-server-0.4.4.zip"
+  url "https://web.archive.org/web/20160818162040/http://s3.thinkaurelius.com/downloads/titan/titan-server-0.4.4.zip"
   sha256 "46703d315aa6ca0602b022fadca3846a58ba69bb490acb210bedd5be3bf12ef5"
 
   # In reference to PR #30107 this patch will update the titan.sh and rexster-console.sh

--- a/Library/Formula/tofrodos.rb
+++ b/Library/Formula/tofrodos.rb
@@ -1,7 +1,7 @@
 class Tofrodos < Formula
   desc "Converts DOS <-> UNIX text files, alias tofromdos"
   homepage "http://www.thefreecountry.com/tofrodos/"
-  url "http://tofrodos.sourceforge.net/download/tofrodos-1.7.13.tar.gz"
+  url "https://web.archive.org/web/20150801124347/https://tofrodos.sourceforge.net/download/tofrodos-1.7.13.tar.gz"
   sha256 "3457f6f3e47dd8c6704049cef81cb0c5a35cc32df9fe800b5fbb470804f0885f"
 
   def install

--- a/Library/Formula/tokyo-dystopia.rb
+++ b/Library/Formula/tokyo-dystopia.rb
@@ -1,7 +1,7 @@
 class TokyoDystopia < Formula
   desc "Lightweight full-text search system"
   homepage "http://fallabs.com/tokyodystopia/"
-  url "http://fallabs.com/tokyodystopia/tokyodystopia-0.9.15.tar.gz"
+  url "https://web.archive.org/web/20221222202441/http://fallabs.com/tokyodystopia/tokyodystopia-0.9.15.tar.gz"
   sha256 "28b43c592a127d1c9168eac98f680aa49d1137b4c14b8d078389bbad1a81830a"
 
   bottle do

--- a/Library/Formula/tokyo-tyrant.rb
+++ b/Library/Formula/tokyo-tyrant.rb
@@ -1,7 +1,7 @@
 class TokyoTyrant < Formula
   desc "Lightweight database server"
   homepage "http://fallabs.com/tokyotyrant/"
-  url "http://fallabs.com/tokyotyrant/tokyotyrant-1.1.41.tar.gz"
+  url "https://web.archive.org/web/20221222202446/http://fallabs.com/tokyotyrant/tokyotyrant-1.1.41.tar.gz"
   sha256 "42af70fb9f2795d4e05c3e37941ce392a9eaafc991e230c48115370f6d64b88f"
   revision 1
 

--- a/Library/Formula/trang.rb
+++ b/Library/Formula/trang.rb
@@ -1,7 +1,7 @@
 class Trang < Formula
   desc "XML schema converter"
   homepage "https://code.google.com/p/jing-trang/"
-  url "https://jing-trang.googlecode.com/files/trang-20091111.zip"
+  url "https://web.archive.org/web/20160117175229/https://jing-trang.googlecode.com/files/trang-20091111.zip"
   sha256 "d8a3f034f9918ebe5b265aafeadbee6729ddda5732cfc368e2c30b3b8c0ca598"
 
   def install

--- a/Library/Formula/trr.rb
+++ b/Library/Formula/trr.rb
@@ -1,7 +1,7 @@
 class Trr < Formula
   desc "Type training program for emacs users"
   homepage "https://code.google.com/p/trr22/"
-  url "https://trr22.googlecode.com/files/trr22_0.99-5.tar.gz"
+  url "https://web.archive.org/web/20160512094720/https://trr22.googlecode.com/files/trr22_0.99-5.tar.gz"
   version "22.0.99.5"
   sha256 "6bac2f947839cebde626cdaab0c0879de8f6f6e40bfd7a14ccdfe1a035a3bcc6"
   revision 1

--- a/Library/Formula/ttf2eot.rb
+++ b/Library/Formula/ttf2eot.rb
@@ -1,7 +1,7 @@
 class Ttf2eot < Formula
   desc "Convert TTF files to EOT"
   homepage "https://code.google.com/p/ttf2eot/"
-  url "https://ttf2eot.googlecode.com/files/ttf2eot-0.0.2-2.tar.gz"
+  url "https://web.archive.org/web/20160507180343/https://ttf2eot.googlecode.com/files/ttf2eot-0.0.2-2.tar.gz"
   sha256 "023cf04d7c717657e92afe566518bf2a696ab22a2a8eba764340000bebff8db8"
 
   def install

--- a/Library/Formula/txt2tags.rb
+++ b/Library/Formula/txt2tags.rb
@@ -1,7 +1,7 @@
 class Txt2tags < Formula
   desc "Conversion tool to generating several file formats"
   homepage "http://txt2tags.org"
-  url "https://txt2tags.googlecode.com/files/txt2tags-2.6.tgz"
+  url "https://web.archive.org/web/20140620132617/https://txt2tags.googlecode.com/files/txt2tags-2.6.tgz"
   sha256 "601467d7860f3cfb3d48050707c6277ff3ceb22fa7be4f5bd968de540ac5b05c"
 
   def install

--- a/Library/Formula/uchardet.rb
+++ b/Library/Formula/uchardet.rb
@@ -1,7 +1,7 @@
 class Uchardet < Formula
   desc "Encoding detector library"
   homepage "https://code.google.com/p/uchardet/"
-  url "https://uchardet.googlecode.com/files/uchardet-0.0.1.tar.gz"
+  url "https://web.archive.org/web/20160509093937/https://uchardet.googlecode.com/files/uchardet-0.0.1.tar.gz"
   sha256 "e238c212350e07ebbe1961f8f128faaa40f71b70d37b63ffa2fe12c664269ee6"
 
   depends_on "cmake" => :build

--- a/Library/Formula/udns.rb
+++ b/Library/Formula/udns.rb
@@ -1,7 +1,7 @@
 class Udns < Formula
   desc "DNS resolver library"
   homepage "http://www.corpit.ru/mjt/udns.html"
-  url "http://www.corpit.ru/mjt/udns/udns-0.4.tar.gz"
+  url "https://web.archive.org/web/20240804152801/http://www.corpit.ru/mjt/udns/udns-0.4.tar.gz"
   sha256 "115108dc791a2f9e99e150012bcb459d9095da2dd7d80699b584ac0ac3768710"
 
   # Build target for dylib. See:

--- a/Library/Formula/uim.rb
+++ b/Library/Formula/uim.rb
@@ -1,7 +1,7 @@
 class Uim < Formula
   desc "Multilingual input method library"
   homepage "https://code.google.com/p/uim/"
-  url "https://uim.googlecode.com/files/uim-1.6.0.tar.bz2"
+  url "https://web.archive.org/web/20160511005958/https://uim.googlecode.com/files/uim-1.6.0.tar.bz2"
   sha256 "2a34dca2091eb6d61f05dabd8512c6658d8cefa8db14b7a684fbb10caea4a3aa"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/unar.rb
+++ b/Library/Formula/unar.rb
@@ -1,7 +1,7 @@
 class Unar < Formula
   desc "RAR archive command-line tools"
   homepage "http://unarchiver.c3.cx/commandline"
-  url "https://wakaba.c3.cx/releases/TheUnarchiver/unar1.8.1_src.zip"
+  url "https://web.archive.org/web/20150914203105/https://wakaba.c3.cx/releases/TheUnarchiver/unar1.8.1_src.zip"
   version "1.8.1"
   sha256 "67ccb1c780150840f38de63b8e7047717ef4c71b7574d9ef57bd9d9c93255709"
 

--- a/Library/Formula/unison.rb
+++ b/Library/Formula/unison.rb
@@ -1,7 +1,7 @@
 class Unison < Formula
   desc "Unison file synchronizer"
   homepage "https://www.cis.upenn.edu/~bcpierce/unison/"
-  url "https://www.seas.upenn.edu/~bcpierce/unison//download/releases/stable/unison-2.48.3.tar.gz"
+  url "https://web.archive.org/web/20160322180003/https://www.seas.upenn.edu/~bcpierce/unison//download/releases/stable/unison-2.48.3.tar.gz"
   sha256 "f40d3cfbe82078d79328b51acab3e5179f844135260c2f4710525b9b45b15483"
 
   bottle do

--- a/Library/Formula/upx.rb
+++ b/Library/Formula/upx.rb
@@ -1,7 +1,7 @@
 class Upx < Formula
   desc "Compress/expand executable files"
   homepage "http://upx.sourceforge.net"
-  url "http://upx.sourceforge.net/download/upx-3.91-src.tar.bz2"
+  url "https://web.archive.org/web/20140922044733/https://fossies.org/linux/privat/upx-3.91-src.tar.bz2"
   mirror "https://fossies.org/linux/privat/upx-3.91-src.tar.bz2"
   sha256 "527ce757429841f51675352b1f9f6fc8ad97b18002080d7bf8672c466d8c6a3c"
   head "https://www.pysol.org:4443/hg/upx.hg", :using => :hg

--- a/Library/Formula/usbmuxd.rb
+++ b/Library/Formula/usbmuxd.rb
@@ -1,7 +1,7 @@
 class Usbmuxd < Formula
   desc "USB multiplexor daemon for iPhone and iPod Touch devices"
   homepage "http://www.libimobiledevice.org"
-  url "http://www.libimobiledevice.org/downloads/libusbmuxd-1.0.10.tar.bz2"
+  url "https://web.archive.org/web/20160305032232/https://libimobiledevice.org/downloads/libusbmuxd-1.0.10.tar.bz2"
   sha256 "1aa21391265d2284ac3ccb7cf278126d10d354878589905b35e8102104fec9f2"
 
   bottle do

--- a/Library/Formula/valgrind.rb
+++ b/Library/Formula/valgrind.rb
@@ -3,7 +3,7 @@ class Valgrind < Formula
   homepage "http://www.valgrind.org/"
 
   stable do
-    url "http://valgrind.org/downloads/valgrind-3.11.0.tar.bz2"
+  url "https://web.archive.org/web/20160506105723/https://valgrind.org/downloads/valgrind-3.11.0.tar.bz2"
     sha256 "6c396271a8c1ddd5a6fb9abe714ea1e8a86fce85b30ab26b4266aeb4c2413b42"
   end
 

--- a/Library/Formula/valkyrie.rb
+++ b/Library/Formula/valkyrie.rb
@@ -1,7 +1,7 @@
 class Valkyrie < Formula
   desc "GUI for Memcheck and Helgrind tools in Valgrind 3.6.X"
   homepage "http://valgrind.org/downloads/guis.html"
-  url "http://valgrind.org/downloads/valkyrie-2.0.0.tar.bz2"
+  url "https://web.archive.org/web/20210626154428/https://valgrind.org/downloads/valkyrie-2.0.0.tar.bz2"
   sha256 "a70b9ffb2409c96c263823212b4be6819154eb858825c9a19aad0ae398d59b43"
 
   head "svn://svn.valgrind.org/valkyrie/trunk"

--- a/Library/Formula/varnish.rb
+++ b/Library/Formula/varnish.rb
@@ -1,7 +1,7 @@
 class Varnish < Formula
   desc "High-performance HTTP accelerator"
   homepage "https://www.varnish-cache.org/"
-  url "https://repo.varnish-cache.org/source/varnish-4.0.3.tar.gz"
+  url "https://web.archive.org/web/20161104073920/https://repo.varnish-cache.org/source/varnish-4.0.3.tar.gz"
   sha256 "94b9a174097f47db2286acd2c35f235e49a2b7a9ddfdbd6eb7aa4da9ae8f8206"
 
   bottle do

--- a/Library/Formula/virtualpg.rb
+++ b/Library/Formula/virtualpg.rb
@@ -1,7 +1,7 @@
 class Virtualpg < Formula
   desc "Loadable dynamic extension for SQLite and SpatiaLite"
   homepage "https://www.gaia-gis.it/fossil/virtualpg/index"
-  url "http://www.gaia-gis.it/gaia-sins/virtualpg-1.0.1.tar.gz"
+  url "https://web.archive.org/web/20161204003908/http://www.gaia-gis.it/gaia-sins/virtualpg-1.0.1.tar.gz"
   sha256 "9e6c4c6c1556b2ea2a1e4deda28909626c3a8b047c81d6b82c042abdb9a99ec8"
 
   depends_on "libspatialite"

--- a/Library/Formula/visitors.rb
+++ b/Library/Formula/visitors.rb
@@ -1,7 +1,7 @@
 class Visitors < Formula
   desc "eb server log analyzer"
   homepage "http://www.hping.org/visitors/"
-  url "http://www.hping.org/visitors/visitors-0.7.tar.gz"
+  url "https://web.archive.org/web/20220420184352/https://www.hping.org/visitors/visitors-0.7.tar.gz"
   sha256 "d2149e33ffe96b1f52b0587cff65973b0bc0b24ec43cdf072a782c1bd52148ab"
 
   bottle do

--- a/Library/Formula/visualnetkit.rb
+++ b/Library/Formula/visualnetkit.rb
@@ -1,7 +1,7 @@
 class Visualnetkit < Formula
   desc "Graphical environment to configure and manage Netkit lab"
   homepage "https://code.google.com/p/visual-netkit/"
-  url "https://visual-netkit.googlecode.com/files/visualnetkit-1.4.tar.bz"
+  url "https://web.archive.org/web/20160420103948/https://visual-netkit.googlecode.com/files/visualnetkit-1.4.tar.bz"
   version "1.4"
   sha256 "d1b02b253520a337ced5c450a0cd68e76aef289fa9d2777470455c0edfec5ce7"
 

--- a/Library/Formula/vit.rb
+++ b/Library/Formula/vit.rb
@@ -2,7 +2,7 @@ class Vit < Formula
   desc "Front-end for Task Warrior"
   homepage "http://taskwarrior.org/news/news.20140406.html"
   head "https://git.tasktools.org/scm/ex/vit.git"
-  url "http://taskwarrior.org/download/vit-1.2.tar.gz"
+  url "https://web.archive.org/web/20211122225155/https://taskwarrior.org/download/vit-1.2.tar.gz"
   sha256 "a78dee573130c8d6bc92cf60fafac0abc78dd2109acfba587cb0ae202ea5bbd0"
   revision 1
 

--- a/Library/Formula/vramsteg.rb
+++ b/Library/Formula/vramsteg.rb
@@ -1,7 +1,7 @@
 class Vramsteg < Formula
   desc "Add progress bars to command-line applications"
   homepage "http://tasktools.org/projects/vramsteg.html"
-  url "http://taskwarrior.org/download/vramsteg-1.0.1.tar.gz"
+  url "https://web.archive.org/web/20150223053403/https://taskwarrior.org/download/vramsteg-1.0.1.tar.gz"
   sha256 "bc47e078079a845fa9c9cc5e4c9f4585402430ac6efc82ea6ff607506af8bdb9"
 
   depends_on "cmake" => :build

--- a/Library/Formula/vtclock.rb
+++ b/Library/Formula/vtclock.rb
@@ -1,7 +1,7 @@
 class Vtclock < Formula
   desc "Text-mode fullscreen digital clock"
   homepage "http://webonastick.com/vtclock/"
-  url "http://webonastick.com/vtclock/vtclock-2005-02-20.tar.gz"
+  url "https://web.archive.org/web/20170228161307/https://webonastick.com/vtclock/vtclock-2005-02-20.tar.gz"
   sha256 "5fcbceff1cba40c57213fa5853c4574895755608eaf7248b6cc2f061133dab68"
 
   version "2005-02-20"

--- a/Library/Formula/wbox.rb
+++ b/Library/Formula/wbox.rb
@@ -1,7 +1,7 @@
 class Wbox < Formula
   desc "HTTP testing tool and configuration-less HTTP server"
   homepage "http://hping.org/wbox/"
-  url "http://www.hping.org/wbox/wbox-5.tar.gz"
+  url "https://web.archive.org/web/20220524011612/https://www.hping.org/wbox/wbox-5.tar.gz"
   sha256 "1589d85e83c8ee78383a491d89e768ab9aab9f433c5f5e035cfb5eed17efaa19"
 
   def install

--- a/Library/Formula/whatmask.rb
+++ b/Library/Formula/whatmask.rb
@@ -1,7 +1,7 @@
 class Whatmask < Formula
   desc "Network settings helper"
   homepage "http://www.laffeycomputer.com/whatmask.html"
-  url "http://downloads.laffeycomputer.com/current_builds/whatmask/whatmask-1.2.tar.gz"
+  url "https://web.archive.org/web/20170107110521/http://downloads.laffeycomputer.com/current_builds/whatmask/whatmask-1.2.tar.gz"
   sha256 "7dca0389e22e90ec1b1c199a29838803a1ae9ab34c086a926379b79edb069d89"
 
   bottle do

--- a/Library/Formula/whitedb.rb
+++ b/Library/Formula/whitedb.rb
@@ -1,7 +1,7 @@
 class Whitedb < Formula
   desc "Lightweight in-memory NoSQL database library"
   homepage "http://whitedb.org/"
-  url "http://whitedb.org/whitedb-0.7.3.tar.gz"
+  url "https://web.archive.org/web/20230523181359/http://whitedb.org/whitedb-0.7.3.tar.gz"
   sha256 "10c4ccd754ed2d53dbdef9ec16c88c732aa73d923fc0ee114e7e3a78a812849d"
 
   bottle do

--- a/Library/Formula/why3.rb
+++ b/Library/Formula/why3.rb
@@ -1,7 +1,7 @@
 class Why3 < Formula
   desc "Platform for deductive program verification"
   homepage "http://why3.lri.fr/"
-  url "https://gforge.inria.fr/frs/download.php/file/34797/why3-0.86.1.tar.gz"
+  url "https://web.archive.org/web/20161228144758/https://gforge.inria.fr/frs/download.php/file/34797/why3-0.86.1.tar.gz"
   sha256 "a7ada8bec9b6717257f2932d8b42e5e3f2dd63800f5e9a3f4004229b0efe3389"
 
   bottle do

--- a/Library/Formula/wy60.rb
+++ b/Library/Formula/wy60.rb
@@ -1,7 +1,7 @@
 class Wy60 < Formula
   desc "Wyse 60 compatible terminal emulator"
   homepage "https://code.google.com/p/wy60/"
-  url "https://wy60.googlecode.com/files/wy60-2.0.9.tar.gz"
+  url "https://web.archive.org/web/20160407150347/https://wy60.googlecode.com/files/wy60-2.0.9.tar.gz"
   sha256 "f7379404f0baf38faba48af7b05f9e0df65266ab75071b2ca56195b63fc05ed0"
 
   def install

--- a/Library/Formula/wyrd.rb
+++ b/Library/Formula/wyrd.rb
@@ -1,7 +1,7 @@
 class Wyrd < Formula
   desc "Ncurses-based front-end for remind"
   homepage "http://pessimization.com/software/wyrd/"
-  url "http://pessimization.com/software/wyrd/wyrd-1.4.6.tar.gz"
+  url "https://web.archive.org/web/20140624173034/http://pessimization.com/software/wyrd/wyrd-1.4.6.tar.gz"
   sha256 "b2b51d6fb38f8b8b3ec30ee72093f791ba9b6fe35418191bc2011d2c8079997e"
 
   bottle do

--- a/Library/Formula/xa.rb
+++ b/Library/Formula/xa.rb
@@ -1,7 +1,7 @@
 class Xa < Formula
   desc "6502 cross assembler"
   homepage "http://www.floodgap.com/retrotech/xa/"
-  url "http://www.floodgap.com/retrotech/xa/dists/xa-2.3.7.tar.gz"
+  url "https://web.archive.org/web/20160829165236/http://www.floodgap.com/retrotech/xa/dists/xa-2.3.7.tar.gz"
   sha256 "34e792c159584153f5b5a246ae5d2142dfc92a20b673ea8c9e04584bde594442"
 
   bottle do

--- a/Library/Formula/xml2.rb
+++ b/Library/Formula/xml2.rb
@@ -1,7 +1,7 @@
 class Xml2 < Formula
   desc "Makes XML and HTML more amenable to classic UNIX text tools"
   homepage "http://ofb.net/~egnor/xml2/"
-  url "http://download.ofb.net/gale/xml2-0.5.tar.gz"
+  url "https://web.archive.org/web/20151001171923/https://download.ofb.net/gale/xml2-0.5.tar.gz"
   sha256 "e3203a5d3e5d4c634374e229acdbbe03fea41e8ccdef6a594a3ea50a50d29705"
 
   depends_on "pkg-config" => :build

--- a/Library/Formula/xsw.rb
+++ b/Library/Formula/xsw.rb
@@ -1,7 +1,7 @@
 class Xsw < Formula
   desc "Slide show presentation tool"
   homepage "https://code.google.com/p/xsw/"
-  url "https://xsw.googlecode.com/files/xsw-0.3.5.tar.gz"
+  url "https://web.archive.org/web/20150802025422/https://xsw.googlecode.com/files/xsw-0.3.5.tar.gz"
   sha256 "d7f86047716d9c4d7b2d98543952d59ce871c7d11c63653f2e21a90bcd7a6085"
 
   depends_on "sdl"

--- a/Library/Formula/xtitle.rb
+++ b/Library/Formula/xtitle.rb
@@ -1,7 +1,7 @@
 class Xtitle < Formula
   desc "Set window title and icon for your X terminal"
   homepage "http://www.cs.indiana.edu/~kinzler/xtitle/"
-  url "http://www.cs.indiana.edu/~kinzler/xtitle/xtitle-1.0.4.tgz"
+  url "https://web.archive.org/web/20161118084736/https://www.cs.indiana.edu/~kinzler/xtitle/xtitle-1.0.4.tgz"
   sha256 "cadddef1389ba1c5e1dc7dd861545a5fe11cb397a3f692cd63881671340fcc15"
 
   def install

--- a/Library/Formula/yafc.rb
+++ b/Library/Formula/yafc.rb
@@ -1,7 +1,7 @@
 class Yafc < Formula
   desc "Command-line FTP client"
   homepage "http://www.yafc-ftp.com/"
-  url "http://www.yafc-ftp.com/downloads/yafc-1.3.6.tar.xz"
+  url "https://web.archive.org/web/20170323003729/https://www.yafc-ftp.com/downloads/yafc-1.3.6.tar.xz"
   sha256 "63a32556ed16a589634a5aca3f03134b8d488e06ecb36f9df6ef450aa3a47973"
   revision 1
 

--- a/Library/Formula/yap.rb
+++ b/Library/Formula/yap.rb
@@ -1,7 +1,7 @@
 class Yap < Formula
   desc "Prolog compiler designed for performance and extensibility"
   homepage "http://www.dcc.fc.up.pt/~vsc/Yap/index.html"
-  url "http://www.dcc.fc.up.pt/~vsc/Yap/yap-6.2.2.tar.gz"
+  url "https://web.archive.org/web/20181031185827/https://www.dcc.fc.up.pt/~vsc/Yap/yap-6.2.2.tar.gz"
   sha256 "f15f8382104443319a5883eafce5f52f4143b526c7f1cd88d19c1f63fc06d750"
 
   devel do

--- a/Library/Formula/yubico-piv-tool.rb
+++ b/Library/Formula/yubico-piv-tool.rb
@@ -1,7 +1,7 @@
 class YubicoPivTool < Formula
   desc "Command-line tool for the YubiKey NEO PIV applet"
   homepage "https://developers.yubico.com/yubico-piv-tool/"
-  url "https://developers.yubico.com/yubico-piv-tool/releases/yubico-piv-tool-1.0.0.tar.gz"
+  url "https://web.archive.org/web/20221028150243/https://developers.yubico.com/yubico-piv-tool/releases/yubico-piv-tool-1.0.0.tar.gz"
   sha256 "303f576eb17af65234f8a3feddcab6add13c6c2dc82de875e165b6bfc2b9bab7"
 
   bottle do

--- a/Library/Formula/zopfli.rb
+++ b/Library/Formula/zopfli.rb
@@ -1,7 +1,7 @@
 class Zopfli < Formula
   desc "New zlib (gzip, deflate) compatible compressor"
   homepage "https://code.google.com/p/zopfli/"
-  url "https://zopfli.googlecode.com/files/zopfli-1.0.0.zip"
+  url "https://web.archive.org/web/20140816192801/https://zopfli.googlecode.com/files/zopfli-1.0.0.zip"
   sha256 "e20d73b56620285e6cce5b510d8e5da6835a81940e48cdf35a69090e666f3adb"
   head "https://code.google.com/p/zopfli/", :using => :git
 

--- a/Library/Formula/zsh-lovers.rb
+++ b/Library/Formula/zsh-lovers.rb
@@ -1,7 +1,7 @@
 class ZshLovers < Formula
   desc "Tips, tricks, and examples for zsh"
   homepage "http://grml.org/zsh/#zshlovers"
-  url "http://grml.org/zsh/zsh-lovers.1"
+  url "https://web.archive.org/web/20230425045120/https://grml.org/zsh/zsh-lovers.1"
   version "0.9.1"
   sha256 "6583aabf4024c951f19a381ce97ce2c7af948b24fc332504c3f719ec9187c72f"
 

--- a/Library/Formula/zurl.rb
+++ b/Library/Formula/zurl.rb
@@ -1,7 +1,7 @@
 class Zurl < Formula
   desc "HTTP and WebSocket client worker with ZeroMQ interface"
   homepage "https://github.com/fanout/zurl"
-  url "https://dl.bintray.com/fanout/source/zurl-1.4.9.tar.bz2"
+  url "https://web.archive.org/web/20210501185808/https://dl.bintray.com/fanout/source/zurl-1.4.9.tar.bz2"
   sha256 "88f2135aeb57690f3d81992fd5bb8d8c68185d4a084f0752b4bb2dbb35235d4f"
 
   bottle do


### PR DESCRIPTION
Here's one more curatorial PR you're welcome to consider for Tigerbrew. 

For any resource which is no longer available, if Wayback Machine contains a match for the same URL with the same checksum, this updates the formula to use that Wayback Machine URL.

This remediates around half of the Tigerbrew packages that fail to `brew fetch` today. Testing confirms that these all now successfully fetch the updated resources. I haven't tested builds for them, and some of those builds will still fail due to missing patch files & such. But this will certainly fully restore many of these packages, and could ease any future work of restoring the rest.

Fun fact: all of Tigerbrew (the resources that download for all packages) is around 23GB.