### PR TITLE
Only run test suite if requested

### DIFF
--- a/Library/Formula/gettext.rb
+++ b/Library/Formula/gettext.rb
@@ -13,6 +13,7 @@ class Gettext < Formula
 
   option :universal
   option 'with-examples', 'Keep example files'
+  option "with-tests", "Build and run the test suite"
 
   # Fix lang-python-* failures when a traditional French locale
   # https://git.savannah.gnu.org/gitweb/?p=gettext.git;a=patch;h=3c7e67be7d4dab9df362ab19f4f5fa3b9ca0836b
@@ -42,7 +43,7 @@ class Gettext < Formula
                           "--without-cvs",
                           "--without-xz"
     system "make"
-    system "make", "check"
+    system "make", "check" if build.with?("tests") || build.bottle?
     ENV.deparallelize # install doesn't support multiple make jobs
     system "make", "install"
   end

--- a/Library/Formula/libiconv.rb
+++ b/Library/Formula/libiconv.rb
@@ -20,6 +20,8 @@ class Libiconv < Formula
 
   patch :DATA
 
+  option "with-tests", "Build and run the test suite"
+
   def install
     ENV.deparallelize
     system "./configure", "--disable-debug",
@@ -29,7 +31,7 @@ class Libiconv < Formula
                           "--enable-static",
                           "--docdir=#{doc}"
     system "make"
-    system "make", "check"
+    system "make", "check" if build.with?("tests") || build.bottle?
     system "make", "install"
   end
 

--- a/Library/Formula/pkg-config.rb
+++ b/Library/Formula/pkg-config.rb
@@ -9,6 +9,8 @@ class PkgConfig < Formula
     sha256 "1b438cc6b776c001c6a45b94f12861a3a5a98fc4ea2ee6069a6a011051188aff" => :tiger_altivec
   end
 
+  option "with-tests", "Build and run the test suite"
+
   def install
     pc_path = %W[
       #{HOMEBREW_PREFIX}/lib/pkgconfig
@@ -25,7 +27,7 @@ class PkgConfig < Formula
                           "--with-internal-glib",
                           "--with-pc-path=#{pc_path}"
     system "make"
-    system "make", "check"
+    system "make", "check" if build.with?("tests") || build.bottle?
     system "make", "install"
   end
 

--- a/Library/Formula/xz.rb
+++ b/Library/Formula/xz.rb
@@ -16,6 +16,7 @@ class Xz < Formula
   end
 
   option :universal
+  option "with-tests", "Build and run the test suite"
 
   def install
     ENV.universal_binary if build.universal?
@@ -23,7 +24,7 @@ class Xz < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
-    system "make", "check"
+    system "make", "check" if build.with?("tests") || build.bottle?
     system "make", "install"
   end
 


### PR DESCRIPTION
or when bottling.
The road to building Mercurial & git on a fresh setup should be a little quicker now.
On a stock OS it should be expected to work without needing to run the test suite every time, as things should've been tested when preparing to commit the update to Tigerbrew.