### PR TITLE
lesstif: help linking against fontconfig

### DIFF
--- a/Library/Formula/lesstif.rb
+++ b/Library/Formula/lesstif.rb
@@ -5,15 +5,11 @@ class Lesstif < Formula
   sha256 "eb4aa38858c29a4a3bcf605cfe7d91ca41f4522d78d770f69721e6e3a4ecf7e3"
 
   bottle do
-    revision 1
-    sha256 "bc26ea0e27740c5b3a045b776737ff94ea0bc68b833fc013b92177511271bbcd" => :el_capitan
-    sha1 "50b1cecbfce9a66ae8253b6efe1ecef4c58678fc" => :yosemite
-    sha1 "f6439fb1fda16afd5ae5447f071170b08a9484c3" => :mavericks
-    sha1 "dff63d044e87b2137cf8f961f9c46186b7af18d1" => :mountain_lion
   end
 
   depends_on :x11
   depends_on "freetype"
+  depends_on "fontconfig"
 
   def install
     # LessTif does naughty, naughty, things by assuming we want autoconf macros
@@ -30,6 +26,8 @@ class Lesstif < Formula
                           "--disable-debug",
                           "--enable-production",
                           "--disable-dependency-tracking",
+                          "--with-fontconfig-lib=#{Formula["fontconfig"].opt_prefix}",
+                          "--with-fontconfig-includes=#{Formula["fontconfig"].opt_prefix}",
                           "--enable-shared",
                           "--enable-static"
 


### PR DESCRIPTION
Fails to resolve
_FcPatternCreate
_FcPatternDestroy
_FcPatternAddInteger
_FcPatternAddString

The fontconfig supplied with the system's X11 has support but opted to use a recent version from Tigerbrew instead.

Fixes #1386

Tested on Tiger PowerPC (G5) with GCC 4.0.1