### PR TITLE
libpng: keg_only on 10.5 & up

### DIFF
--- a/Library/Formula/libpng.rb
+++ b/Library/Formula/libpng.rb
@@ -19,7 +19,7 @@ class Libpng < Formula
   end
 
   depends_on "zlib"
-  keg_only :provided_pre_mountain_lion
+  keg_only :provided_by_osx, "X11 includes libpng" if MacOS.version >= :leopard
 
   option :universal
   option "with-tests", "Build and run the test suite"


### PR DESCRIPTION
libpng was included in X11 shipped in Leopard, and is present in current versions of Xquartz.
It was not included in Tiger.

Fixes issue #1519