### PR TITLE
zlib: Enable universal build option

### DIFF
--- a/Library/Formula/zlib.rb
+++ b/Library/Formula/zlib.rb
@@ -11,6 +11,8 @@ class Zlib < Formula
 
   keg_only :provided_by_osx
 
+  option :universal
+
   # http://zlib.net/zlib_how.html
   resource "test_artifact" do
     url "http://zlib.net/zpipe.c"
@@ -19,6 +21,7 @@ class Zlib < Formula
   end
 
   def install
+    ENV.universal_binary if build.universal?
     # The test in configure to see if shared library support is available
     # is done so by invoking gcc -w and then falls back to building just a
     # static library.


### PR DESCRIPTION
Unbreaks universal build of packages which depend on it. e.g libpng.

```
$ file opt/zlib/lib/libz.1.3.1.dylib
opt/zlib/lib/libz.1.3.1.dylib: Mach-O universal binary with 2 architectures
opt/zlib/lib/libz.1.3.1.dylib (for architecture i386):	Mach-O dynamically linked shared library i386
opt/zlib/lib/libz.1.3.1.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
$ file opt/libpng/lib/libpng16.16.dylib
opt/libpng/lib/libpng16.16.dylib: Mach-O universal binary with 2 architectures
opt/libpng/lib/libpng16.16.dylib (for architecture i386):	Mach-O dynamically linked shared library i386
opt/libpng/lib/libpng16.16.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
```

Tested on Lion with clang.

Resolves issue #1297