### PR TITLE
ranger 1.9.4

### DIFF
--- a/Library/Formula/ranger.rb
+++ b/Library/Formula/ranger.rb
@@ -1,34 +1,90 @@
 class Ranger < Formula
   desc "File browser"
-  homepage "http://ranger.nongnu.org/"
-  url "http://ranger.nongnu.org/ranger-1.7.1.tar.gz"
-  sha256 "f8b06135165142508ae7ec22ab2c95f6e51b4018c645d11226086d4c45b7df86"
+  homepage "https://ranger.github.io"
+  url "https://ranger.github.io/ranger-1.9.4.tar.gz"
+  sha256 "7ad75e0d1b29087335fbb1691b05a800f777f4ec9cba84faa19355075d7f0f89"
+  license "GPL-3.0-or-later"
+  head "https://github.com/ranger/ranger.git", branch: "master"
 
-  head "git://git.savannah.nongnu.org/ranger.git"
+  depends_on :python3
 
-  bottle do
-    cellar :any_skip_relocation
-    sha256 "b71c72d76937f8ae47761ba3c642eaef9e121a1b9fc5173d56a42b321f80e9ec" => :el_capitan
-    sha256 "5f0901ba96568d3f8ba713bbb39939538cbcdd1dffa06beee98c5cce13405d20" => :yosemite
-    sha256 "97bf46731d0b5cc20adbd3bd6052ca36508cb3b6deccb80c42cd5cc1ab5d83bc" => :mavericks
-    sha256 "f64e5e2629bcd9bffc74b3453539ce956a293cad9d2925aef5e5f1cd532c5c09" => :mountain_lion
-  end
+  option "with-libcaca", "For ASCII-art image previews"
+  depends_on "libcaca" => :optional
 
-  # requires 2.6 or newer; Leopard comes with 2.5
-  depends_on :python if MacOS.version <= :leopard
+  option "with-imagemagick", "To auto-rotate images and for image previews"
+  depends_on "imagemagick" => :optional
+
+  option "with-librsvg", "For SVG previews"
+  depends_on "librsvg" => :optional
+
+  option "with-ffmpeg", "For video thumbnails"
+  depends_on "ffmpeg" => :optional
+  option "with-ffmpegthumbnailer", "For video thumbnails"
+  depends_on "ffmpegthumbnailer" => :optional
+
+  option "with-highlight", "For syntax highlighting of code"
+  depends_on "highlight" => :optional
+
+  option "with-atool", "To preview archives"
+  depends_on "atool" => :optional
+  option "with-unrar", "To preview archives"
+  depends_on "unrar" => :optional
+  option "with-p7zip", "To preview archives"
+  depends_on "p7zip" => :optional
+
+  option "with-lynx", "To preview HTML pages"
+  depends_on "lynx" => :optional
+  option "with-w3m", "To preview HTML pages"
+  depends_on "w3m" => :optional
+  option "with-elinks", "To preview HTML pages"
+  depends_on "elinks" => :optional
+
+  option "with-poppler", "For textual PDF previews"
+  depends_on "poppler" => :optional
+  option "with-mupdf-tools", "For textual PDF previews"
+  depends_on "mupdf-tools" => :optional
+
+  option "with-transmission", "For viewing BitTorrent information"
+  depends_on "transmission" => :optional
+
+  option "with-media-info", "For viewing information about media files"
+  depends_on "media-info" => :optional
+  option "with-exiftool", "For viewing information about media files"
+  depends_on "exiftool" => :optional
+
+  option "with-odt2txt", "For OpenDocument text files"
+  depends_on "odt2txt" => :optional
+
+  option "with-jq", "For JSON files"
+  depends_on "jq" => :optional
+
+  option "with-sqlite", "For listing tables in SQLite database"
+  depends_on "sqlite" => :optional
 
   def install
     inreplace %w[ranger.py ranger/ext/rifle.py] do |s|
-      s.gsub! "#!/usr/bin/python", "#!#{PythonRequirement.new.which_python}"
-    end if MacOS.version <= :leopard
+      s.gsub! "#!/usr/bin/python", "#!#{Formula["python3"].opt_bin}/python3"
+    end
+
+    inreplace %w[
+      doc/tools/convert_papermode_to_metadata.py
+      doc/tools/performance_test.py
+      doc/tools/print_colors.py
+      doc/tools/print_keys.py
+    ] do |s|
+      s.gsub! "#!/usr/bin/env python", "#!/usr/bin/env python3"
+    end
 
     man1.install "doc/ranger.1"
+    man1.install "doc/rifle.1"
+    doc.install "doc/cheatsheet.svg", "doc/colorschemes.md", "doc/config", "doc/tools", "examples"
     libexec.install "ranger.py", "ranger"
-    bin.install_symlink libexec+"ranger.py" => "ranger"
-    doc.install "examples"
+    bin.install_symlink libexec/"ranger.py" => "ranger"
+    bin.install_symlink libexec/"ranger/ext/rifle.py" => "rifle"
   end
 
   test do
     assert_match version.to_s, shell_output("script -q /dev/null #{bin}/ranger --version")
+    assert_match version.to_s, shell_output("script -q /dev/null #{bin}/rifle --version")
   end
 end


### PR DESCRIPTION
Bump version to 1.9.4 and rewrite the formula. Make Python 3 a dependency. Although Python 2.6 should be sufficient, I found it breaking plugins such as `ranger-devicons`, and some Linux distros require Python 3 for 1.9.4 anyway. One question remains.

A python3 shebang is currently patched in with this line:
`s.gsub! "#!/usr/bin/python", "#!#{Python3Requirement.new.which_python}"`

We end up with:
`#!/usr/local/opt/python3/bin/python3.10`

Instead of pointing to a specific version of Python 3, Is there a reason not to use the following? And what's the best way to arrive at that path programmatically in a formula (in case a non-standard Brew prefix is used)?
`#!/usr/local/opt/python3/bin/python3`

Tested on PowerPC G5 with Sorbet Leopard. More extensive testing is welcome, as I'm not a power user of Ranger or lf.