### PR TITLE
libaacs 0.9.0

### DIFF
--- a/Library/Formula/libaacs.rb
+++ b/Library/Formula/libaacs.rb
@@ -1,16 +1,13 @@
 class Libaacs < Formula
   desc "Implements the Advanced Access Content System specification"
   homepage "https://www.videolan.org/developers/libaacs.html"
-  url "https://download.videolan.org/pub/videolan/libaacs/0.8.1/libaacs-0.8.1.tar.bz2"
-  mirror "http://videolan-nyc.defaultroute.com/libaacs/0.8.1/libaacs-0.8.1.tar.bz2"
-  sha256 "95c344a02c47c9753c50a5386fdfb8313f9e4e95949a5c523a452f0bcb01bbe8"
+  url "https://get.videolan.org/libaacs/0.9.0/libaacs-0.9.0.tar.bz2"
+  mirror "https://download.videolan.org/pub/videolan/libaacs/0.9.0/libaacs-0.9.0.tar.bz2"
+  sha256 "47e0bdc9c9f0f6146ed7b4cc78ed1527a04a537012cf540cf5211e06a248bace"
+  license "LGPL-2.1-or-later"
 
   bottle do
     cellar :any
-    sha256 "f1cea0863d8e5898f26ea50c0e9d459861c7a07549583ae113e57d7bd5c826c8" => :el_capitan
-    sha256 "7400d1add43105cc37e0f0901b8ec697e9173289f5551929a63939c16147e11e" => :yosemite
-    sha256 "023017918e674900f04616fbd4a312627b632236f7aa290e9b05ba0b03c90288" => :mavericks
-    sha256 "294596adf06da1cf609775be4cd03b4abc150208dddb62f6bfb893169dc8ed15" => :mountain_lion
   end
 
   head do
@@ -21,6 +18,8 @@ class Libaacs < Formula
     depends_on "libtool" => :build
   end
 
+  # Expects IOKit from Leopard, but can be convinced to build Tiger
+  depends_on :macos => :leopard
   depends_on "bison" => :build
   depends_on "libgcrypt"
 


### PR DESCRIPTION
v0.9.0 is the most recent version which compiles out of the box on Leopard. It's possble to get this to compile on Tiger but I decided on not including the patch since the most recent version of VLC which runs on Tiger is v0.9.10.
I also lack the hardware and any other software which could use libaacs in order to be able to test beyond compilation.
Let me know if you want to give it a try.

Build tested on Leopard PowerPC (G4) with GCC 4.2