### PR TITLE
makeicns: Update urls for source

### DIFF
--- a/Library/Formula/makeicns.rb
+++ b/Library/Formula/makeicns.rb
@@ -1,16 +1,14 @@
 class Makeicns < Formula
   desc "Create icns files from the command-line"
-  homepage "https://bitbucket.org/mkae/makeicns"
-  url "https://bitbucket.org/mkae/makeicns/downloads/makeicns-1.4.10a.tar.bz2"
+  homepage "http://www.amnoid.de/icns/makeicns.html"
+  url "https://web.archive.org/web/20200621132052/https://bitbucket.org/mkae/makeicns/downloads/makeicns-1.4.10a.tar.bz2"
+  mirror "https://distfiles.macports.org/makeicns/makeicns-1.4.10a.tar.bz2"
   sha256 "10e44b8d84cb33ed8d92b9c2cfa42f46514586d2ec11ae9832683b69996ddeb8"
+  license "MIT"
+
   bottle do
     cellar :any
-    sha256 "40c3d4befe2d4625d7013ea40f307b4f5b26e122a6dad51706a25bb22734f075" => :yosemite
-    sha256 "8c54ce9e5f819dda4eb274f8bf8a22d49e1d0086e33300f236840acf1a46837f" => :mavericks
-    sha256 "dfffe46a25b846de31dc220c279a628b719a3b353aa220ed31189bc8ce5da4b2" => :mountain_lion
   end
-
-  head "https://bitbucket.org/mkae/makeicns", :using => :hg
 
   patch :p0 do
     url "https://trac.macports.org/export/114372/trunk/dports/graphics/makeicns/files/patch-IconFamily.m.diff"
@@ -20,5 +18,11 @@ class Makeicns < Formula
   def install
     system "make"
     bin.install "makeicns"
+  end
+
+  test do
+    system bin/"makeicns", "-in", test_fixtures("test.png"),
+           "-out", testpath/"test.icns"
+    assert File.exist?(testpath/"test.icns")
   end
 end


### PR DESCRIPTION
Project source repo originally Mercurial based, hosted on Bitbucket. Bitbucket stopped hosting Mercurial based projects many years ago. Sync with makeicns.rb from upstream
https://github.com/Homebrew/homebrew-core/blob/afdd81fd28c55f4c6025eeb034a7f6eb620a3f99/Formula/m/makeicns.rb Have left the patch url as was before though.

Fixes #1445


Tested on Tiger PowerPC (G4) with GCC 4.0.1