### PR TITLE
erlang 23.3.4.20

### DIFF
--- a/Library/Formula/erlang.rb
+++ b/Library/Formula/erlang.rb
@@ -1,126 +1,67 @@
-# Major releases of erlang should typically start out as separate formula in
-# Homebrew-versions, and only be merged to master when things like couchdb and
-# elixir are compatible.
 class Erlang < Formula
   desc "Erlang Programming Language"
   homepage "http://www.erlang.org"
 
-  head "https://github.com/erlang/otp.git"
-
   stable do
-    # Download tarball from GitHub; it is served faster than the official tarball.
-    url "https://github.com/erlang/otp/archive/OTP-18.3.4.11.tar.gz"
-    sha256 "94f84e8ca0db0dcadd3411fa7a05dd937142b6ae830255dc341c30b45261b01a"
+    url "https://github.com/erlang/otp/archive/OTP-23.3.4.20.tar.gz"
+    sha256 "887859a686f3278e2a60435713ade724f97e6222cb7693a5f37c6a894ac42f8e"
   end
 
   resource "man" do
-    url "http://www.erlang.org/download/otp_doc_man_18.3.tar.gz"
-    sha256 "978be100e9016874921b3ad1a65ee46b7b6a1e597b8db2ec4b5ef436d4c9ecc2"
+    url "http://www.erlang.org/download/otp_doc_man_23.3.tar.gz"
+    sha256 "b890e99d3fe1b317ed083455985225550ebf74b4a8ec2af4c758e4ce6e2934ff"
   end
 
   resource "html" do
-    url "http://www.erlang.org/download/otp_doc_html_18.3.tar.gz"
-    sha256 "8fd6980fd05367735779a487df107ace7c53733f52fbe56de7ca7844a355676f"
+    url "http://www.erlang.org/download/otp_doc_html_23.3.tar.gz"
+    sha256 "03d86ac3e71bb58e27d01743a9668c7a1265b573541d4111590f0f3ec334383e"
   end
 
-  # Current autoconf (2.7.x) has trouble dealing with $ERL_TOP, resulting in
-  # configure: error: cannot find required auxiliary files: install-sh config.guess config.sub
-  patch :p0, :DATA
-
-  option "without-hipe", "Disable building HiPE (High-Performance Erlang); fails on various OS X systems"
-  option "with-native-libs", "Enable native library compilation"
-  option "with-dirty-schedulers", "Enable experimental dirty schedulers"
-  option "without-docs", "Do not install documentation"
-
-  deprecated_option "disable-hipe" => "without-hipe"
-  deprecated_option "no-docs" => "without-docs"
-
-  depends_on "autoconf" => :build
-  depends_on "unixodbc" if MacOS.version >= :mavericks
-  depends_on "fop" => :optional # enables building PDF docs
-  # Need wxWidgets 2.8.4 or above. Tiger includes 2.5.3, 3.x needs Leopard minimum.
-  depends_on "wxmac" => :recommended if MacOS.version > :tiger # for GUI apps like observer
-  depends_on "libutil" if MacOS.version < :leopard
-  depends_on "zlib"
-
   fails_with :gcc_4_0 do
-    build 5370
-    cause "error: invalid preprocessing directive in HiPE PPC glue"
+    build 5493
+    cause "beam/erl_process.c fails to compile with gcc < 4.4"
   end
 
   fails_with :gcc do
-    build 5666
-    cause "Bus error when attempting to build HiPE"
+    build 5577
+    cause "beam/erl_process.c fails to compile with gcc < 4.4"
   end
 
