### PR TITLE
minicom 2.8

### DIFF
--- a/Library/Formula/minicom.rb
+++ b/Library/Formula/minicom.rb
@@ -1,8 +1,11 @@
 class Minicom < Formula
   desc "Menu-driven communications program"
-  homepage "http://alioth.debian.org/projects/minicom/"
-  url "http://ftp.de.debian.org/debian/pool/main/m/minicom/minicom_2.7.orig.tar.gz"
-  sha256 "9ac3a663b82f4f5df64114b4792b9926b536c85f59de0f2d2b321c7626a904f4"
+  homepage "https://salsa.debian.org/minicom-team/minicom"
+  url "https://salsa.debian.org/minicom-team/minicom/-/archive/2.8/minicom-2.8.tar.bz2"
+  sha256 "38cea30913a20349326ff3f1763ee1512b7b41601c24f065f365e18e9db0beba"
+
+  # no-format-truncation showed up in GCC 7.x
+  patch :p0, :DATA
 
   def install
     # There is a silly bug in the Makefile where it forgets to link to iconv. Workaround below.
@@ -35,3 +38,15 @@ Control to be set to "No" to input text.
     EOS
   end
 end
+__END__
+--- configure.orig	2025-10-31 20:42:45.000000000 +0000
++++ configure	2025-10-31 20:42:58.000000000 +0000
+@@ -11342,7 +11342,7 @@
+ 
+ if test "x$ac_cv_c_compiler_gnu" = xyes
+ then
+-	CFLAGS="$CFLAGS -W -Wall -Wextra -std=gnu99 -fno-common -Wno-format-truncation"
++	CFLAGS="$CFLAGS -W -Wall -Wextra -std=gnu99 -fno-common"
+ fi
+ 
+ # this is a hack, if we need getopt_long we also need getopt


### PR DESCRIPTION
v2.8 builds without issue using GCC 4.0. v2.9 introduces the use of _Static_assert() which is a C11-ism, yet `std` is still set to `gnu99` :(
Tested with a Prolific PL2303 USB to RS-232 adapter and some network hardware at 9600 baud on OS X Tiger.

Fixes issue highlighted in #557