### PR TITLE
perl 5.44.0

### DIFF
--- a/Library/Formula/perl.rb
+++ b/Library/Formula/perl.rb
@@ -1,8 +1,8 @@
 class Perl < Formula
   desc "Highly capable, feature-rich programming language"
   homepage "https://www.perl.org/"
-  url "https://www.cpan.org/src/5.0/perl-5.42.0.tar.gz"
-  sha256 "e093ef184d7f9a1b9797e2465296f55510adb6dab8842b0c3ed53329663096dc"
+  url "https://www.cpan.org/src/5.0/perl-5.44.0.tar.gz"
+  sha256 "3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
 
   head "https://perl5.git.perl.org/perl.git", :branch => "blead"
@@ -10,17 +10,10 @@ class Perl < Formula
   keg_only :provided_by_osx,
     "OS X ships Perl and overriding that can cause unintended issues"
 
-  # Unbreak Perl build on legacy Darwin systems
-  # https://github.com/Perl/perl5/pull/21023
-  # lib/ExtUtils/MM_Darwin.pm: Unbreak Perl build
-  # https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/444/files
-  patch :p0, :DATA
-
   option "with-dtrace", "Build with DTrace probes" if MacOS.version >= :leopard
   option "with-tests", "Build and run the test suite"
 
   bottle do
-    sha256 "f8b1ac0e29178e4505d2ea3099a2d20fdc7bc7d6f4f2d17d309bf6d11f124595" => :tiger_g3
   end
 
   def install
@@ -59,48 +52,3 @@ class Perl < Formula
   end
 
 end
-__END__
---- cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm.orig	2023-03-02 11:53:45.000000000 +0000
-+++ cpan/ExtUtils-MakeMaker/lib/ExtUtils/MM_Darwin.pm	2023-05-21 05:13:48.000000000 +0100
-@@ -46,29 +46,4 @@
-     $self->SUPER::init_dist(@_);
- }
- 
--=head3 cflags
--
--Over-ride Apple's automatic setting of -Werror
--
--=cut
--
--sub cflags {
--    my($self,$libperl)=@_;
--    return $self->{CFLAGS} if $self->{CFLAGS};
--    return '' unless $self->needs_linking();
--
--    my $base = $self->SUPER::cflags($libperl);
--
--    foreach (split /\n/, $base) {
--        /^(\S*)\s*=\s*(\S*)$/ and $self->{$1} = $2;
--    };
--    $self->{CCFLAGS} .= " -Wno-error=implicit-function-declaration";
--
--    return $self->{CFLAGS} = qq{
--CCFLAGS = $self->{CCFLAGS}
--OPTIMIZE = $self->{OPTIMIZE}
--PERLTYPE = $self->{PERLTYPE}
--};
--}
--
- 1;
---- dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm.orig	2023-03-02 11:53:46.000000000 +0000
-+++ dist/ExtUtils-CBuilder/lib/ExtUtils/CBuilder/Platform/darwin.pm	2023-05-21 05:18:00.000000000 +0100
-@@ -16,9 +16,6 @@
-   local $cf->{ccflags} = $cf->{ccflags};
-   $cf->{ccflags} =~ s/-flat_namespace//;
- 
--  # XCode 12 makes this fatal, breaking tons of XS modules
--  $cf->{ccflags} .= ($cf->{ccflags} ? ' ' : '').'-Wno-error=implicit-function-declaration';
--
-   $self->SUPER::compile(@_);
- }
- 


### PR DESCRIPTION
Drop remaining patches, they've all been integrated now.

Built on 600Mhz iBook G3 running Tiger using GCC 4.0.1 in 365.7 minutes.
Built on 1.33Ghz PowerBook G4 running Tiger using GCC 4.0.1 in 140.3 minutes.
Built on 1.67Ghz PowerBook G4 running Tiger using GCC 4.0.1 in 132.7 minutes.
Built on 1.33Ghz iBook G4 running Leopard using GCC 4.2 in 136.6 minutes.
Built on 1st gen 1.8Ghz iMac G5 running Tiger using GCC 4.0.1 in 111.8 minutes.
Built on mid-2009 Air running Leopard using GCC 4.2 in 48.7 minutes.
Built on mid-2009 Air running Snow Leopard using GCC 4.2 in 52 minutes.
Built on late 2009 white MacBook running Lion using clang in 38.1 minutes.
Built on late 2009 white MacBook running Mountain Lion using clang in 38.9 minutes.
Built on late 2009 white MacBook running Mavericks using clang in 39.7 minutes.
Built on mid-2009 Air running El Capitan using clang in 56.7 minutes.