### PR TITLE
Coreutils 9.10

### DIFF
--- a/Library/Formula/coreutils.rb
+++ b/Library/Formula/coreutils.rb
@@ -44,6 +44,7 @@ class Coreutils < Formula
     args = %W[
       --prefix=#{prefix}
       --program-prefix=g
+      --disable-year2038
     ]
     args << "--without-gmp" if build.without? "gmp"
     system "./configure", *args


### PR DESCRIPTION
This PR bumps coreutils to 9.10. I have also compiled a `leopard_g5` bottle: 
[coreutils-9.10.tiger_g5.bottle.tar.gz](https://github.com/user-attachments/files/25252730/coreutils-9.10.tiger_g5.bottle.tar.gz)
