### PR TITLE
ddrescue 1.29

### DIFF
--- a/Library/Formula/ddrescue.rb
+++ b/Library/Formula/ddrescue.rb
@@ -1,19 +1,20 @@
 class Ddrescue < Formula
   desc "GNU data recovery tool"
   homepage "https://www.gnu.org/software/ddrescue/ddrescue.html"
-  url "http://ftpmirror.gnu.org/ddrescue/ddrescue-1.27.tar.lz"
-  mirror "https://ftp.gnu.org/gnu/ddrescue/ddrescue-1.27.tar.lz"
-  sha256 "38c80c98c5a44f15e53663e4510097fd68d6ec20758efdf3a925037c183232eb"
+  url "http://ftpmirror.gnu.org/ddrescue/ddrescue-1.29.tar.lz"
+  mirror "https://ftp.gnu.org/gnu/ddrescue/ddrescue-1.29.tar.lz"
+  sha256 "01a414327853b39fba2fd0ece30f7bee2e9d8c8e8eb314318524adf5a60039a3"
 
   bottle do
-    sha256 "817916afa65a7f92c8a489634d947e9968a42ff63210a7049023e04265531a0a" => :tiger_altivec
   end
+
+  option "with-tests", "Build and run the test suite"
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "CXX=#{ENV.cxx}"
     system "make"
-    system "make", "check"
+    system "make", "check" if build.with?("tests") || build.bottle?
     system "make", "install"
   end
 


### PR DESCRIPTION
To save time, only run testsuite if chosen to or when bottling to save time.

Tested on Tiger PowerPC (G3) with GCC 4.0.1
Built on 600Mhz iBook G3 running Tiger using GCC 4.0.1 in 103 seconds