### PR TITLE
openssl3 3.5.4

### DIFF
--- a/Library/Formula/openssl3.rb
+++ b/Library/Formula/openssl3.rb
@@ -6,6 +6,7 @@ class Openssl3 < Formula
   license "Apache-2.0"
 
   bottle do
+    sha256 "9fe56a7a89f70df7b1e5b3d34332db5e110df703c037e09dbc3f5cf37933e132" => :tiger_g3
   end
 
   keg_only :provided_by_osx


### PR DESCRIPTION
Built 3.5.1 with tests on a:
1.33Ghz iBook G4 running Leopard in 161 minutes using GCC 4.2

Built 3.5.4 with tests on a:
600Mhz iBook G3 running Tiger using GCC 4.0.1 in 500.5 minutes.
1st gen 1.8Ghz iMac G5 running Tiger using GCC 4.0.1 in 184 minutes.
1.33Ghz iBook G4 running Leopard using GCC 4.2 - missed recording the time.

Marking as draft until I've done more testing.
~Maybe one for merging in the winter but it's here in case anyone needs it.~

There's a regression in QUIC support which means `test_quic_tserver` doesn't always pass.
Found on Tiger, but reproduced on Leopard.
https://github.com/openssl/openssl/issues/28721

