### PR TITLE
stlink 1.7.0

### DIFF
--- a/Library/Formula/stlink.rb
+++ b/Library/Formula/stlink.rb
@@ -6,6 +6,7 @@ class Stlink < Formula
 
   bottle do
     cellar :any
+    sha256 "3e7284432576b03b20adb80e29c334a1f205e66b24b01ab6a82b6bc2907bc42b" => :tiger_g3
   end
 
   # Don't assume the compiler will default to C99


### PR DESCRIPTION
This is the last version which support macOS. v1.8.0 drops support.
To build with GCC 4.0 on Tiger, need to enable warnings as passing the flag to turn them off to libtool trips it up, but if you enable warnings, can't treat them as hard errors.
GCC 4.0 defaults to C89.

Tested that st-info was able to probe an st-link v2 module, and to use st-util to spawn a gdbserver which arm-none-eabi-gdb was able to attach to where an stm32-discovery board was connected to the st-link v2 module for SWD.


Tested on Tiger PowerPC (G3/G4) with GCC 4.0.1
Built on 600Mhz iBook G3 running Tiger using GCC 4.0.1 in 2.1 minutes.

Requires #1455

Marking as draft until #1455 has landed.