### PR TITLE
git: Fix build on Leopard

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -82,6 +82,7 @@ class Git < Formula
     ENV["PERL_PATH"] = which "perl"
     ENV["CURLDIR"] = Formula["curl"].opt_prefix
     ENV["NO_APPLE_COMMON_CRYPTO"] = "1" if MacOS.version < :leopard
+    ENV["NO_TCLTK"] = "1" if MacOS.version <:snow_leopard # Needs Tcl-Tk 8.5 or newer with Aqua support
     ENV.append "CFLAGS", "-std=gnu99"
 
     perl_version = /\d\.\d+/.match(`perl --version`)


### PR DESCRIPTION
To build Git-Gui.app Tcl-Tk 8.5 with Aqua support is required.
Snow Leopard shipped with Tcl-Tk 8.5.
Unable to use an up to date version of Tcl-Tk via Tigerbrew since Tk requires functionality in AppKit introduced in Snow Leopard for Aqua support.
Perhaps an option is to not build the .app and see if it can be run via X11 support on Leopard and prior.

Fixes issue #1410