### PR TITLE
links 2.30

### DIFF
--- a/Library/Formula/links.rb
+++ b/Library/Formula/links.rb
@@ -1,25 +1,26 @@
 class Links < Formula
   desc "Lynx-like WWW browser that supports tables, menus, etc."
   homepage "http://links.twibright.com/"
-  url "http://links.twibright.com/download/links-2.11.tar.bz2"
-  mirror "https://mirrors.kernel.org/debian/pool/main/l/links2/links2_2.11.orig.tar.bz2"
-  sha256 "87f7f927d6394f1dc45886dd5ff89234c4e0fb321132ceaa009db5bcc26f123f"
-  revision 1
+  url "http://links.twibright.com/download/links-2.30.tar.bz2"
+  sha256 "c4631c6b5a11527cdc3cb7872fc23b7f2b25c2b021d596be410dadb40315f166"
+  license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
 
   bottle do
     cellar :any
-    sha256 "8779e7a0cf9424c4115ca1fcc7ebc894e576cee06ce16be100dcfbd7e9a496bf" => :el_capitan
-    sha256 "3fb2262ebfabe71227d8bc1ccaa13e54e4b44b85792b7720874c27a0975cf6de" => :yosemite
-    sha256 "c02773c8a66a69990669d35e712852db52c8f64a3f801af9e10222d811351869" => :mavericks
   end
 
   depends_on "pkg-config" => :build
-  depends_on "openssl" => :recommended
+  depends_on :x11 => :recommended
+  depends_on "bzip2"
+  depends_on "openssl3" => :recommended
   depends_on "libressl" => :optional
-  depends_on "libtiff" => :optional
-  depends_on "jpeg" => :optional
+  depends_on "libevent" if MacOS.version >= :snow_leopard
+  depends_on "libpng" if build.with? "x11"
+  depends_on "libtiff" if build.with? "x11"
+  depends_on "jpeg" if build.with? "x11"
+  depends_on "webp" if build.with? "x11"
   depends_on "librsvg" => :optional
-  depends_on :x11 => :optional
+  depends_on "zlib"
 
   def install
     args = %W[
@@ -32,13 +33,15 @@ class Links < Formula
     if build.with? "libressl"
       args << "--with-ssl=#{Formula["libressl"].opt_prefix}"
     else
-      args << "--with-ssl=#{Formula["openssl"].opt_prefix}"
+      args << "--with-ssl=#{Formula["openssl3"].opt_prefix}"
     end
 
     args << "--enable-graphics" if build.with? "x11"
-    args << "--without-libtiff" if build.without? "libtiff"
-    args << "--without-libjpeg" if build.without? "jpeg"
+    args << "--without-libtiff" if build.without? "x11"
+    args << "--without-libjpeg" if build.without? "x11"
     args << "--without-librsvg" if build.without? "librsvg"
+    args << "--without-libevent" if MacOS.version < :snow_leopard # ERROR: event_base_loop failed: Operation not supported
+    args << "--without-libwebp" if build.without? "x11"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Rework options, hang image support off X11 support, and make X11 support default.
Pull in up to date deps, with the exception of fontconfig and by indirect dependency freetype as it causes issues starting in graphics mode on 10.6, and has a build issue on 10.7 which need to be resolved before they can be depended on.

Tested on Tiger PowerPC (G4/G5) with GCC 4.0.1, Snow Leopard with GCC 4.2, Lion with Clang.