### PR TITLE
spidermonkey: require mac os x leopard

### DIFF
--- a/Library/Formula/spidermonkey.rb
+++ b/Library/Formula/spidermonkey.rb
@@ -6,6 +6,8 @@ class Spidermonkey < Formula
   sha256 "5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687"
   revision 2
 
+  depends_on :macos => :leopard
+
   head "https://hg.mozilla.org/tracemonkey/archive/tip.tar.gz"
 
   bottle do


### PR DESCRIPTION
While working on `couchdb` builds for https://github.com/mistydemeo/tigerbrew/pull/1414 I confirmed that no version of `spidermonkey` will build on Mac OS X Tiger. I'd propose labeling the `spidermonkey` formula as requiring `:leopard` or greater to clarify this for users.