### PR TITLE
libtiff: close circular dependency

### DIFF
--- a/Library/Formula/libtiff.rb
+++ b/Library/Formula/libtiff.rb
@@ -32,6 +32,7 @@ class Libtiff < Formula
     zlib = Formula["zlib"].opt_prefix
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--disable-webp",
                           "--with-jpeg-include-dir=#{jpeg}/include",
                           "--with-jpeg-lib-dir=#{jpeg}/lib",
                           "--with-lzma-include-dir=#{xz}/include",


### PR DESCRIPTION
This can bite on installs where libtiff has been upgraded with webp installed. The subsequent libtiff builds would have linked to webp and then when you come to upgrade webp the build fails indirectly.

Skipping revbump as it'll correct itself on the build of the next version update.