### PR TITLE
cppformat 2.0.0

### DIFF
--- a/Library/Formula/cppformat.rb
+++ b/Library/Formula/cppformat.rb
@@ -1,14 +1,11 @@
 class Cppformat < Formula
   desc "Open-source formatting library for C++"
-  homepage "https://cppformat.github.io/"
-  url "https://github.com/cppformat/cppformat/releases/download/1.1.0/cppformat-1.1.0.zip"
-  sha256 "bfa5db9d5bafe079b711981c336ec33b3980715aadf89efc7855aca507845a0e"
+  homepage "https://web.archive.org/web/20160325180910/http://cppformat.github.io/latest/index.html"
+  url "https://github.com/ibayer/cppformat/archive/refs/tags/2.0.0.tar.gz"
+  sha256 "2f333779a0709cc28490a4ac0690ba9f64db52c2883a971997aab1c2fbd6f6af"
 
   bottle do
     cellar :any
-    sha256 "69209bdc16296c7d84ca4e1484f64384c7e880715d338be69e792fe3e55976d6" => :yosemite
-    sha256 "caef34333b39765174c968ff3a7bbdf303894a9a402b172b4035338b7ca88c0c" => :mavericks
-    sha256 "b2880f33158da37e8a1b064e2bd30edb6c091cff42b6c126fb1b0627f682850f" => :mountain_lion
   end
 
   depends_on "cmake" => :build
@@ -32,9 +29,9 @@ class Cppformat < Formula
     EOS
 
     system ENV.cxx, "test.cpp", "-o", "test",
-                  "-I#{include}",
+                  "-I#{include}/cppformat",
                   "-L#{lib}",
-                  "-lformat"
+                  "-lcppformat"
     assert_equal "The answer is 42", shell_output("./test")
   end
 end


### PR DESCRIPTION
Website is gone, use archive.org mirror.
Fix test.
Development continues in {fmt} but that requires a compiler with C++11 support. https://fmt.dev

Tested on Tiger PowerPC (G4) with GCC 4.0.1

Built on 1.33Ghz PowerBook G4 running Tiger using GCC 4.0.1 in 6.7 minutes.