### PR TITLE
docs: use vendored ruby & modern curl

### DIFF
--- a/share/doc/homebrew/FAQ.md
+++ b/share/doc/homebrew/FAQ.md
@@ -44,10 +44,12 @@ to see what would be cleaned up:
 <a name="uninstall"></a>
 
 ### How do I uninstall Homebrew?
+Assuming you have Tigerbrew installed in `/usr/local`, along with `curl` from
+Tigerbrew. Otherwise substitute `/usr/local` for the prefix you are using.
 To uninstall Tigerbrew, paste the command below in a terminal prompt.
 
 ```bash
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/d8aeae7efb14ed9e4f7934b4782f04d5305562cc/uninstall)"
+/usr/local/Library/Homebrew/vendor/portable-ruby/current/bin/ruby -e "$(/usr/local/Library/Homebrew/vendor/portable-curl/current/bin/curl -fsSL https://raw.githubusercontent.com/Homebrew/install/d8aeae7efb14ed9e4f7934b4782f04d5305562cc/uninstall)"
 ```
 Download the [uninstall script](https://raw.githubusercontent.com/Homebrew/install/d8aeae7efb14ed9e4f7934b4782f04d5305562cc/uninstall)
 and run `./uninstall --help` to view more uninstall options.


### PR DESCRIPTION
curl included with the OS most definitely will be unable to fetch the script due to ancient OpenSSL, and the uninstall script needs a newer version of ruby than is provided at the very least in Leopard and Tiger.

uninstall script uses String#start_with?
String#start_with? showed up in Ruby 1.8.7.
Ruby shipped in Leopard is 1.8.6

Discovered in issue #1459