### PR TITLE
libxml2 2.11.9

### DIFF
--- a/Library/Formula/libxml2.rb
+++ b/Library/Formula/libxml2.rb
@@ -1,8 +1,8 @@
 class Libxml2 < Formula
   desc "GNOME XML library"
   homepage "http://xmlsoft.org"
-  url "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.8.tar.xz"
-  sha256 "53961af1721b72246180cd844b7ddae36ea8e1e4e27b683567990a1ee78b02c1"
+  url "https://download.gnome.org/sources/libxml2/2.11/libxml2-2.11.9.tar.xz"
+  sha256 "780157a1efdb57188ec474dca87acaee67a3a839c2525b2214d318228451809f"
 
   head do
     url "https://git.gnome.org/browse/libxml2", :using => :git
@@ -13,7 +13,6 @@ class Libxml2 < Formula
   end
 
   bottle do
-    sha256 "69550a566cdc2e31f81550b33d3470ff9d2c998dc34ac35ab807b555d91c44e8" => :tiger_altivec
   end
 
   depends_on "python" => :optional


### PR DESCRIPTION
This is the latest release on the 2.11 branch, skipped on upgrading to the latest branch as ABI changes start from 2.12 and while there's a configure flag to preserve legacy behaviour which we're currently on, things get dropped and I didn't want to veer off into testing libxml2 just now.

Tested on Tiger PowerPC (G3) with GCC 4.0.1
Built on 600Mhz iBook G3 running Tiger using GCC 4.0.1 in 7.1 minutes