### PR TITLE
Handle no_optimization in superenv

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -202,7 +202,7 @@ class Cmd
 
     args << "-pipe"
     args << "-w" unless configure?
-    args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}"
+    args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}" unless ENV["HOMEBREW_OPTIMIZATION_LEVEL"].nil?
     args.concat(optflags)
     args.concat(archflags)
     args << "-std=#{@arg0}" if @arg0 =~ /c[89]9/

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -319,6 +319,10 @@ module Superenv
     end
   end
 
+  def no_optimization
+      delete("HOMEBREW_OPTIMIZATION_LEVEL")
+  end
+
   # @private
   def noop(*_args); end
   noops = []
@@ -329,7 +333,7 @@ module Superenv
 
   # These methods provide functionality that has not yet been ported to
   # superenv.
-  noops.concat %w[gcc_4_0_1 minimal_optimization no_optimization enable_warnings]
+  noops.concat %w[gcc_4_0_1 minimal_optimization enable_warnings]
 
   noops.each { |m| alias_method m, :noop }
 end


### PR DESCRIPTION
`ENV.no_optimization` has handled things in the `stdenv` where setting the default optimisation flags are skipped in `C/CXXFLAGS`. However, indirectly in the background, the `cc` wrapper script still sets `-Os` via the `$HOMEBREW_OPTIMIZATION_LEVEL` in the `superenv`. This causes issues on GCC builds from version 7 onwards where `g++` is always being invoked with `-Os` via `superenv` which generates a different compiler from the one which the build process does (`xgcc`) and when it comes to do the stage comparison, things fail.

With this change if `ENV.no_optimization` is set, `$HOMEBREW_OPTIMIZATION_LEVEL` is deleted from the build env, and the `cc` wrapper skips setting an optimisation level.

Fixes issue #554