### PR TITLE
docs: drop curl reference in paragraph

### DIFF
--- a/share/doc/homebrew/FAQ.md
+++ b/share/doc/homebrew/FAQ.md
@@ -44,9 +44,9 @@ to see what would be cleaned up:
 <a name="uninstall"></a>
 
 ### How do I uninstall Homebrew?
-Assuming you have Tigerbrew installed in `/usr/local`, along with `curl` from
-Tigerbrew. Otherwise substitute `/usr/local` for the prefix you are using.
-To uninstall Tigerbrew, paste the command below in a terminal prompt.
+Assuming you have Tigerbrew installed in `/usr/local`, otherwise substitute
+`/usr/local` for the prefix you are using.  To uninstall Tigerbrew, paste
+the command below in a terminal prompt.
 
 ```bash
 /usr/local/Library/Homebrew/vendor/portable-ruby/current/bin/ruby -e "$(/usr/local/Library/Homebrew/vendor/portable-curl/current/bin/curl -fsSL https://raw.githubusercontent.com/Homebrew/install/d8aeae7efb14ed9e4f7934b4782f04d5305562cc/uninstall)"


### PR DESCRIPTION
We went with vendored ruby/curl before it landed and I forgot to edit the paragraph, only adjusting the command.