### PR TITLE
x11: fix install message for Tiger/Leopard

### DIFF
--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -5,7 +5,6 @@ class X11Requirement < Requirement
   attr_reader :min_version
 
   fatal true
-  cask "xquartz"
   download "https://xquartz.macosforge.org"
 
   env { ENV.x11 }
@@ -27,9 +26,23 @@ class X11Requirement < Requirement
   end
 
   def message
-    s = "XQuartz#{@min_version_string} is required to install this formula."
-    s += super
-    s
+    name = MacOS.version == :tiger ? "X11" : "XQuartz"
+
+    s = "#{name}#{@min_version_string} is required to install this formula."
+
+    if MacOS.version == :tiger
+      s += "You can install it using the X11 installer located in the"
+      s += "\"Optional Installs\" folder on your Mac OS X 10.4 DVD."
+    elsif MacOS.version == :leopard
+      s += "You can install it from the XQuartz website:"
+      s += "https://www.xquartz.org/releases/XQuartz-2.6.3.html"
+    elsif MacOS.version <= :mountain_lion
+      s += "You can install it from the XQuartz website:"
+      s += "https://www.xquartz.org/releases/XQuartz-2.7.11.html"
+    else
+      s += "You can install it from the XQuartz website:"
+      s += "https://www.xquartz.org/releases/index.html"
+    end
   end
 
   def <=>(other)


### PR DESCRIPTION
The previous message doesn't work for Tigerbrew; we should just tell users to get it from the XQuartz site or their Mac OS X DVD, as appropriate. I've also added messages for specific OS versions that can't use the latest release.

cc @sevan - how do you feel about this messaging? Any other versions we want in?

Fixes #1499.