-  # Adds a missing extern to a type definition
-  # https://github.com/erlang/otp/pull/1692
-  patch do
-    url "https://github.com/erlang/otp/commit/58632af80fd43955ec58c021e5c0d04caa1840de.patch?full_index=1"
-    sha256 "39aedcf957511ef67024ea584e9143fb5b8592d0089622e4268f7ec517ef163d"
-  end
+  option "with-dirty-schedulers", "Enable dirty schedulers"
+  option "without-docs", "Do not install documentation"
+
+  depends_on "autoconf" => :build
+  depends_on "fop" => :optional
+  depends_on "wxmac" => :recommended if MacOS.version > :tiger
+  depends_on "libutil" if MacOS.version < :leopard
+  depends_on "openssl"
+  depends_on "zlib"
 
   def install
-    # Unset these so that building wx, kernel, compiler and
-    # other modules doesn't fail with an unintelligable error.
-    %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
-
     ENV["FOP"] = "#{HOMEBREW_PREFIX}/bin/fop" if build.with? "fop"
-
-    # Fixes an error with newer GCCs and in6addr
-    # https://github.com/asdf-vm/asdf-erlang/issues/157
-    ENV.append_to_cflags "-Wno-error=implicit-function-declaration"
-
-    # Do this if building from a checkout to generate configure
-    system "./otp_build", "autoconf" if File.exist? "otp_build"
 
     args = %W[
       --disable-debug
       --disable-silent-rules
       --prefix=#{prefix}
-      --enable-kernel-poll
-      --enable-threads
-      --enable-shared-zlib
-      --enable-smp-support
+      --disable-kernel-poll
+      --enable-dynamic-ssl-lib
+      --with-ssl=#{Formula["openssl"].opt_prefix}
     ]
 
-    args << "--enable-darwin-64bit" if MacOS.prefer_64_bit?
-    args << "--enable-native-libs" if build.with? "native-libs"
     args << "--enable-dirty-schedulers" if build.with? "dirty-schedulers"
     args << "--enable-wx" if build.with? "wxmac"
-    # Older Javas not supported by jinterface
-    # https://github.com/mistydemeo/tigerbrew/issues/372
     args << "--without-javac" if MacOS.version < :snow_leopard
-    # error: cannot compute sizeof (__int128_t, 77)
-    # In /usr/include/c++/4.0.0/powerpc64-apple-darwin8/bits/stdc++.h.gch/O0g.gch & O2g.gch
-    # symbol is found but configure's test for it fails, breaking the build
-    args << "ac_cv_type___int128_t=no" if MacOS.version == :tiger && Hardware::CPU.family == :g5
-    # configure iritatingly picks a different compiler than CC in this one place
-    # It's set to prioritize a compiler named "gcc-4.2"
-    # over "gcc" if present, which causes build failures for Tiger users with
-    # apple-gcc42 installed
-    args << "ac_cv_prog_emu_cc=#{ENV.cc}"
-
     if MacOS.version >= :snow_leopard && MacOS::CLT.installed?
       args << "--with-dynamic-trace=dtrace"
     end
 
-    if build.without? "hipe"
-      # HiPE doesn't strike me as that reliable on OS X
-      # http://syntatic.wordpress.com/2008/06/12/macports-erlang-bus-error-due-to-mac-os-x-1053-update/
-      # http://www.erlang.org/pipermail/erlang-patches/2008-September/000293.html
-      args << "--disable-hipe"
-    else
-      args << "--enable-hipe"
-    end
-
     system "./configure", *args
     system "make"
-    ENV.j1 # Install is not thread-safe; can try to create folder twice and fail
     system "make", "install"
 
     if build.with? "docs"
-      (lib/"erlang").install resource("man").files("man")
+      (lib/"erlang/man").install resource("man")
       doc.install resource("html")
     end
   end
@@ -137,66 +78,3 @@ class Erlang < Formula
     system "#{bin}/erl", "-noshell", "-eval", "crypto:start().", "-s", "init", "stop"
   end
 end
