### PR TITLE
requirement: remove cask support

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -9,16 +9,14 @@ require "build_environment"
 class Requirement
   include Dependable
 
-  attr_reader :tags, :name, :cask, :download, :default_formula
+  attr_reader :tags, :name, :download, :default_formula
   alias_method :option_name, :name
 
   def initialize(tags = [])
     @default_formula = self.class.default_formula
-    @cask ||= self.class.cask
     @download ||= self.class.download
     tags.each do |tag|
       next unless tag.is_a? Hash
-      @cask ||= tag[:cask]
       @download ||= tag[:download]
     end
     @tags = tags
@@ -29,14 +27,6 @@ class Requirement
   # The message to show when the requirement is not met.
   def message
     s = ""
-    if cask
-      s +=  <<-EOS.undent
-
-        You can install with Homebrew Cask:
-          brew install Caskroom/cask/#{cask}
-      EOS
-    end
-
     if download
       s += <<-EOS.undent
 
@@ -136,7 +126,7 @@ class Requirement
 
     attr_reader :env_proc
     attr_rw :fatal, :default_formula
-    attr_rw :cask, :download
+    attr_rw :download
     # build is deprecated, use `depends_on <requirement> => :build` instead
     attr_rw :build
 

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -2,7 +2,6 @@ require "language/java"
 
 class JavaRequirement < Requirement
   fatal true
-  cask "java"
   download "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
   satisfy(:build_env => false) { java_version }

--- a/Library/Homebrew/requirements/osxfuse_requirement.rb
+++ b/Library/Homebrew/requirements/osxfuse_requirement.rb
@@ -3,7 +3,6 @@ require "requirement"
 class OsxfuseRequirement < Requirement
   fatal true
   default_formula "osxfuse"
-  cask "osxfuse"
   download "https://osxfuse"
 
   satisfy(:build_env => false) { Formula["osxfuse"].installed? || self.class.binary_osxfuse_installed? }

--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -3,7 +3,6 @@ require "language/python"
 class PythonRequirement < Requirement
   fatal true
   default_formula "python"
-  cask "python"
 
   satisfy :build_env => false do
     python = which_python
@@ -56,7 +55,6 @@ end
 class Python3Requirement < PythonRequirement
   fatal true
   default_formula "python3"
-  cask "python3"
 
   satisfy(:build_env => false) { which_python }
 

--- a/Library/Homebrew/requirements/tuntap_requirement.rb
+++ b/Library/Homebrew/requirements/tuntap_requirement.rb
@@ -3,7 +3,6 @@ require "requirement"
 class TuntapRequirement < Requirement
   fatal true
   default_formula "tuntap"
-  cask "tuntap"
   satisfy(:build_env => false) { self.class.binary_tuntap_installed? || Formula["tuntap"].installed? }
 
   def self.binary_tuntap_installed?


### PR DESCRIPTION
Cask doesn't support the Mac versions we do, and even if it did it wouldn't have casks that work on these OS releases. We should stop recommending casks as ways to install the software from these requirements.

X11 was previously removed in #1501, but these remaining ones would still recommend the user install a cask. All of them can be satisfied by Tigerbrew except Java, which we can eventually find a better recommendation for.

cc @sevan 