### PR TITLE
openssh 10.3p1

### DIFF
--- a/Library/Formula/openssh.rb
+++ b/Library/Formula/openssh.rb
@@ -1,14 +1,13 @@
 class Openssh < Formula
   desc "OpenBSD freely-licensed SSH connectivity tools"
   homepage "https://www.openssh.com/"
-  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.2p1.tar.gz"
-  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.2p1.tar.gz"
-  version "10.2p1"
-  sha256 "ccc42c0419937959263fa1dbd16dafc18c56b984c03562d2937ce56a60f798b2"
+  url "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.3p1.tar.gz"
+  mirror "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-10.3p1.tar.gz"
+  version "10.3p1"
+  sha256 "56682a36bb92dcf4b4f016fd8ec8e74059b79a8de25c15d670d731e7d18e45f4"
   license "SSH-OpenSSH"
 
   bottle do
-    sha256 "d69009bc9e9af938192e21d804c9c5c41f3b9d25e9645f7c987eef1bb507c7c9" => :tiger_g3
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.


### PR DESCRIPTION
Tested on Tiger PowerPC (G4) with GCC 4.0.1

Built on 1.33Ghz PowerBook G4 running Tiger using GCC 4.0.1 in 6.6 minutes.