-__END__
---- lib/snmp/configure.in.orig	2025-04-28 01:39:37.000000000 +0100
-+++ lib/snmp/configure.in	2025-04-28 01:40:16.000000000 +0100
-@@ -4,12 +4,8 @@
- 
- AC_INIT(vsn.mk)
- 
--if test -z "$ERL_TOP" || test ! -d $ERL_TOP ; then
--  AC_CONFIG_AUX_DIRS(autoconf)
--else
--  erl_top=${ERL_TOP}
--  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
--fi
-+erl_top=${ERL_TOP}
-+AC_CONFIG_AUX_DIRS(../../erts/autoconf)
- 
- if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
-     AC_CANONICAL_HOST
---- lib/megaco/configure.in.orig	2025-04-28 01:40:32.000000000 +0100
-+++ lib/megaco/configure.in	2025-04-28 01:40:56.000000000 +0100
-@@ -29,12 +29,8 @@
- 
- AC_INIT(vsn.mk)
- 
--if test -z "$ERL_TOP" || test ! -d $ERL_TOP ; then
--  AC_CONFIG_AUX_DIRS(autoconf)
--else
--  erl_top=${ERL_TOP}
--  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
--fi
-+erl_top=${ERL_TOP}
-+AC_CONFIG_AUX_DIRS(../../erts/autoconf)
- 
- if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
-     AC_CANONICAL_HOST
---- lib/odbc/configure.in.orig	2025-04-28 01:41:20.000000000 +0100
-+++ lib/odbc/configure.in	2025-04-28 01:41:44.000000000 +0100
-@@ -31,12 +31,8 @@
- dnl Process this file with autoconf to produce a configure script.
- AC_INIT(c_src/odbcserver.c)
- 
--if test -z "$ERL_TOP" || test ! -d $ERL_TOP ; then
--  AC_CONFIG_AUX_DIRS(autoconf)
--else
--  erl_top=${ERL_TOP}
--  AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
--fi
-+erl_top=${ERL_TOP}
-+AC_CONFIG_AUX_DIRS(../../erts/autoconf)
- 
- if test "X$host" != "Xfree_source" -a "X$host" != "Xwin32"; then
-     AC_CANONICAL_HOST
---- lib/gs/configure.in.orig	2025-04-28 01:44:20.000000000 +0100
-+++ lib/gs/configure.in	2025-04-28 01:44:54.000000000 +0100
-@@ -8,7 +8,7 @@
-   AC_MSG_ERROR(You need to set the environment variable ERL_TOP!)
- fi
- erl_top=${ERL_TOP}
--AC_CONFIG_AUX_DIRS($erl_top/erts/autoconf)
-+AC_CONFIG_AUX_DIRS(../../erts/autoconf)
- 
- dnl FIXME: Should be AC_CANONICAL_TARGET but we follow pattern in
- dnl main configure.in.


### PR DESCRIPTION
Hi @mistydemeo and @sevan, 

I've been looking at which versions of `erlang`, and packages that use it, run on old Mac OS X versions. The conclusion is that it would be possible to upgrade Tigerbrew's `erlang` to [23.3.4.20](https://www.erlang.org/patches/otp-23.3.4.20) - which is a patch release from March 2024. (Erlang 23 itself was released in [2020](https://www.erlang.org/patches/otp-23.0)).

Here's a PR for that version. It also removes some build options and config flags that aren't used any longer. This version of `erlang` must be built with at least `gcc-4.4`, and tbh I'm not sure I specified that in the right way in this formula.

Offering this version would mean some tradeoffs in support of packages that use `erlang`. Several can or must be upgraded themselves to newer versions to stay compatible. Some projects that stopped receiving patches a long time ago have no compatible version available, and would need to be deprecated. On the other hand, support increased for things like `rabbitmq`. It's possible that this would enable adding a [Gleam](https://gleam.run/) package to Tigerbrew, but I haven't looked into that too deeply.

I'll submit an accompanying draft PR that includes the best updates I've been able to find for everything that uses `erlang`. If you decide to merge this `erlang` version upgrade, I'll be happy to submit each of those as individual follow-on PRs.

