### PR TITLE
mpfr 4.2.2

### DIFF
--- a/Library/Formula/mpfr.rb
+++ b/Library/Formula/mpfr.rb
@@ -1,16 +1,16 @@
 class Mpfr < Formula
   desc "C library for multiple-precision floating-point computations"
   homepage "http://www.mpfr.org/"
-  url "https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.1.tar.xz"
-  sha256 "277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2"
+  url "https://www.mpfr.org/mpfr-4.2.2/mpfr-4.2.2.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+  sha256 "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
 
   bottle do
     cellar :any
-    sha256 "2be468ac995cbad3fa75c17a7fc41b2967c52591434124de10420b823fc95aa6" => :tiger_altivec
   end
 
   option "32-bit"
+  option "with-tests", "Build and run the test suite"
 
   depends_on "gmp"
 
@@ -19,7 +19,7 @@ class Mpfr < Formula
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
                           "--disable-silent-rules"
     system "make"
-    system "make", "check"
+    system "make", "check" if build.with?("tests") || build.bottle?
     system "make", "install"
   end
 


### PR DESCRIPTION
To save time, only run the testsuite if chosen to or when bottling.

Tested on Tiger PowerPC (G3) with GCC 4.0.1
Built on 600Mhz iBook G3 running Tiger using GCC 4.0.1 in 52.6 minutes (with test suite run)