### PR TITLE
zstd: add basic formula

### DIFF
--- a/Library/Formula/zstd.rb
+++ b/Library/Formula/zstd.rb
@@ -19,7 +19,6 @@ class Zstd < Formula
 
   def install
     ENV["AS"] = Formula["cctools"].bin/"as"
-    system "gmake", "clean"
     system "gmake", "BACKTRACE=0"
     system "gmake", "install", "PREFIX=#{prefix}"
   end


### PR DESCRIPTION
Unlike upstream Homebrew formula, uses plain Makefile available in repository.

BACKTRACE is disabled as it requires execinfo.h header, that either brings a new dependency libexecinfo, or shall be implemented by system libc.

The default Makefile target only builds both library and programs.