### PR TITLE
requirement: remove lingering cask reference

### DIFF
--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -75,7 +75,6 @@ end
 
 class TeXRequirement < Requirement
   fatal true
-  cask "mactex"
   download "https://www.tug.org/mactex/"
 
   satisfy { which("tex") || which("latex") }


### PR DESCRIPTION
Now that cask support has been removed.

Apologies, missed it as part of the #1502 review.