### PR TITLE
README.md: remove unused link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,3 @@ Code is under the [BSD 2 Clause (NetBSD) license][license].
 [license]:https://github.com/mistydemeo/tigerbrew/blob/master/LICENSE.txt
 [issues]:https://github.com/mistydemeo/tigerbrew/issues
 [prs]:https://github.com/mistydemeo/tigerbrew/pulls
-[tip]:https://www.gratipay.com/mistydemeo/


### PR DESCRIPTION
Gratipay donations were dropped in commit db85420e888cff86611c9f76d1bc5d34bae1f80c.
Service is no longer around.