### PR TITLE
curl 8.17.0

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -1,9 +1,9 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.haxx.se/"
-  url "https://curl.se/download/curl-8.16.0.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-8_16_0/curl-8.16.0.tar.bz2"
-  sha256 "9459180ab4933b30d0778ddd71c91fe2911fab731c46e59b3f4c8385b1596c91"
+  url "https://curl.se/download/curl-8.17.0.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-8_17_0/curl-8.17.0.tar.bz2"
+  sha256 "230032528ce5f85594d4f3eace63364c4244ccc3c801b7f8db1982722f2761f4"
   license "curl"
 
   bottle do
@@ -33,6 +33,7 @@ class Curl < Formula
   depends_on "libressl" => :optional
   depends_on "libnghttp2"
   depends_on "libpsl"
+  depends_on "libidn2"
   depends_on "zlib"
 
   def install


### PR DESCRIPTION
libidn2 gets pulled via libpsl and curl links to it opportunistically.

Tested on Tiger PowerPC (G3) with GCC 4.0.1
Built on 600Mhz iBook G3 running Tiger using GCC 4.0.1 in 42.6 minutes
8.16.0 took 38.6.