### PR TITLE
git: only install osxkeychain on 10.9 & up

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -125,9 +125,11 @@ class Git < Formula
 
     system "gmake", "install", *args
 
-    if MacOS.version >= :lion
+    if MacOS.version >= :mavericks
     # Install the OS X keychain credential helper
     # Needs Security.framework from 10.7 or newer
+    # but we skip on 10.8 and prior due to build
+    # infra not coping with combining CFLAGS or LDFLAGS
     cd "contrib/credential/osxkeychain" do
       system "gmake", "CC=#{ENV.cc}",
                      "CFLAGS=#{ENV.cflags}",


### PR DESCRIPTION
On 10.7 & 10.8 it unravels in one of two ways, either libgit.a complaining about not resolving symbols from OpenSSL, or libicov + some more.  I think the change to build infra that landed in this release is a little premature and assumes you're not setting LDFLAGS/CFLAGS, and it depends on things which are set earlier in its build.

Fixes issue #1516


Built on late 2009 white MacBook running Lion using clang in 101 seconds. 
Built on late 2009 white MacBook running Mountain Lion using clang in 2 minutes.