### PR TITLE
mtr 0.96

### DIFF
--- a/Library/Formula/mtr.rb
+++ b/Library/Formula/mtr.rb
@@ -1,37 +1,40 @@
 class Mtr < Formula
   desc "'traceroute' and 'ping' in a single tool"
   homepage "http://www.bitwizard.nl/mtr/"
-  url "ftp://ftp.bitwizard.nl/mtr/mtr-0.86.tar.gz"
-  sha256 "c5d948920b641cc35f8b380fc356ddfe07cce6a9c6474afe242fc58113f28c06"
+  url "https://github.com/traviscross/mtr/archive/refs/tags/v0.96.tar.gz"
+  sha256 "73e6aef3fb6c8b482acb5b5e2b8fa7794045c4f2420276f035ce76c5beae632d"
+  # Main license is GPL-2.0-only but some compatibility code is under other licenses:
+  # 1. portability/queue.h is BSD-3-Clause
+  # 2. portability/error.* is LGPL-2.0-only (only used on macOS)
+  # 3. portability/getopt.* is omitted as unused
+  license all_of: ["GPL-2.0-only", "BSD-3-Clause", "LGPL-2.0-only"]
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "06b43ecc7ac538e43a3835998317e9cd7673ff6015f1a2436c985540c454af95" => :el_capitan
-    sha1 "8c08e6d32997d6a82ee755de600ba5d63cc50a4e" => :yosemite
-    sha1 "8cc2160f36567c5a0e913c0e0a9f60b9e835ba28" => :mavericks
-    sha1 "be91d5c1ad604d190ef1e1d56842592b816197bf" => :mountain_lion
   end
 
   head do
     url "https://github.com/traviscross/mtr.git"
-    depends_on "automake" => :build
   end
 
-  depends_on "autoconf" => :build
+  # Fix build on Tiger & Leopard
+  # https://github.com/traviscross/mtr/pull/540
+  patch :DATA
+
   depends_on "pkg-config" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "gtk+" => :optional
-  depends_on "glib" => :optional
+  depends_on "jansson"
+  depends_on "ncurses" # Needed for braille output.
 
   def install
-    # We need to add this because nameserver8_compat.h has been removed in Snow Leopard
-    ENV["LIBS"] = "-lresolv"
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}
     ]
     args << "--without-gtk" if build.without? "gtk+"
-    args << "--without-glib" if build.without? "glib"
-    system "./bootstrap.sh" if build.head?
+    system "./bootstrap.sh"
     system "./configure", *args
     system "make", "install"
   end
@@ -39,6 +42,81 @@ class Mtr < Formula
   def caveats; <<-EOS.undent
     mtr requires root privileges so you will need to run `sudo mtr`.
     You should be certain that you trust any software you grant root privileges.
+
+    Use something other than Terminal.app on Tiger for braille output.
     EOS
   end
 end
+__END__
+diff --git a/packet/construct_unix.c b/packet/construct_unix.c
+index 95fefba..51894a1 100644
+--- a/packet/construct_unix.c
++++ b/packet/construct_unix.c
+@@ -250,7 +250,6 @@ int construct_udp6_packet(
+     int packet_size,
+     const struct probe_param_t *param)
+ {
+-    int udp_socket = net_state->platform.udp6_send_socket;
+     struct UDPHeader *udp;
+     int udp_size;
+ 
+@@ -428,19 +427,28 @@ int set_stream_socket_options(
+     }
+ 
+     /*  Set the "type of service" field of the IP header  */
++#ifdef IPV6_TCLASS
+     if (param->ip_version == 6) {
+         level = IPPROTO_IPV6;
+         opt = IPV6_TCLASS;
+     } else {
++#else
++    opt = 0;
++    if (param->ip_version == 4) {
++#endif
+         level = IPPROTO_IP;
+         opt = IP_TOS;
+     }
+ 
+-    if (setsockopt(stream_socket, level, opt,
+-                   &param->type_of_service, sizeof(int)) == -1) {
++    /* Avoid trying to set on IPv6 stacks which lack RFC 3542 support (IPV6_TCLASS) */
++    if (opt != 0) {
++        if (setsockopt(stream_socket, level, opt,
++                       &param->type_of_service, sizeof(int)) == -1) {
+ 
+-        return -1;
++            return -1;
++        }
+     }
++
+ #ifdef SO_MARK
+     if (param->routing_mark) {
+         if (set_socket_mark(stream_socket, param->routing_mark)) {
+@@ -836,11 +844,13 @@ int construct_ip6_packet(
+         }
+     }
+ 
++#ifdef IPV6_TCLASS
+     /*  The traffic class in IPv6 is analogous to ToS in IPv4  */
+     if (setsockopt(send_socket, IPPROTO_IPV6,
+                    IPV6_TCLASS, &param->type_of_service, sizeof(int))) {
+         return -1;
+     }
++#endif
+ 
+     /*  Set the time-to-live  */
+     if (setsockopt(send_socket, IPPROTO_IPV6,
+diff --git a/ui/asn.c b/ui/asn.c
+index 111c394..28f5cd3 100644
+--- a/ui/asn.c
++++ b/ui/asn.c
+@@ -30,9 +30,6 @@
+ #endif
+ #include <errno.h>
+ 
+-#ifdef __APPLE__
+-#define BIND_8_COMPAT
+-#endif
+ #include <arpa/nameser.h>
+ #ifdef HAVE_ARPA_NAMESER_COMPAT_H
+ #include <arpa/nameser_compat.h>


### PR DESCRIPTION
glib is no longer supported.
libresolv is linked to automatically now.
Depend on ncurses so braille support works. Tested with iTerm on Tiger & Terminal.app on Leopard.
[Add license from upstream](https://github.com/Homebrew/homebrew-core/blob/b7f106d8cd0243d2c9c2c2b2ecc5dc0231869ae4/Formula/m/mtr.rb).

Todo: Reverse DNS lookup of IP addresses is not working on 10.4 & 10.5

Resolves #302

Tested on 10.4 to 10.6, 10.10.