### PR TITLE
zstd: build fix

### DIFF
--- a/Library/Formula/zstd.rb
+++ b/Library/Formula/zstd.rb
@@ -27,6 +27,14 @@ class Zstd < Formula
     system "gmake", "ALREADY_APPENDED_NOEXECSTACK=1"
     system "gmake", "install", "PREFIX=#{prefix}"
   end
+
+  test do
+    data = "Hello, Tigerbrew"
+    assert_equal data, pipe_output("#{bin}/zstd -d", pipe_output("#{bin}/zstd", data))
+    ["xz", "lz4", "gzip"].each do |prog|
+      assert_equal data, pipe_output("#{prog} -d", pipe_output("#{bin}/zstd --format=#{prog}", data))
+    end
+  end
 end
 __END__
 diff --git a/lib/libzstd.mk b/lib/libzstd.mk
@@ -63,5 +71,5 @@ index 91bd4ca..a7d13dc 100644
 -$(LIBZSTD): CFLAGS   += -fPIC -fvisibility=hidden
 +$(LIBZSTD): CFLAGS   += -fPIC -fvisibility=hidden -fno-common
  $(LIBZSTD): LDFLAGS  += -shared $(LDFLAGS_DYNLIB)
-
+ 
  ifndef BUILD_DIR


### PR DESCRIPTION
GCC 4.0 from Xcode is hardcoded to use supplied linker & assembler.
Unfortunately it's not overridable.
Installed tools link to lz4, liblzma via xz, zlib
There's a BACKTRACE_ENABLE, but not having it set doesn't affect the build
Drop the patch to lib/common/threading.c, GCC 4.0 & 14 are happy without the change.
Use ALREADY_APPENDED_NOEXECSTACK setting to avoid dealing with noexecstack which as(1)
does not support.
Adapted from the upstream version which uses pzstd, that we currently
lack.
Include a whitespace that was missed by mistake in previous commit.

Tested on Tiger PowerPC (G4) with GCC 4.0.1 & 14, Leopard PowerPC (G4) with GCC 4.2