### PR TITLE
libusb: build fix for dependents

### DIFF
--- a/Library/Formula/libusb.rb
+++ b/Library/Formula/libusb.rb
@@ -7,6 +7,7 @@ class Libusb < Formula
   revision 1
 
   bottle do
+    sha256 "4a948607743f9459b6bdd264baf3787e33c6a454ca5f11971c309ef496bf625d" => :tiger_g3
   end
 
   # USB 3.0 support showed up in 10.8's IOKit


### PR DESCRIPTION
ld on Tiger complains when building a dylib which depends on libusb


Tested on Tiger PowerPC (G4) with GCC 4.0.1.

Marking as draft until I've had a chance to test all the dependencies which previously built fine.