### PR TITLE
openssh 10.1p1

### DIFF
--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -1,18 +1,21 @@
 class Openssh < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools"
   homepage "https://www.openssh.com/"
-  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.0p1.tar.gz"
-  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.0p1.tar.gz"
-  version "10.0p1"
-  sha256 "021a2e709a0edf4250b1256bd5a9e500411a90dddabea830ed59cef90eb9d85c"
+  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.1p1.tar.gz"
+  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.1p1.tar.gz"
+  version "10.1p1"
+  sha256 "b9fc7a2b82579467a6f2f43e4a81c8e1dfda614ddb4f9b255aafd7020bbf0758"
   license "SSH-OpenSSH"
 
   bottle do
-    sha256 "f2c01d5ec1252b6566c1883724b05f71b74ed4844b00fd94118198357d1da410" => :tiger_altivec
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.
   # https://archive.is/hSB6d#10%25
+
+  # clock_gettime(3) showed up in Sierra
+  # https://marc.info/?l=openssh-unix-dev&m=175935977710302&w=2
+  patch :DATA
 
   depends_on "pkg-config" => :build
   depends_on "ldns"
@@ -66,3 +69,58 @@ class Openssh < Formula
     assert_match "sshd", shell_output("lsof -i :#{port}")
   end
 end
+__END__
+diff --git a/openbsd-compat/bsd-misc.c b/openbsd-compat/bsd-misc.c
+index 983cd3fe6..2c196ec23 100644
+--- a/openbsd-compat/bsd-misc.c
++++ b/openbsd-compat/bsd-misc.c
+@@ -494,6 +494,30 @@ localtime_r(const time_t *timep, struct tm *result)
+ }
+ #endif
+ 
++#ifndef HAVE_CLOCK_GETTIME
++int
++clock_gettime(clockid_t clockid, struct timespec *ts)
++{
++	struct timeval tv;
++
++	if (clockid != CLOCK_REALTIME) {
++		errno = ENOSYS;
++		return -1;
++	}
++	if (ts == NULL) {
++		errno = EFAULT;
++		return -1;
++	}
++
++	if (gettimeofday(&tv, NULL) == -1)
++		return -1;
++
++	ts->tv_sec = tv.tv_sec;
++	ts->tv_nsec = (long)tv.tv_usec * 1000;
++	return 0;
++}
++#endif
++
+ #ifdef ASAN_OPTIONS
+ const char *__asan_default_options(void) {
+ 	return ASAN_OPTIONS;
+diff --git a/openbsd-compat/bsd-misc.h b/openbsd-compat/bsd-misc.h
+index 2ad89cd83..8495f471c 100644
+--- a/openbsd-compat/bsd-misc.h
++++ b/openbsd-compat/bsd-misc.h
+@@ -202,6 +202,14 @@ int flock(int, int);
+ struct tm *localtime_r(const time_t *, struct tm *);
+ #endif
+ 
++#ifndef HAVE_CLOCK_GETTIME
++typedef int clockid_t;
++#ifndef CLOCK_REALTIME
++# define CLOCK_REALTIME	0
++#endif
++int clock_gettime(clockid_t, struct timespec *);
++#endif
++
+ #ifndef HAVE_REALPATH
+ #define realpath(x, y)	(sftp_realpath((x), (y)))
+ #endif


### PR DESCRIPTION
Need to patch for lack of clock_gettime(3) on 10.11 and prior.

Tested on 10.4 to 10.11.

Tested on 10.4 (G4/G5) with GCC 4.0.1, 10.5 (i386) wth GCC 4.0.1 & 4.2

Missed 10.4 i386 and 10.5 PowerPC