### PR TITLE
libarchive 3.8.8

### DIFF
--- a/Library/Formula/libarchive.rb
+++ b/Library/Formula/libarchive.rb
@@ -1,9 +1,9 @@
 class Libarchive < Formula
   desc "Multi-format archive and compression library"
   homepage "http://www.libarchive.org"
-  url "http://www.libarchive.org/downloads/libarchive-3.8.7.tar.gz"
-  mirror "https://github.com/libarchive/libarchive/releases/download/v3.8.7/libarchive-3.8.7.tar.gz"
-  sha256 "4b787cca6697a95c7725e45293c973c208cbdc71ae2279f30ef09f52472b9166"
+  url "http://www.libarchive.org/downloads/libarchive-3.8.8.tar.gz"
+  mirror "https://github.com/libarchive/libarchive/releases/download/v3.8.8/libarchive-3.8.8.tar.gz"
+  sha256 "038918ea315cdd446cc63acfe880d6011832bbe1711c887de5de5441b306c190"
   license "BSD-2-Clause"
 
   bottle do
@@ -18,6 +18,11 @@ class Libarchive < Formula
   keg_only :provided_by_osx
 
   def install
+    # GCC 4.2 blows up with any optimisation enabled.
+    # libarchive/archive_write_set_format_pax.c: In function ‘archive_write_pax_header’:
+    # libarchive/archive_write_set_format_pax.c:580: internal compiler error: Bus error
+    # https://github.com/libarchive/libarchive/issues/3189
+    ENV.O0 if ENV.compiler == :gcc
     system "./configure", "--prefix=#{prefix}",
                           "--without-lzo2",
                           "--without-nettle",


### PR DESCRIPTION
Any form of compiler optimisation trips up GCC 4.2 whether it's Tigebrew's default `-Os`, or libarchive's default of `-O2`.
Turning off optimisation allows the build to succeed. Issue observed on Leopard & Snow Leopard.
`apple-gcc42` on Tiger untested.
https://github.com/libarchive/libarchive/issues/3189

Built on 1.33Ghz PowerBook G4 running Tiger using GCC 4.0.1 in 5.9 minutes.
Built on 1st gen 1.8Ghz iMac G5 running Tiger using GCC 4.0.1 in 5.5 minutes. 
Built on 1.33Ghz iBook G4 running Leopard using GCC 4.2 in 6.4 minutes. 
 Built on mid-2009 Air running Leopard using GCC 4.2 in 99 seconds.
Built on mid-2009 Air running Snow Leopard using GCC 4.2 in 118 seconds.
Built on late 2009 white MacBook running Lion using clang in 70 seconds.
Built on mid-2009 Air running El Capitan using clang in 3.6 minutes.