### PR TITLE
giflib: update source url

### DIFF
--- a/Library/Formula/giflib.rb
+++ b/Library/Formula/giflib.rb
@@ -1,7 +1,7 @@
 class Giflib < Formula
   desc "GIF library using patented LZW algorithm"
   homepage "http://giflib.sourceforge.net/"
-  url "https://prdownloads.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz"
+  url "https://prdownloads.sourceforge.net/project/giflib/giflib-5.x/giflib-5.2.2.tar.gz"
   sha256 "be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb"
 
   bottle do


### PR DESCRIPTION
The project seems to have reorganized their files, the download lives in a `giflib-5.x` subdirectory now.