### PR TITLE
apr-util: Need to explicitly enable crypto support

### DIFF
--- a/Library/Formula/apr-util.rb
+++ b/Library/Formula/apr-util.rb
@@ -3,9 +3,9 @@ class AprUtil < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-util-1.6.3.tar.bz2"
   sha256 "a41076e3710746326c3945042994ad9a4fcac0ce0277dd8fea076fec3c9772b5"
+  revision 1
 
   bottle do
-    sha256 "a6c899235a89ad4ce2f1edd3b999a9ee80081d33eda75c4a219acb6f7db9aaa6" => :tiger_altivec
   end
 
   keg_only :provided_by_osx, "Apple's CLT package contains apr."
@@ -13,8 +13,8 @@ class AprUtil < Formula
   option :universal
 
   depends_on "apr"
-  depends_on "expat" if MacOS.version < :tiger
-  depends_on "openssl"
+  depends_on "expat"
+  depends_on "openssl3"
   depends_on "postgresql" => :optional
 
   def install
@@ -24,7 +24,8 @@ class AprUtil < Formula
     args = %W[
       --prefix=#{libexec}
       --with-apr=#{Formula["apr"].opt_prefix}
-      --with-openssl=#{Formula["openssl"].opt_prefix}
+      --with-openssl=#{Formula["openssl3"].opt_prefix}
+      --with-crypto
     ]
 
     args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"


### PR DESCRIPTION
It doesn't enable it by default.
Best to just rely on expat for everything.

Tested to Tiger PowerPC (G5) with GCC 4.0.1