### PR TITLE
nano 8.7

### DIFF
--- a/Library/Formula/nano.rb
+++ b/Library/Formula/nano.rb
@@ -1,8 +1,8 @@
 class Nano < Formula
   desc "Free (GNU) replacement for the Pico text editor"
   homepage "https://www.nano-editor.org/"
-  url "https://www.nano-editor.org/dist/v8/nano-8.0.tar.xz"
-  sha256 "c17f43fc0e37336b33ee50a209c701d5beb808adc2d9f089ca831b40539c9ac4"
+  url "https://www.nano-editor.org/dist/v8/nano-8.7.tar.xz"
+  sha256 "afd287aa672c48b8e1a93fdb6c6588453d527510d966822b687f2835f0d986e9"
   license "GPL-3.0-or-later"
 
   bottle do


### PR DESCRIPTION
Nano 8.0 was released quite a while ago. I bumped it to 8.7 and it builds ok on my iMac G5 running Leopard. If it builds fine on Tiger machines as well, I think we can merge it. Also, can someone compile a bottle for @mistydemeo to host for Tiger? I built a bottle for Leopard myself, attached below.
[nano-8.7.leopard_g5.bottle.tar.gz](https://github.com/user-attachments/files/24043542/nano-8.7.leopard_g5.bottle.tar.gz) (`36e9ea82a539fe055ab8e80ac1a5335f73c665e20da413bfef2871f5fc7807a4`)

I would like these to be hosted on @mistydemeo's bottle domain.