### PR TITLE
dosbox: Add formula for v0.74-3

### DIFF
--- a/Library/Formula/dosbox.rb
+++ b/Library/Formula/dosbox.rb
@@ -1,0 +1,23 @@
+class Dosbox < Formula
+  desc "An x86 emulator with DOS"
+  homepage "https://dosbox.com"
+  url "https://sourceforge.net/projects/dosbox/files/dosbox/0.74-3/dosbox-0.74-3.tar.gz"
+  version "0.74-3"
+  sha256 "c0d13dd7ed2ed363b68de615475781e891cd582e8162b5c3669137502222260a"
+
+  depends_on "sdl"
+  depends_on "sdl_net"
+  depends_on "sdl_sound"
+  depends_on "ncurses"
+  depends_on "libpng"
+  depends_on "zlib"
+
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
Tested that it's possible to mount a directory from host (OS X Tiger) as a drive on dosbox & to execute an .exe file (kermit).


Tested on Tiger PowerPC (G4) with GCC 4.0.1, took 7 minutes!