### PR TITLE
software_spec.rb: Set DEFAULT_DOMAIN to archive.org

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -281,7 +281,7 @@ end
 class BottleSpecification
   DEFAULT_PREFIX = "/usr/local".freeze
   DEFAULT_CELLAR = "/usr/local/Cellar".freeze
-  DEFAULT_DOMAIN = (ENV["HOMEBREW_BOTTLE_DOMAIN"] || "https://ia904500.us.archive.org/24/items/tigerbrew").freeze
+  DEFAULT_DOMAIN = (ENV["HOMEBREW_BOTTLE_DOMAIN"] || "https://archive.org/download/tigerbrew").freeze
 
   attr_rw :prefix, :cellar, :revision
   alias_method :rebuild, :revision


### PR DESCRIPTION
Rather than a specific hostname in a subdomain.
This allows the archive.org infra to redirect requests to the active host at the time the request is made and it save us from having to update this setting when previously specified hosts stop responding as discovered by @dotsam.

Resolves issue #1530