### PR TITLE
docs: update uninstall script path

### DIFF
--- a/share/doc/homebrew/FAQ.md
+++ b/share/doc/homebrew/FAQ.md
@@ -47,9 +47,9 @@ to see what would be cleaned up:
 To uninstall Tigerbrew, paste the command below in a terminal prompt.
 
 ```bash
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall)"
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/d8aeae7efb14ed9e4f7934b4782f04d5305562cc/install)"
 ```
-Download the [uninstall script](https://raw.githubusercontent.com/Homebrew/install/master/uninstall)
+Download the [uninstall script](https://raw.githubusercontent.com/Homebrew/install/d8aeae7efb14ed9e4f7934b4782f04d5305562cc/install)
 and run `./uninstall --help` to view more uninstall options.
 
 <a name="uninstall-package"></a>


### PR DESCRIPTION
This script doesn't exist upstream anymore, but the version at this commit was current at the time the FAQ was written so it should work. Eventually, it'd be good to migrate it into this repo altogether.

refs #1459.