### PR TITLE
qtads: Add formula for v2.1.7

### DIFF
--- a/Library/Formula/qtads.rb
+++ b/Library/Formula/qtads.rb
@@ -1,0 +1,76 @@
+class Qtads < Formula
+  desc "A cross-platform, multimedia interpreter for TADS games"
+  homepage "https://realnc.github.io/qtads/"
+  url "https://github.com/realnc/qtads/releases/download/2.1.7/qtads-2.1.7.tar.bz2"
+  version "2.1.7"
+  sha256 "7477bb3cb1f74dcf7995a25579be8322c13f64fb02b7a6e3b2b95a36276ef231"
+  license "GPL-2.0-or-later"
+
+  # Ride the defaults, rather than raising requirements
+  # Use SDL rather than SDL2, as we lack SDL2_sound
+  # Skip checking for an update on start to avoid being greeted with an error
+  # for HTTP 301
+  patch :p0, :DATA
+
+  depends_on "qt"
+  depends_on "sdl_mixer"
+  depends_on "sdl_sound"
+
+  def install
+    system "qmake"
+    system "make"
+    prefix.install "QTads.app"
+    man6.install "share/man/man6/qtads.6"
+  end
+
+  def caveats
+    <<~EOS
+    Visit The Interactive Fiction Archive for games
+    https://ifarchive.org
+    EOS
+  end
+
+end
+__END__
+--- qtads.pro.orig	2026-01-25 14:05:32.000000000 +0000
++++ qtads.pro	2026-01-25 14:27:55.000000000 +0000
+@@ -32,11 +32,10 @@
+ 
+ macx {
+     QMAKE_INFO_PLIST = Info.plist
+-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+     CONFIG += link_pkgconfig
+-    PKGCONFIG += SDL2_mixer
++    PKGCONFIG += SDL_mixer
+     LIBS += -lSDL_sound
+-    QMAKE_CFLAGS += -std=gnu11 -fvisibility=hidden
++    QMAKE_CFLAGS += -fvisibility=hidden
+     QMAKE_CXXFLAGS += -fvisibility=hidden
+     QMAKE_LFLAGS += -dead_strip
+ } else:!android {
+--- src/sysframe.cc.orig	2026-01-25 14:20:43.000000000 +0000
++++ src/sysframe.cc	2026-01-25 14:21:31.000000000 +0000
+@@ -365,23 +365,6 @@
+     this->fMainWin->resize(this->fSettings->appSize);
+     this->fMainWin->show();
+ 
+-    // Do an online update check.
+-    int daysRequired;
+-    switch (this->fSettings->updateFreq) {
+-      case Settings::UpdateOnEveryStart: daysRequired = 0; break;
+-      case Settings::UpdateDaily:        daysRequired = 1; break;
+-      case Settings::UpdateWeekly:       daysRequired = 7; break;
+-      default:                           daysRequired = -1;
+-    }
+-    if (not this->fSettings->lastUpdateDate.isValid()) {
+-        // Force update check.
+-        daysRequired = 0;
+-    }
+-    int daysPassed = this->fSettings->lastUpdateDate.daysTo(QDate::currentDate());
+-    if (daysPassed >= daysRequired and daysRequired > -1) {
+-        this->fMainWin->checkForUpdates();
+-    }
+-
+     // If a game file was specified, try to run it.
+     if (not gameFileName.isEmpty()) {
+         this->setNextGame(gameFileName);


### PR DESCRIPTION
v2.1.7 is the last version to support Qt 4.
With v3.0 it switched to Qt 5 and then to 5.5 in subsequent releases.
SDL2 switched to cmake with v2.0.23, and SDL2_sound uses cmake for build infra, pulling in cmake files SDL2 which our version obviously lacks.
Qt 4 is built without SSL support in Tigerbrew since it only supports the OpenSSL 1.x API.
Qtads by default attempts to connect to sourceforge via HTTP and expects a 200 responce, but the redirect to HTTPS trips it up, so you're prompted with an error on launch which you have to click through.
We know there are newer versions! :)

Tested on a Tiger PowerPC (G4) with GCC 4.0.1
Built on 1.33Ghz PowerBook G4 running Tiger using GCC 4.0.1 in 7.5 minutes.