### PR TITLE
gawk 5.3.2

### DIFF
--- a/Library/Formula/gawk.rb
+++ b/Library/Formula/gawk.rb
@@ -9,6 +9,7 @@ class Gawk < Formula
   end
 
   # spawn.h containing posix_spawnattr_* functions showed up in Leopard
+  # MAP_ANONYMOUS is not defined on Snow Leopard
   patch :p0, :DATA
 
   depends_on "mpfr"
@@ -41,3 +42,16 @@ __END__
  	// This code is for macos
  	if (persist_file != NULL) {
  		const char *cp = getenv("GAWK_PMA_REINCARNATION");
+--- support/pma.c.orig	2025-11-16 00:19:56.000000000 +0000
++++ support/pma.c	2025-11-16 00:21:10.000000000 +0000
+@@ -345,6 +345,10 @@
+ #define MAP_NORESERVE 0
+ #endif /* MAP_NORESERVE */
+ 
++#ifndef MAP_ANONYMOUS
++#define MAP_ANONYMOUS MAP_ANON
++#endif /* MAP_ANONYMOUS */
++
+ #define MMAP(N) mmap(NULL, (N), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0)
+ #define MUNMAP(A, N) do { if (0 != munmap((A), (N))) { ERR("munmap()" ERN); SERN; } } while (0)
+ static void * addrgap(off_t n) {  // find big gap in address space to map n bytes


### PR DESCRIPTION
mpfr support works on PowerPC OS X build now
Use readline as libedit doesn't cut it.
Fix build on Tiger, spawn.h and posix_spawnattr_* first appeard in Leopard.
The gawk testsuite contains several tests which are non determinstic, don't bother running the test suite for now until I've removed all those.


Tested on Tiger PowerPC (G5) with GCC 4.0.1, Leopard PowerPC (G4) with GCC 4.2, Snow Leopard with GCC 4.2