### PR TITLE
sqlitebrowser 3.9.1

### DIFF
--- a/Library/Formula/sqlitebrowser.rb
+++ b/Library/Formula/sqlitebrowser.rb
@@ -1,18 +1,19 @@
 class Sqlitebrowser < Formula
   desc "Visual tool to create, design, and edit SQLite databases"
   homepage "http://sqlitebrowser.org"
-  url "https://github.com/sqlitebrowser/sqlitebrowser/archive/v3.7.0.tar.gz"
-  sha256 "3093a1dcf5b3138c1adf29857d62249ab2b068e70b001869a31151763e28cc3a"
+  url "https://github.com/sqlitebrowser/sqlitebrowser/archive/refs/tags/v3.9.1.tar.gz"
+  sha256 "d0d2e06a69927ba1d0b955f3261ce70c61befc5bd5ddaa06752dae8bb4219ed8"
 
   head "https://github.com/sqlitebrowser/sqlitebrowser.git"
 
   bottle do
     cellar :any
-    sha256 "43cd89b3e12b4581ccc436f243ab0dd98a4930c9bee1f0a83f5ca7613275c174" => :el_capitan
-    sha256 "0f94ada07ec575124cac4cb5ebc3e4dfa072150a4f79764153e30187077f0ccd" => :yosemite
-    sha256 "7a7abdea93ad0401a29eac53c54066f366619717e07c14b9e2f9a1487a8a54ce" => :mavericks
-    sha256 "d675792776191eb65256b6aba1f7a50099a2768eb5c3975e4efa224cb95978ba" => :mountain_lion
   end
+
+  # GCC 4.0 C++ support is lacking.
+  fails_with :gcc_4_0
+  # GCC 4.2 on Tiger struggles with 10.4u SDK "error: stdarg.h: No such file or directory"
+  fails_with :gcc if MacOS.version == :tiger
 
   depends_on "qt"
   depends_on "cmake" => :build


### PR DESCRIPTION
v3.9.1 is the last version which support Qt 4. Qt 5.x is required from v3.10.0 onwards.
Need something other than GCC 4.0/4.2 on Tiger.
Compiles fine on Leopard with GCC 4.2.

Tested on Tiger PowerPC (G5) with GCC 14.2, Leopard PowerPC (G4) with GCC 4.2